### PR TITLE
Extend `morphism` functionality

### DIFF
--- a/gyronimo/core/IR3algebra.hh
+++ b/gyronimo/core/IR3algebra.hh
@@ -113,6 +113,33 @@ class dIR3 {
   std::array<double, 9> data_;
 };
 
+//! Double partial derivatives of a @f$\mathbb{R}^3@f$ vector.
+/*!
+    **Aggregate** type supporting list initialization. Unlike `IR3`, no
+    vectorised algebraic operations are supported. The index operator
+    `B[ddIR3::ijk]` returns the value @f$\partial_k\partial_j B^i@f$ (for contravariant
+    vectors) or @f$\partial_k\partial_j B_i@f$ (for covariant vectors) with `i,j,k = u, v,
+    w`.
+*/
+class ddIR3 {
+ public:
+  enum index {
+    uuu = 0, uuv = 1, uuw = 2, uvv = 3, uvw = 4, uww = 5,
+    vuu = 6, vuv = 7, vuw = 8, vvv = 9, vvw = 10, vww = 11,
+    wuu = 12, wuv = 13, wuw = 14, wvv = 15, wvw = 16, www = 17,
+	};
+
+  double& operator[](index i) {return data_[i];}
+  const double& operator[](index i) const {return data_[i];}
+  template <typename T>
+  ddIR3& operator=(const T& expr) {
+    for(size_t i = 0;i < 18;i++) data_[i] = expr[i];
+    return *this;
+  }
+
+  std::array<double, 18> data_;
+};
+
 //! Inverse of a dIR3 matrix.
 dIR3 inverse(const dIR3& m);
 

--- a/gyronimo/core/IR3algebra.hh
+++ b/gyronimo/core/IR3algebra.hh
@@ -106,7 +106,7 @@ class dIR3 {
   const double& operator[](index i) const {return data_[i];}
   template <typename T>
   dIR3& operator=(const T& expr) {
-    for(size_t i = 0;i < 3;i++) data_[i] = expr[i];
+    for(size_t i = 0;i < 9;i++) data_[i] = expr[i];
     return *this;
   }
 

--- a/gyronimo/core/IR3algebra.hh
+++ b/gyronimo/core/IR3algebra.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021-2022 Paulo Rodrigues.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -113,13 +113,13 @@ class dIR3 {
   std::array<double, 9> data_;
 };
 
-//! Double partial derivatives of a @f$\mathbb{R}^3@f$ vector.
+//! Second partial derivatives of a @f$\mathbb{R}^3@f$ vector.
 /*!
     **Aggregate** type supporting list initialization. Unlike `IR3`, no
     vectorised algebraic operations are supported. The index operator
-    `B[ddIR3::ijk]` returns the value @f$\partial_k\partial_j B^i@f$ (for contravariant
-    vectors) or @f$\partial_k\partial_j B_i@f$ (for covariant vectors) with `i,j,k = u, v,
-    w`.
+    `B[ddIR3::ijk]` returns the value @f$\partial_j\partial_k B^i@f$ (for
+    contravariant vectors) or @f$\partial_j\partial_k B_i@f$ (for covariant
+    vectors) with `i,j,k = u, v, w`.
 */
 class ddIR3 {
  public:

--- a/gyronimo/core/IR3algebra.hh
+++ b/gyronimo/core/IR3algebra.hh
@@ -126,8 +126,8 @@ class ddIR3 {
   enum index {
     uuu = 0, uuv = 1, uuw = 2, uvv = 3, uvw = 4, uww = 5,
     vuu = 6, vuv = 7, vuw = 8, vvv = 9, vvw = 10, vww = 11,
-    wuu = 12, wuv = 13, wuw = 14, wvv = 15, wvw = 16, www = 17,
-	};
+    wuu = 12, wuv = 13, wuw = 14, wvv = 15, wvw = 16, www = 17
+  };
 
   double& operator[](index i) {return data_[i];}
   const double& operator[](index i) const {return data_[i];}

--- a/gyronimo/core/contraction.cc
+++ b/gyronimo/core/contraction.cc
@@ -59,7 +59,7 @@ IR3 contraction<first>(const dIR3& dA, const IR3& B) {
     dA[dIR3::uw]*B[IR3::u] + dA[dIR3::vw]*B[IR3::v] + dA[dIR3::ww]*B[IR3::w]};
 }
 
-//! Second-index contration of a `dIR3` object and a `IR3` vector.
+//! Second-index contraction of a `dIR3` object and a `IR3` vector.
 /*!
     Returns the object
     ```
@@ -76,15 +76,14 @@ IR3 contraction<second>(const dIR3& dA, const IR3& B) {
     dA[dIR3::wu]*B[IR3::u] + dA[dIR3::wv]*B[IR3::v] + dA[dIR3::ww]*B[IR3::w]};
 }
 
-//! First and Second index contration of a `ddIR3` object and two `IR3` vectors.
+//! First and second index contraction of a `ddIR3` and two `IR3` vectors.
 /*!
     Returns the object
     ```
     C[IR3::k] = ddA[ddIR3::ijk] * B[IR3::i] * C[IR3::j]
     ```
     where summation is implicit in the indices `i,j`, with `i,j,k = u, v, w`.
-    Replacements ddIR3::ikj -> ddIR3::ijk have been
-    explicitly performed.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been explicitly performed.
 */
 template<>
 IR3 contraction<first, second>(const ddIR3& ddA, const IR3& B, const IR3& C) {
@@ -119,15 +118,14 @@ IR3 contraction<first, second>(const ddIR3& ddA, const IR3& B, const IR3& C) {
   };
 }
 
-//! Second and Third index contration of a `ddIR3` object and two `IR3` vectors.
+//! Second and third index contraction of a `ddIR3` and two `IR3` vectors.
 /*!
     Returns the object
     ```
     C[IR3::i] = ddA[ddIR3::ijk] * B[IR3::j] * C[IR3::k]
     ```
     where summation is implicit in the indices `j,k`, with `i,j,k = u, v, w`.
-    Replacements ddIR3::ikj -> ddIR3::ijk have been
-    explicitly performed.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been explicitly performed.
 */
 template<>
 IR3 contraction<second, third>(const ddIR3& ddA, const IR3& B, const IR3& C) {
@@ -153,14 +151,13 @@ IR3 contraction<second, third>(const ddIR3& ddA, const IR3& B, const IR3& C) {
   };
 }
 
-//! One index contraction of `SM3` object and First index of `ddIR3` object.
+//! First-index contraction of a `ddIR3` by second index of a `SM3` matrix.
 /*!
     Returns the object
     ```
-    ddC[ddIR3::ijk] = g[SM3::iu] * ddA[ddIR3::ujk] +
-			+ g[SM3::iv] * ddA[ddIR3::vjk] + g[SM3::iw] * ddA[ddIR3::wjk]
+    ddC[ddIR3::ijk] = g[SM3::im] * ddA[ddIR3::mjk]
     ```
-    with `i,j,k = u, v, w`.
+    where summation is implicit in the index `m`, with `m,i,j,k = u, v, w`.
     Replacements SM3::ij -> SM3::ji and ddIR3::ikj -> ddIR3::ijk have been
     explicitly performed.
 */
@@ -188,16 +185,14 @@ ddIR3 contraction<second, first>(const SM3& g, const ddIR3& ddA) {
   };
 }
 
-//! First-index contraction of `dIR3` object with First index of `ddIR3` object.
+//! First-by-first index contraction of `dIR3` and `ddIR3` objects.
 /*!
     Returns the object
     ```
-    ddC[ddIR3::ijk] = dA[dIR3::ui] * ddB[ddIR3::ujk] +
-			+ dA[dIR3::vi] * ddB[ddIR3::vjk] + dA[dIR3::wi] * ddB[ddIR3::wjk]
+    ddC[ddIR3::ijk] = dA[dIR3::mi] * ddB[ddIR3::mjk]
     ```
-    with `i,j,k = u, v, w`.
-    Replacements ddIR3::ikj -> ddIR3::ijk have been
-    explicitly performed.
+    where summation is implicit in the index `m`, with `m,i,j,k = u, v, w`.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been explicitly performed.
 */
 template<>
 ddIR3 contraction<first, first>(const dIR3& dA, const ddIR3& ddB) {
@@ -223,16 +218,14 @@ ddIR3 contraction<first, first>(const dIR3& dA, const ddIR3& ddB) {
   };
 }
 
-//! Second-index contraction of `dIR3` object with First index of `ddIR3` object.
+//! Second-by-first index contraction of `dIR3` and `ddIR3` objects.
 /*!
     Returns the object
     ```
-    ddC[ddIR3::ijk] = dA[dIR3::iu] * ddB[ddIR3::ujk] +
-			+ dA[dIR3::iv] * ddB[ddIR3::vjk] + dA[dIR3::iw] * ddB[ddIR3::wjk]
+    ddC[ddIR3::ijk] = dA[dIR3::im] * ddB[ddIR3::mjk]
     ```
-    with `i,j,k = u, v, w`.
-    Replacements ddIR3::ikj -> ddIR3::ijk have been
-    explicitly performed.
+    where summation is implicit in the index `m`, with `m,i,j,k = u, v, w`.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been explicitly performed.
 */
 template<>
 ddIR3 contraction<second, first>(const dIR3& dA, const ddIR3& ddB) {
@@ -258,7 +251,7 @@ ddIR3 contraction<second, first>(const dIR3& dA, const ddIR3& ddB) {
   };
 }
 
-//! First-index contration of a `dSM3` object and a `IR3` vector.
+//! First-index contraction of a `dSM3` object and a `IR3` vector.
 /*!
     Returns the object
     ```
@@ -283,7 +276,7 @@ dIR3 contraction<first>(const dSM3& dA, const IR3& B) {
   };
 }
 
-//! Second-index contration of a `dSM3` object and a `IR3` vector.
+//! Second-index contraction of a `dSM3` object and a `IR3` vector.
 /*!
     Returns the object
     ```
@@ -311,7 +304,7 @@ dIR3 contraction<second>(const dSM3& dA, const IR3& B) {
   };
 }
 
-//! Third-index contration of a `dSM3` object and a `IR3` vector.
+//! Third-index contraction of a `dSM3` object and a `IR3` vector.
 /*!
     Returns the object
     ```
@@ -336,7 +329,7 @@ dIR3 contraction<third>(const dSM3& dA, const IR3& B) {
   };
 }
 
-//! Second-by-first-index contration of `dSM3` and `dIR3` objects.
+//! Second-by-first-index contraction of `dSM3` and `dIR3` objects.
 /*!
     Returns the object
     ```

--- a/gyronimo/core/contraction.cc
+++ b/gyronimo/core/contraction.cc
@@ -153,6 +153,111 @@ IR3 contraction<second, third>(const ddIR3& ddA, const IR3& B, const IR3& C) {
   };
 }
 
+//! One index contraction of `SM3` object and First index of `ddIR3` object.
+/*!
+    Returns the object
+    ```
+    ddC[ddIR3::ijk] = g[SM3::iu] * ddA[ddIR3::ujk] +
+			+ g[SM3::iv] * ddA[ddIR3::vjk] + g[SM3::iw] * ddA[ddIR3::wjk]
+    ```
+    with `i,j,k = u, v, w`.
+    Replacements SM3::ij -> SM3::ji and ddIR3::ikj -> ddIR3::ijk have been
+    explicitly performed.
+*/
+template<>
+ddIR3 contraction<second, first>(const SM3& g, const ddIR3& ddA) {
+  return {
+    g[SM3::uu]*ddA[ddIR3::uuu] + g[SM3::uv]*ddA[ddIR3::vuu] + g[SM3::uw]*ddA[ddIR3::wuu], // uuu
+    g[SM3::uu]*ddA[ddIR3::uuv] + g[SM3::uv]*ddA[ddIR3::vuv] + g[SM3::uw]*ddA[ddIR3::wuv], // uuv
+    g[SM3::uu]*ddA[ddIR3::uuw] + g[SM3::uv]*ddA[ddIR3::vuw] + g[SM3::uw]*ddA[ddIR3::wuw], // uuw
+    g[SM3::uu]*ddA[ddIR3::uvv] + g[SM3::uv]*ddA[ddIR3::vvv] + g[SM3::uw]*ddA[ddIR3::wvv], // uvv
+    g[SM3::uu]*ddA[ddIR3::uvw] + g[SM3::uv]*ddA[ddIR3::vvw] + g[SM3::uw]*ddA[ddIR3::wvw], // uvw
+    g[SM3::uu]*ddA[ddIR3::uww] + g[SM3::uv]*ddA[ddIR3::vww] + g[SM3::uw]*ddA[ddIR3::www], // uww
+    g[SM3::uv]*ddA[ddIR3::uuu] + g[SM3::vv]*ddA[ddIR3::vuu] + g[SM3::vw]*ddA[ddIR3::wuu], // vuu
+    g[SM3::uv]*ddA[ddIR3::uuv] + g[SM3::vv]*ddA[ddIR3::vuv] + g[SM3::vw]*ddA[ddIR3::wuv], // vuv
+    g[SM3::uv]*ddA[ddIR3::uuw] + g[SM3::vv]*ddA[ddIR3::vuw] + g[SM3::vw]*ddA[ddIR3::wuw], // vuw
+    g[SM3::uv]*ddA[ddIR3::uvv] + g[SM3::vv]*ddA[ddIR3::vvv] + g[SM3::vw]*ddA[ddIR3::wvv], // vvv
+    g[SM3::uv]*ddA[ddIR3::uvw] + g[SM3::vv]*ddA[ddIR3::vvw] + g[SM3::vw]*ddA[ddIR3::wvw], // vvw
+    g[SM3::uv]*ddA[ddIR3::uww] + g[SM3::vv]*ddA[ddIR3::vww] + g[SM3::vw]*ddA[ddIR3::www], // vww
+    g[SM3::uw]*ddA[ddIR3::uuu] + g[SM3::vw]*ddA[ddIR3::vuu] + g[SM3::ww]*ddA[ddIR3::wuu], // wuu
+    g[SM3::uw]*ddA[ddIR3::uuv] + g[SM3::vw]*ddA[ddIR3::vuv] + g[SM3::ww]*ddA[ddIR3::wuv], // wuv
+    g[SM3::uw]*ddA[ddIR3::uuw] + g[SM3::vw]*ddA[ddIR3::vuw] + g[SM3::ww]*ddA[ddIR3::wuw], // wuw
+    g[SM3::uw]*ddA[ddIR3::uvv] + g[SM3::vw]*ddA[ddIR3::vvv] + g[SM3::ww]*ddA[ddIR3::wvv], // wvv
+    g[SM3::uw]*ddA[ddIR3::uvw] + g[SM3::vw]*ddA[ddIR3::vvw] + g[SM3::ww]*ddA[ddIR3::wvw], // wvw
+    g[SM3::uw]*ddA[ddIR3::uww] + g[SM3::vw]*ddA[ddIR3::vww] + g[SM3::ww]*ddA[ddIR3::www], // www
+  };
+}
+
+//! First-index contraction of `dIR3` object with First index of `ddIR3` object.
+/*!
+    Returns the object
+    ```
+    ddC[ddIR3::ijk] = dA[dIR3::ui] * ddB[ddIR3::ujk] +
+			+ dA[dIR3::vi] * ddB[ddIR3::vjk] + dA[dIR3::wi] * ddB[ddIR3::wjk]
+    ```
+    with `i,j,k = u, v, w`.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been
+    explicitly performed.
+*/
+template<>
+ddIR3 contraction<first, first>(const dIR3& dA, const ddIR3& ddB) {
+  return {
+    dA[dIR3::uu]*ddB[ddIR3::uuu] + dA[dIR3::vu]*ddB[ddIR3::vuu] + dA[dIR3::wu]*ddB[ddIR3::wuu], // uuu
+    dA[dIR3::uu]*ddB[ddIR3::uuv] + dA[dIR3::vu]*ddB[ddIR3::vuv] + dA[dIR3::wu]*ddB[ddIR3::wuv], // uuv
+    dA[dIR3::uu]*ddB[ddIR3::uuw] + dA[dIR3::vu]*ddB[ddIR3::vuw] + dA[dIR3::wu]*ddB[ddIR3::wuw], // uuw
+    dA[dIR3::uu]*ddB[ddIR3::uvv] + dA[dIR3::vu]*ddB[ddIR3::vvv] + dA[dIR3::wu]*ddB[ddIR3::wvv], // uvv
+    dA[dIR3::uu]*ddB[ddIR3::uvw] + dA[dIR3::vu]*ddB[ddIR3::vvw] + dA[dIR3::wu]*ddB[ddIR3::wvw], // uvw
+    dA[dIR3::uu]*ddB[ddIR3::uww] + dA[dIR3::vu]*ddB[ddIR3::vww] + dA[dIR3::wu]*ddB[ddIR3::www], // uww
+    dA[dIR3::uv]*ddB[ddIR3::uuu] + dA[dIR3::vv]*ddB[ddIR3::vuu] + dA[dIR3::wv]*ddB[ddIR3::wuu], // vuu
+    dA[dIR3::uv]*ddB[ddIR3::uuv] + dA[dIR3::vv]*ddB[ddIR3::vuv] + dA[dIR3::wv]*ddB[ddIR3::wuv], // vuv
+    dA[dIR3::uv]*ddB[ddIR3::uuw] + dA[dIR3::vv]*ddB[ddIR3::vuw] + dA[dIR3::wv]*ddB[ddIR3::wuw], // vuw
+    dA[dIR3::uv]*ddB[ddIR3::uvv] + dA[dIR3::vv]*ddB[ddIR3::vvv] + dA[dIR3::wv]*ddB[ddIR3::wvv], // vvv
+    dA[dIR3::uv]*ddB[ddIR3::uvw] + dA[dIR3::vv]*ddB[ddIR3::vvw] + dA[dIR3::wv]*ddB[ddIR3::wvw], // vvw
+    dA[dIR3::uv]*ddB[ddIR3::uww] + dA[dIR3::vv]*ddB[ddIR3::vww] + dA[dIR3::wv]*ddB[ddIR3::www], // vww
+    dA[dIR3::uw]*ddB[ddIR3::uuu] + dA[dIR3::vw]*ddB[ddIR3::vuu] + dA[dIR3::ww]*ddB[ddIR3::wuu], // wuu
+    dA[dIR3::uw]*ddB[ddIR3::uuv] + dA[dIR3::vw]*ddB[ddIR3::vuv] + dA[dIR3::ww]*ddB[ddIR3::wuv], // wuv
+    dA[dIR3::uw]*ddB[ddIR3::uuw] + dA[dIR3::vw]*ddB[ddIR3::vuw] + dA[dIR3::ww]*ddB[ddIR3::wuw], // wuw
+    dA[dIR3::uw]*ddB[ddIR3::uvv] + dA[dIR3::vw]*ddB[ddIR3::vvv] + dA[dIR3::ww]*ddB[ddIR3::wvv], // wvv
+    dA[dIR3::uw]*ddB[ddIR3::uvw] + dA[dIR3::vw]*ddB[ddIR3::vvw] + dA[dIR3::ww]*ddB[ddIR3::wvw], // wvw
+    dA[dIR3::uw]*ddB[ddIR3::uww] + dA[dIR3::vw]*ddB[ddIR3::vww] + dA[dIR3::ww]*ddB[ddIR3::www], // www
+  };
+}
+
+//! Second-index contraction of `dIR3` object with First index of `ddIR3` object.
+/*!
+    Returns the object
+    ```
+    ddC[ddIR3::ijk] = dA[dIR3::iu] * ddB[ddIR3::ujk] +
+			+ dA[dIR3::iv] * ddB[ddIR3::vjk] + dA[dIR3::iw] * ddB[ddIR3::wjk]
+    ```
+    with `i,j,k = u, v, w`.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been
+    explicitly performed.
+*/
+template<>
+ddIR3 contraction<second, first>(const dIR3& dA, const ddIR3& ddB) {
+  return {
+    dA[dIR3::uu]*ddB[ddIR3::uuu] + dA[dIR3::uv]*ddB[ddIR3::vuu] + dA[dIR3::uw]*ddB[ddIR3::wuu], // uuu
+    dA[dIR3::uu]*ddB[ddIR3::uuv] + dA[dIR3::uv]*ddB[ddIR3::vuv] + dA[dIR3::uw]*ddB[ddIR3::wuv], // uuv
+    dA[dIR3::uu]*ddB[ddIR3::uuw] + dA[dIR3::uv]*ddB[ddIR3::vuw] + dA[dIR3::uw]*ddB[ddIR3::wuw], // uuw
+    dA[dIR3::uu]*ddB[ddIR3::uvv] + dA[dIR3::uv]*ddB[ddIR3::vvv] + dA[dIR3::uw]*ddB[ddIR3::wvv], // uvv
+    dA[dIR3::uu]*ddB[ddIR3::uvw] + dA[dIR3::uv]*ddB[ddIR3::vvw] + dA[dIR3::uw]*ddB[ddIR3::wvw], // uvw
+    dA[dIR3::uu]*ddB[ddIR3::uww] + dA[dIR3::uv]*ddB[ddIR3::vww] + dA[dIR3::uw]*ddB[ddIR3::www], // uww
+    dA[dIR3::vu]*ddB[ddIR3::uuu] + dA[dIR3::vv]*ddB[ddIR3::vuu] + dA[dIR3::vw]*ddB[ddIR3::wuu], // vuu
+    dA[dIR3::vu]*ddB[ddIR3::uuv] + dA[dIR3::vv]*ddB[ddIR3::vuv] + dA[dIR3::vw]*ddB[ddIR3::wuv], // vuv
+    dA[dIR3::vu]*ddB[ddIR3::uuw] + dA[dIR3::vv]*ddB[ddIR3::vuw] + dA[dIR3::vw]*ddB[ddIR3::wuw], // vuw
+    dA[dIR3::vu]*ddB[ddIR3::uvv] + dA[dIR3::vv]*ddB[ddIR3::vvv] + dA[dIR3::vw]*ddB[ddIR3::wvv], // vvv
+    dA[dIR3::vu]*ddB[ddIR3::uvw] + dA[dIR3::vv]*ddB[ddIR3::vvw] + dA[dIR3::vw]*ddB[ddIR3::wvw], // vvw
+    dA[dIR3::vu]*ddB[ddIR3::uww] + dA[dIR3::vv]*ddB[ddIR3::vww] + dA[dIR3::vw]*ddB[ddIR3::www], // vww
+    dA[dIR3::wu]*ddB[ddIR3::uuu] + dA[dIR3::wv]*ddB[ddIR3::vuu] + dA[dIR3::ww]*ddB[ddIR3::wuu], // wuu
+    dA[dIR3::wu]*ddB[ddIR3::uuv] + dA[dIR3::wv]*ddB[ddIR3::vuv] + dA[dIR3::ww]*ddB[ddIR3::wuv], // wuv
+    dA[dIR3::wu]*ddB[ddIR3::uuw] + dA[dIR3::wv]*ddB[ddIR3::vuw] + dA[dIR3::ww]*ddB[ddIR3::wuw], // wuw
+    dA[dIR3::wu]*ddB[ddIR3::uvv] + dA[dIR3::wv]*ddB[ddIR3::vvv] + dA[dIR3::ww]*ddB[ddIR3::wvv], // wvv
+    dA[dIR3::wu]*ddB[ddIR3::uvw] + dA[dIR3::wv]*ddB[ddIR3::vvw] + dA[dIR3::ww]*ddB[ddIR3::wvw], // wvw
+    dA[dIR3::wu]*ddB[ddIR3::uww] + dA[dIR3::wv]*ddB[ddIR3::vww] + dA[dIR3::ww]*ddB[ddIR3::www], // www
+  };
+}
+
 //! First-index contration of a `dSM3` object and a `IR3` vector.
 /*!
     Returns the object

--- a/gyronimo/core/contraction.cc
+++ b/gyronimo/core/contraction.cc
@@ -76,6 +76,83 @@ IR3 contraction<second>(const dIR3& dA, const IR3& B) {
     dA[dIR3::wu]*B[IR3::u] + dA[dIR3::wv]*B[IR3::v] + dA[dIR3::ww]*B[IR3::w]};
 }
 
+//! First and Second index contration of a `ddIR3` object and two `IR3` vectors.
+/*!
+    Returns the object
+    ```
+    C[IR3::k] = ddA[ddIR3::ijk] * B[IR3::i] * C[IR3::j]
+    ```
+    where summation is implicit in the indices `i,j`, with `i,j,k = u, v, w`.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been
+    explicitly performed.
+*/
+template<>
+IR3 contraction<first, second>(const ddIR3& ddA, const IR3& B, const IR3& C) {
+  return {
+    ddA[ddIR3::uuu] * B[IR3::u] * C[IR3::u] +
+    ddA[ddIR3::uuv] * B[IR3::u] * C[IR3::v] +
+    ddA[ddIR3::uuw] * B[IR3::u] * C[IR3::w] +
+    ddA[ddIR3::vuu] * B[IR3::v] * C[IR3::u] +
+    ddA[ddIR3::vuv] * B[IR3::v] * C[IR3::v] +
+    ddA[ddIR3::vuw] * B[IR3::v] * C[IR3::w] +
+    ddA[ddIR3::wuu] * B[IR3::w] * C[IR3::u] +
+    ddA[ddIR3::wuv] * B[IR3::w] * C[IR3::v] +
+    ddA[ddIR3::wuw] * B[IR3::w] * C[IR3::w], // C[IR3::u]
+    ddA[ddIR3::uuv] * B[IR3::u] * C[IR3::u] +
+    ddA[ddIR3::uvv] * B[IR3::u] * C[IR3::v] +
+    ddA[ddIR3::uvw] * B[IR3::u] * C[IR3::w] +
+    ddA[ddIR3::vuv] * B[IR3::v] * C[IR3::u] +
+    ddA[ddIR3::vvv] * B[IR3::v] * C[IR3::v] +
+    ddA[ddIR3::vvw] * B[IR3::v] * C[IR3::w] +
+    ddA[ddIR3::wuv] * B[IR3::w] * C[IR3::u] +
+    ddA[ddIR3::wvv] * B[IR3::w] * C[IR3::v] +
+    ddA[ddIR3::wvw] * B[IR3::w] * C[IR3::w], // C[IR3::v]
+    ddA[ddIR3::uuw] * B[IR3::u] * C[IR3::u] +
+    ddA[ddIR3::uvw] * B[IR3::u] * C[IR3::v] +
+    ddA[ddIR3::uww] * B[IR3::u] * C[IR3::w] +
+    ddA[ddIR3::vuw] * B[IR3::v] * C[IR3::u] +
+    ddA[ddIR3::vvw] * B[IR3::v] * C[IR3::v] +
+    ddA[ddIR3::vww] * B[IR3::v] * C[IR3::w] +
+    ddA[ddIR3::wuw] * B[IR3::w] * C[IR3::u] +
+    ddA[ddIR3::wvw] * B[IR3::w] * C[IR3::v] +
+    ddA[ddIR3::www] * B[IR3::w] * C[IR3::w] // C[IR3::w]
+  };
+}
+
+//! Second and Third index contration of a `ddIR3` object and two `IR3` vectors.
+/*!
+    Returns the object
+    ```
+    C[IR3::i] = ddA[ddIR3::ijk] * B[IR3::j] * C[IR3::k]
+    ```
+    where summation is implicit in the indices `j,k`, with `i,j,k = u, v, w`.
+    Replacements ddIR3::ikj -> ddIR3::ijk have been
+    explicitly performed.
+*/
+template<>
+IR3 contraction<second, third>(const ddIR3& ddA, const IR3& B, const IR3& C) {
+  return {
+    ddA[ddIR3::uuu] *  B[IR3::u] * C[IR3::u] +
+    ddA[ddIR3::uuv] * (B[IR3::u] * C[IR3::v] + B[IR3::v] * C[IR3::u]) +
+    ddA[ddIR3::uuw] * (B[IR3::u] * C[IR3::w] + B[IR3::w] * C[IR3::u]) +
+    ddA[ddIR3::uvv] *  B[IR3::v] * C[IR3::v] +
+    ddA[ddIR3::uvw] * (B[IR3::v] * C[IR3::w] + B[IR3::w] * C[IR3::v]) +
+    ddA[ddIR3::uww] *  B[IR3::w] * C[IR3::w], // C[IR3::u]
+    ddA[ddIR3::vuu] *  B[IR3::u] * C[IR3::u] +
+    ddA[ddIR3::vuv] * (B[IR3::u] * C[IR3::v] + B[IR3::v] * C[IR3::u]) +
+    ddA[ddIR3::vuw] * (B[IR3::u] * C[IR3::w] + B[IR3::w] * C[IR3::u]) +
+    ddA[ddIR3::vvv] *  B[IR3::v] * C[IR3::v] +
+    ddA[ddIR3::vvw] * (B[IR3::v] * C[IR3::w] + B[IR3::w] * C[IR3::v]) +
+    ddA[ddIR3::vww] *  B[IR3::w] * C[IR3::w], // C[IR3::v]
+    ddA[ddIR3::wuu] *  B[IR3::u] * C[IR3::u] +
+    ddA[ddIR3::wuv] * (B[IR3::u] * C[IR3::v] + B[IR3::v] * C[IR3::u]) +
+    ddA[ddIR3::wuw] * (B[IR3::u] * C[IR3::w] + B[IR3::w] * C[IR3::u]) +
+    ddA[ddIR3::wvv] *  B[IR3::v] * C[IR3::v] +
+    ddA[ddIR3::wvw] * (B[IR3::v] * C[IR3::w] + B[IR3::w] * C[IR3::v]) +
+    ddA[ddIR3::www] *  B[IR3::w] * C[IR3::w] // C[IR3::w]
+  };
+}
+
 //! First-index contration of a `dSM3` object and a `IR3` vector.
 /*!
     Returns the object

--- a/gyronimo/core/contraction.hh
+++ b/gyronimo/core/contraction.hh
@@ -36,6 +36,10 @@ template<contraction_index>
 IR3 contraction(const dIR3& dA, const IR3& B);
 template<contraction_index, contraction_index>
 IR3 contraction(const ddIR3& ddA, const IR3& B, const IR3& C);
+template<contraction_index, contraction_index>
+ddIR3 contraction(const SM3& g, const ddIR3& ddA);
+template<contraction_index, contraction_index>
+ddIR3 contraction(const dIR3& dA, const ddIR3& ddB);
 template<contraction_index>
 dIR3 contraction(const dSM3& dA, const IR3& B);
 template<contraction_index, contraction_index>

--- a/gyronimo/core/contraction.hh
+++ b/gyronimo/core/contraction.hh
@@ -34,14 +34,14 @@ enum contraction_index {first, second, third};
 
 template<contraction_index>
 IR3 contraction(const dIR3& dA, const IR3& B);
+template<contraction_index>
+dIR3 contraction(const dSM3& dA, const IR3& B);
 template<contraction_index, contraction_index>
 IR3 contraction(const ddIR3& ddA, const IR3& B, const IR3& C);
 template<contraction_index, contraction_index>
 ddIR3 contraction(const SM3& g, const ddIR3& ddA);
 template<contraction_index, contraction_index>
 ddIR3 contraction(const dIR3& dA, const ddIR3& ddB);
-template<contraction_index>
-dIR3 contraction(const dSM3& dA, const IR3& B);
 template<contraction_index, contraction_index>
 dIR3 contraction(const SM3& g, const dIR3& dB);
 dSM3 contraction(const SM3& g, const dSM3& d, const SM3& h);

--- a/gyronimo/core/contraction.hh
+++ b/gyronimo/core/contraction.hh
@@ -34,6 +34,8 @@ enum contraction_index {first, second, third};
 
 template<contraction_index>
 IR3 contraction(const dIR3& dA, const IR3& B);
+template<contraction_index, contraction_index>
+IR3 contraction(const ddIR3& ddA, const IR3& B, const IR3& C);
 template<contraction_index>
 dIR3 contraction(const dSM3& dA, const IR3& B);
 template<contraction_index, contraction_index>

--- a/gyronimo/core/multiroot.hh
+++ b/gyronimo/core/multiroot.hh
@@ -57,7 +57,7 @@ class multiroot {
   template<SizedContiguousRange UserArgs>
   auto allocate_gsl_objects(
       user_function_t<UserArgs>& f, const UserArgs& guess) const;
-  void deallocate_gsl_objects(
+  inline void deallocate_gsl_objects(
       gsl_multiroot_fsolver*, gsl_vector*, gsl_multiroot_function*) const;
 };
 
@@ -114,7 +114,7 @@ auto multiroot::allocate_gsl_objects(
           >({solver, guess_gsl, struct_f_gsl});
 }
 
-void multiroot::deallocate_gsl_objects(
+inline void multiroot::deallocate_gsl_objects(
     gsl_multiroot_fsolver* solver,
     gsl_vector* guess_gsl, gsl_multiroot_function* struct_f_gsl) const {
   gsl_multiroot_fsolver_free(solver);

--- a/gyronimo/fields/eigenmode_castor_a.cc
+++ b/gyronimo/fields/eigenmode_castor_a.cc
@@ -39,7 +39,7 @@ eigenmode_castor_a::eigenmode_castor_a(
 IR3 eigenmode_castor_a::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
-  double chi = metric_->reduce_chi(position[IR3::v]);
+  double chi = metric_->parser()->reduce_chi(position[IR3::v]);
   std::complex<double> factor = norm_factor_*std::exp(w_*time + i_n_tor_*phi);
   return {
       std::real(factor*(this->tildeA1_(s, chi))),
@@ -47,7 +47,7 @@ IR3 eigenmode_castor_a::covariant(const IR3& position, double time) const {
               std::real(factor*(this->tildeA3_(s, chi)))};
 }
 IR3 eigenmode_castor_a::contravariant(const IR3& position, double time) const {
-  return this->metric()->
+  return metric_->
       to_contravariant(this->covariant(position, time), position);
 }
 

--- a/gyronimo/fields/eigenmode_castor_b.cc
+++ b/gyronimo/fields/eigenmode_castor_b.cc
@@ -44,7 +44,7 @@ eigenmode_castor_b::eigenmode_castor_b(
 IR3 eigenmode_castor_b::contravariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
-  double chi = metric_->reduce_chi(position[IR3::v]);
+  double chi = metric_->parser()->reduce_chi(position[IR3::v]);
   std::complex<double> factor = norm_factor_*
       this->exp_wt_nphi(time, phi)/this->metric()->jacobian(position);
   return {
@@ -62,7 +62,7 @@ IR3 eigenmode_castor_b::contravariant(const IR3& position, double time) const {
 dIR3 eigenmode_castor_b::del_contravariant(
     const IR3& position, double time) const {
   double s = position[IR3::u];
-  double chi = metric_->reduce_chi(position[IR3::v]);
+  double chi = metric_->parser()->reduce_chi(position[IR3::v]);
   double phi = position[IR3::w];
   std::complex<double> factor = norm_factor_*this->exp_wt_nphi(time, phi);
   std::valarray epsilon_ijk_partial2_jl_A_k = {
@@ -92,7 +92,7 @@ IR3 eigenmode_castor_b::partial_t_contravariant(
     const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
-  double chi = metric_->reduce_chi(position[IR3::v]);
+  double chi = metric_->parser()->reduce_chi(position[IR3::v]);
   std::complex<double> factor = norm_factor_*this->exp_wt_nphi(time, phi);
   using namespace std::complex_literals;
   factor *= 1i*w_/this->metric()->jacobian(position);

--- a/gyronimo/fields/equilibrium_helena.cc
+++ b/gyronimo/fields/equilibrium_helena.cc
@@ -51,8 +51,8 @@ dIR3 equilibrium_helena::del_contravariant(
   double chi = this->metric_->parser()->reduce_chi(position[IR3::v]);
   return {
       0.0, 0.0, 0.0, 
-	  Bchi_->partial_u(s, chi), Bchi_->partial_v(s, chi) , 0.0, 
-	  Bphi_->partial_u(s, chi), Bphi_->partial_v(s, chi) , 0.0};
+      Bchi_->partial_u(s, chi), Bchi_->partial_v(s, chi) , 0.0, 
+      Bphi_->partial_u(s, chi), Bphi_->partial_v(s, chi) , 0.0};
 }
 
 }// end namespace gyronimo.

--- a/gyronimo/fields/equilibrium_helena.cc
+++ b/gyronimo/fields/equilibrium_helena.cc
@@ -42,13 +42,13 @@ equilibrium_helena::~equilibrium_helena() {
 }
 IR3 equilibrium_helena::contravariant(const IR3& position, double time) const {
   double s = position[IR3::u];
-  double chi = this->metric_->reduce_chi(position[IR3::v]);
+  double chi = this->metric_->parser()->reduce_chi(position[IR3::v]);
   return {0.0, (*Bchi_)(s, chi), (*Bphi_)(s, chi)};
 }
 dIR3 equilibrium_helena::del_contravariant(
     const IR3& position, double time) const {
   double s = position[IR3::u];
-  double chi = this->metric_->reduce_chi(position[IR3::v]);
+  double chi = this->metric_->parser()->reduce_chi(position[IR3::v]);
   return {
       0.0, 0.0, 0.0, 
 	  Bchi_->partial_u(s, chi), Bchi_->partial_v(s, chi) , 0.0, 

--- a/gyronimo/fields/equilibrium_vmec.cc
+++ b/gyronimo/fields/equilibrium_vmec.cc
@@ -93,7 +93,7 @@ dIR3 equilibrium_vmec::del_contravariant(
   };
   return {
       0.0, 0.0, 0.0, 
-	    dB_zeta_ds, dB_zeta_dzeta, dB_zeta_dtheta,
+      dB_zeta_ds, dB_zeta_dzeta, dB_zeta_dtheta,
       dB_theta_ds, dB_theta_dzeta, dB_theta_dtheta
   };
 }

--- a/gyronimo/fields/msphere_luhmann.cc
+++ b/gyronimo/fields/msphere_luhmann.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,7 +25,8 @@ namespace gyronimo {
 msphere_luhmann::msphere_luhmann(
     double smooth_factor,
     double dipole_factor, double csheet_factor, double m_factor)
-    : IR3field_c1(m_factor, 1.0, new metric_spherical(earth_radius)),
+    : IR3field_c1(m_factor, 1.0, 
+		new metric_spherical(new morphism_spherical(earth_radius))),
       c_bar_(0.001*csheet_factor/(earth_radius*m_factor)),
       d_bar_(dipole_factor/(earth_radius*m_factor)),
       idelta_(1.0/smooth_factor),
@@ -33,7 +34,10 @@ msphere_luhmann::msphere_luhmann(
   metric_ = dynamic_cast<const metric_spherical*>(IR3field::metric());
 }
 msphere_luhmann::~msphere_luhmann() {
-  if (metric_) delete metric_;
+  if (metric_) {
+    if(metric_->morph()) delete metric_->morph();
+    delete metric_;
+  }
 }
 IR3 msphere_luhmann::contravariant(const IR3& position, double time) const {
   double r = position[IR3::u], r3 = r*r*r, r4 = r3*r;

--- a/gyronimo/fields/msphere_luhmann.cc
+++ b/gyronimo/fields/msphere_luhmann.cc
@@ -26,7 +26,7 @@ msphere_luhmann::msphere_luhmann(
     double smooth_factor,
     double dipole_factor, double csheet_factor, double m_factor)
     : IR3field_c1(m_factor, 1.0, 
-		new metric_spherical(new morphism_spherical(earth_radius))),
+      new metric_spherical(new morphism_spherical(earth_radius))),
       c_bar_(0.001*csheet_factor/(earth_radius*m_factor)),
       d_bar_(dipole_factor/(earth_radius*m_factor)),
       idelta_(1.0/smooth_factor),
@@ -35,7 +35,7 @@ msphere_luhmann::msphere_luhmann(
 }
 msphere_luhmann::~msphere_luhmann() {
   if (metric_) {
-    if(metric_->morph()) delete metric_->morph();
+    if(metric_->my_morphism()) delete metric_->my_morphism();
     delete metric_;
   }
 }

--- a/gyronimo/fields/msphere_luhmann.hh
+++ b/gyronimo/fields/msphere_luhmann.hh
@@ -45,6 +45,8 @@ namespace gyronimo {
           \mathbf{u}_x
     @f}
     where the versor @f$\mathbf{u}_x@f$ is directed towards the Sun.
+
+    @todo: get rid of the self-built metric and related pointer wizardry.
 */
 class msphere_luhmann : public IR3field_c1 {
  public:

--- a/gyronimo/fields/msphere_luhmann.hh
+++ b/gyronimo/fields/msphere_luhmann.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/metric_cartesian.cc
+++ b/gyronimo/metrics/metric_cartesian.cc
@@ -21,87 +21,40 @@
 
 namespace gyronimo {
 
-metric_cartesian::metric_cartesian(const morphism_cartesian *morph) 
-	: metric_connected(morph) {
-}
+metric_cartesian::metric_cartesian(const morphism_cartesian* morph)
+    : metric_connected(morph) {}
 
-//! General-purpose implementation of the covariant metric.
-/*!
-	Implements the covariant metric in cartesian coordinates: 
-	@f$ g_{\alpha\beta} = \left(\begin{matrix}
-		1 && 0 && 0 \\
-		0 && 1 && 0 \\
-		0 && 0 && 1
-	\end{matrix}\right) @f$
-*/
 SM3 metric_cartesian::operator()(const IR3& r) const {
-	return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
+  return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
 }
-
-//! General-purpose implementation of the inverse (i.e., contravariant metric).
-/*!
-	Implements the contravariant metric in cartesian coordinates: 
-	@f$ g^{\alpha\beta} = \left(\begin{matrix}
-		1 && 0 && 0 \\
-		0 && 1 && 0 \\
-		0 && 0 && 1
-	\end{matrix}\right) @f$
-*/
 SM3 metric_cartesian::inverse(const IR3& r) const {
-	return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
+  return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
 }
 dSM3 metric_cartesian::del(const IR3& r) const {
-	return {
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-	};
+  return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
 dSM3 metric_cartesian::del_inverse(const IR3& r) const {
-	return {
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-	};
+  return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ \textbf{x} @f$.
-/*!
-	Implements the Jacobian in cartesian coordinates: 
-	@f$ J = 1 @f$
-*/
-double metric_cartesian::jacobian(const IR3& r) const {
-	return 1.0;
-}
-
-//! General-purpose implementation of the Jacobian gradient in point @f$ \textbf{x} @f$.
-/*!
-	Implements the Jacobian gradient in cartesian coordinates: 
-	@f$ \nabla J = \left( 0,0,0 \right) @f$
-*/
+double metric_cartesian::jacobian(const IR3& r) const { return 1.0; }
 IR3 metric_cartesian::del_jacobian(const IR3& r) const {
-	return {0.0, 0.0, 0.0};
+  return {0.0, 0.0, 0.0};
 }
-
 ddIR3 metric_cartesian::christoffel_first_kind(const IR3& r) const {
-	return {
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-	};
+  return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
 ddIR3 metric_cartesian::christoffel_second_kind(const IR3& r) const {
-	return {
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-	};
+  return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
 IR3 metric_cartesian::to_covariant(const IR3& B, const IR3& r) const {
-	return B;
+  return B;
 }
 IR3 metric_cartesian::to_contravariant(const IR3& B, const IR3& r) const {
-	return B;
+  return B;
 }
 
-}
+}  // namespace gyronimo

--- a/gyronimo/metrics/metric_cartesian.cc
+++ b/gyronimo/metrics/metric_cartesian.cc
@@ -1,0 +1,76 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @metric_cartesian.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/metrics/metric_cartesian.hh>
+
+namespace gyronimo {
+
+metric_cartesian::metric_cartesian(const morphism_cartesian *morph) 
+	: metric_connected(morph), Lref_(morph->Lref()), 
+	Lref_2_(Lref_*Lref_), iLref_2_(1/Lref_2_) {
+}
+SM3 metric_cartesian::operator()(const IR3& r) const {
+	return {Lref_2_, 0.0, 0.0, Lref_2_, 0.0, Lref_2_};
+}
+SM3 metric_cartesian::inverse(const IR3& r) const {
+	return {iLref_2_, 0.0, 0.0, iLref_2_, 0.0, iLref_2_};
+}
+dSM3 metric_cartesian::del(const IR3& r) const {
+	return {
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+	};
+}
+dSM3 metric_cartesian::del_inverse(const IR3& r) const {
+	return {
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+	};
+}
+double metric_cartesian::jacobian(const IR3& r) const {
+	return morph_->jacobian(r);
+}
+IR3 metric_cartesian::del_jacobian(const IR3& r) const {
+	return {0.0, 0.0, 0.0};
+}
+
+ddIR3 metric_cartesian::christoffel_first_kind(const IR3& r) const {
+	return {
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+	};
+}
+ddIR3 metric_cartesian::christoffel_second_kind(const IR3& r) const {
+	return {
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+	};
+}
+IR3 metric_cartesian::to_covariant(const IR3& B, const IR3& r) const {
+	return B;
+}
+IR3 metric_cartesian::to_contravariant(const IR3& B, const IR3& r) const {
+	return B;
+}
+
+}

--- a/gyronimo/metrics/metric_cartesian.cc
+++ b/gyronimo/metrics/metric_cartesian.cc
@@ -22,14 +22,13 @@
 namespace gyronimo {
 
 metric_cartesian::metric_cartesian(const morphism_cartesian *morph) 
-	: metric_connected(morph), Lref_(morph->Lref()), 
-	Lref_2_(Lref_*Lref_), iLref_2_(1/Lref_2_) {
+	: metric_connected(morph) {
 }
 SM3 metric_cartesian::operator()(const IR3& r) const {
-	return {Lref_2_, 0.0, 0.0, Lref_2_, 0.0, Lref_2_};
+	return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
 }
 SM3 metric_cartesian::inverse(const IR3& r) const {
-	return {iLref_2_, 0.0, 0.0, iLref_2_, 0.0, iLref_2_};
+	return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
 }
 dSM3 metric_cartesian::del(const IR3& r) const {
 	return {
@@ -46,7 +45,7 @@ dSM3 metric_cartesian::del_inverse(const IR3& r) const {
 	};
 }
 double metric_cartesian::jacobian(const IR3& r) const {
-	return morph_->jacobian(r);
+	return 1.0;
 }
 IR3 metric_cartesian::del_jacobian(const IR3& r) const {
 	return {0.0, 0.0, 0.0};

--- a/gyronimo/metrics/metric_cartesian.cc
+++ b/gyronimo/metrics/metric_cartesian.cc
@@ -24,9 +24,29 @@ namespace gyronimo {
 metric_cartesian::metric_cartesian(const morphism_cartesian *morph) 
 	: metric_connected(morph) {
 }
+
+//! General-purpose implementation of the covariant metric.
+/*!
+	Implements the covariant metric in cartesian coordinates: 
+	@f$ g_{\alpha\beta} = \left(\begin{matrix}
+		1 && 0 && 0 \\
+		0 && 1 && 0 \\
+		0 && 0 && 1
+	\end{matrix}\right) @f$
+*/
 SM3 metric_cartesian::operator()(const IR3& r) const {
 	return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
 }
+
+//! General-purpose implementation of the inverse (i.e., contravariant metric).
+/*!
+	Implements the contravariant metric in cartesian coordinates: 
+	@f$ g^{\alpha\beta} = \left(\begin{matrix}
+		1 && 0 && 0 \\
+		0 && 1 && 0 \\
+		0 && 0 && 1
+	\end{matrix}\right) @f$
+*/
 SM3 metric_cartesian::inverse(const IR3& r) const {
 	return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
 }
@@ -44,9 +64,21 @@ dSM3 metric_cartesian::del_inverse(const IR3& r) const {
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 	};
 }
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ \textbf{x} @f$.
+/*!
+	Implements the Jacobian in cartesian coordinates: 
+	@f$ J = 1 @f$
+*/
 double metric_cartesian::jacobian(const IR3& r) const {
 	return 1.0;
 }
+
+//! General-purpose implementation of the Jacobian gradient in point @f$ \textbf{x} @f$.
+/*!
+	Implements the Jacobian gradient in cartesian coordinates: 
+	@f$ \nabla J = \left( 0,0,0 \right) @f$
+*/
 IR3 metric_cartesian::del_jacobian(const IR3& r) const {
 	return {0.0, 0.0, 0.0};
 }

--- a/gyronimo/metrics/metric_cartesian.hh
+++ b/gyronimo/metrics/metric_cartesian.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,35 +20,35 @@
 #ifndef GYRONIMO_METRIC_CARTESIAN
 #define GYRONIMO_METRIC_CARTESIAN
 
-#include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/morphism_cartesian.hh>
+#include <gyronimo/metrics/metric_connected.hh>
 
 namespace gyronimo {
 
 //! Trivial covariant metric for cartesian space.
-class metric_cartesian : public metric_covariant {
- public:
-  metric_cartesian() {};
-  virtual ~metric_cartesian() override {};
+class metric_cartesian : public metric_connected {
+public:
+	metric_cartesian(const morphism_cartesian *morph);
+	virtual ~metric_cartesian() override {};
 
-  virtual SM3 operator()(const IR3& r) const override {
-    return {1.0, 0.0, 0.0, 1.0, 0.0, 1.0};
-  };
-  virtual dSM3 del(const IR3& r) const override {
-    return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  };
-  virtual double jacobian(const IR3& r) const override {
-    return 1.0;
-  };
-  virtual IR3 del_jacobian(const IR3& r) const override {
-    return {0.0, 0.0, 0.0};
-  };
-  virtual IR3 to_covariant(const IR3& B, const IR3& r) const override {
-    return B;
-  };
-  virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override {
-    return B;
-  };
+	virtual SM3 operator()(const IR3& r) const override;
+	virtual SM3 inverse(const IR3& r) const override;
+	virtual dSM3 del(const IR3& r) const override;
+	virtual dSM3 del_inverse(const IR3& r) const override;
+	virtual double jacobian(const IR3& r) const override;
+	virtual IR3 del_jacobian(const IR3& r) const override;
+
+	virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
+	virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
+
+	virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
+	virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
+
+	double Lref() const {return Lref_;};
+
+private:
+	const morphism_cartesian *morph_;
+	double Lref_, Lref_2_, iLref_2_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_cartesian.hh
+++ b/gyronimo/metrics/metric_cartesian.hh
@@ -44,11 +44,8 @@ public:
 	virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
 	virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
 
-	double Lref() const {return Lref_;};
-
 private:
 	const morphism_cartesian *morph_;
-	double Lref_, Lref_2_, iLref_2_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_cartesian.hh
+++ b/gyronimo/metrics/metric_cartesian.hh
@@ -20,37 +20,36 @@
 #ifndef GYRONIMO_METRIC_CARTESIAN
 #define GYRONIMO_METRIC_CARTESIAN
 
-#include <gyronimo/metrics/morphism_cartesian.hh>
 #include <gyronimo/metrics/metric_connected.hh>
+#include <gyronimo/metrics/morphism_cartesian.hh>
 
 namespace gyronimo {
 
 //! Trivial covariant metric for cartesian space.
 class metric_cartesian : public metric_connected {
-public:
-	metric_cartesian(const morphism_cartesian *morph);
-	virtual ~metric_cartesian() override {};
+ public:
+  metric_cartesian(const morphism_cartesian* morph);
+  virtual ~metric_cartesian() override {};
 
-	virtual SM3 operator()(const IR3& r) const override;
-	virtual SM3 inverse(const IR3& r) const override;
-	virtual dSM3 del(const IR3& r) const override;
-	virtual dSM3 del_inverse(const IR3& r) const override;
-	virtual double jacobian(const IR3& r) const override;
-	virtual IR3 del_jacobian(const IR3& r) const override;
+  virtual SM3 operator()(const IR3& r) const override;
+  virtual SM3 inverse(const IR3& r) const override;
+  virtual dSM3 del(const IR3& r) const override;
+  virtual dSM3 del_inverse(const IR3& r) const override;
+  virtual double jacobian(const IR3& r) const override;
+  virtual IR3 del_jacobian(const IR3& r) const override;
 
-	virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
-	virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
+  virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
+  virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
 
-	virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
-	virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
+  virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
+  virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
 
-	virtual const morphism_cartesian* morph() const override {
-		return static_cast<const morphism_cartesian*>(morph_);
-	};
-
-private:
+  virtual const morphism_cartesian* my_morphism() const override {
+    return static_cast<const morphism_cartesian*>(
+        metric_connected::my_morphism());
+  };
 };
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.
 
-#endif // GYRONIMO_METRIC_CARTESIAN
+#endif  // GYRONIMO_METRIC_CARTESIAN

--- a/gyronimo/metrics/metric_cartesian.hh
+++ b/gyronimo/metrics/metric_cartesian.hh
@@ -45,11 +45,10 @@ public:
 	virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
 
 	virtual const morphism_cartesian* morph() const override {
-		return static_cast<const morphism_cartesian*>(this->metric_connected::morph());
+		return static_cast<const morphism_cartesian*>(morph_);
 	};
 
 private:
-	const morphism_cartesian *morph_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_cartesian.hh
+++ b/gyronimo/metrics/metric_cartesian.hh
@@ -44,6 +44,10 @@ public:
 	virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
 	virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
 
+	virtual const morphism_cartesian* morph() const override {
+		return static_cast<const morphism_cartesian*>(this->metric_connected::morph());
+	};
+
 private:
 	const morphism_cartesian *morph_;
 };

--- a/gyronimo/metrics/metric_connected.cc
+++ b/gyronimo/metrics/metric_connected.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Manuel Assunção.
+// Copyright (C) 2022 Manuel Assunção and Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -21,109 +21,109 @@
 
 namespace gyronimo {
 
-metric_connected::metric_connected(const morphism *morph) 
-		: morph_(morph) {
-	
-	if(morph_ == nullptr)
-		error(__func__, __FILE__, __LINE__, " morphism cannot be nullptr.", 1);
+double metric_connected::jacobian(const IR3& r) const {
+  return my_morphism_->jacobian(r);
 }
 
-//! General-purpose implementation of the local metric matrix `SM3`.
-/*!
-	Implemented the rule
-	@f$ g_{\alpha\beta} = \textbf{e}_\alpha \cdot \textbf{e}_\beta @f$
-*/
+//! General-purpose covariant metric @f$g_{ij}=\mathbf{e}_i\cdot\mathbf{e}_j@f$.
 SM3 metric_connected::operator()(const IR3& r) const {
-	dIR3 e = morph_->del(r);
-	IR3 e1 = {e[dIR3::uu], e[dIR3::vu], e[dIR3::wu]};
-	IR3 e2 = {e[dIR3::uv], e[dIR3::vv], e[dIR3::wv]};
-	IR3 e3 = {e[dIR3::uw], e[dIR3::vw], e[dIR3::ww]};
-	SM3 g = {inner_product(e1, e1), inner_product(e1, e2), inner_product(e1, e3),
-			 inner_product(e2, e2), inner_product(e2, e3), inner_product(e3, e3)};
-	return g;
+  dIR3 e = my_morphism_->del(r);
+  IR3 e1 = {e[dIR3::uu], e[dIR3::vu], e[dIR3::wu]};
+  IR3 e2 = {e[dIR3::uv], e[dIR3::vv], e[dIR3::wv]};
+  IR3 e3 = {e[dIR3::uw], e[dIR3::vw], e[dIR3::ww]};
+  SM3 g = {inner_product(e1, e1), inner_product(e1, e2), inner_product(e1, e3),
+           inner_product(e2, e2), inner_product(e2, e3), inner_product(e3, e3)};
+  return g;
 }
 
-//! General implementation of `metric_connected` derivatives
+//! General-purpose covariant-metric derivatives.
 /*!
-	Implemented the rule
-	@f$ \partial_\gamma \, g_{\alpha\beta} = \Gamma_{\alpha\beta\gamma} + \Gamma_{\beta\alpha\gamma} @f$
+    Implements the rule
+    ```
+    \partial_\gamma \, g_{\alpha\beta} =
+        \Gamma_{\alpha\beta\gamma} + \Gamma_{\beta\alpha\gamma}
+    ```
 */
 dSM3 metric_connected::del(const IR3& r) const {
-	ddIR3 CF = christoffel_first_kind(r);
-	return {
-		CF[ddIR3::uuu] + CF[ddIR3::uuu], // uuu
-		CF[ddIR3::uuv] + CF[ddIR3::uuv], // uuv
-		CF[ddIR3::uuw] + CF[ddIR3::uuw], // uuw
-		CF[ddIR3::uuv] + CF[ddIR3::vuu], // uvu
-		CF[ddIR3::uvv] + CF[ddIR3::vuv], // uvv
-		CF[ddIR3::uvw] + CF[ddIR3::vuw], // uvw
-    	CF[ddIR3::uuw] + CF[ddIR3::wuu], // uwu
-		CF[ddIR3::uvw] + CF[ddIR3::wuv], // uwv
-		CF[ddIR3::uww] + CF[ddIR3::wuw], // uww
-		CF[ddIR3::vuv] + CF[ddIR3::vuv], // vvu
-		CF[ddIR3::vvv] + CF[ddIR3::vvv], // vvv
-		CF[ddIR3::vvw] + CF[ddIR3::vvw], // vvw
-    	CF[ddIR3::vuw] + CF[ddIR3::wuv], // vwu
-		CF[ddIR3::vvw] + CF[ddIR3::wvv], // vwv
-		CF[ddIR3::vww] + CF[ddIR3::wvw], // vww
-		CF[ddIR3::wuw] + CF[ddIR3::wuw], // wwu
-		CF[ddIR3::wvw] + CF[ddIR3::wvw], // wwv
-		CF[ddIR3::www] + CF[ddIR3::www]  // www
-	};
+  ddIR3 CF = christoffel_first_kind(r);
+  return {
+      CF[ddIR3::uuu] + CF[ddIR3::uuu],  // uuu
+      CF[ddIR3::uuv] + CF[ddIR3::uuv],  // uuv
+      CF[ddIR3::uuw] + CF[ddIR3::uuw],  // uuw
+      CF[ddIR3::uuv] + CF[ddIR3::vuu],  // uvu
+      CF[ddIR3::uvv] + CF[ddIR3::vuv],  // uvv
+      CF[ddIR3::uvw] + CF[ddIR3::vuw],  // uvw
+      CF[ddIR3::uuw] + CF[ddIR3::wuu],  // uwu
+      CF[ddIR3::uvw] + CF[ddIR3::wuv],  // uwv
+      CF[ddIR3::uww] + CF[ddIR3::wuw],  // uww
+      CF[ddIR3::vuv] + CF[ddIR3::vuv],  // vvu
+      CF[ddIR3::vvv] + CF[ddIR3::vvv],  // vvv
+      CF[ddIR3::vvw] + CF[ddIR3::vvw],  // vvw
+      CF[ddIR3::vuw] + CF[ddIR3::wuv],  // vwu
+      CF[ddIR3::vvw] + CF[ddIR3::wvv],  // vwv
+      CF[ddIR3::vww] + CF[ddIR3::wvw],  // vww
+      CF[ddIR3::wuw] + CF[ddIR3::wuw],  // wwu
+      CF[ddIR3::wvw] + CF[ddIR3::wvw],  // wwv
+      CF[ddIR3::www] + CF[ddIR3::www]  // www
+  };
 }
 
-//! General-purpose implementation of the Jacobian.
-double metric_connected::jacobian(const IR3& r) const {
-	return morph_->jacobian(r);
-}
-
-//! General-purpose implementation of the Jacobian gradient.
+//! General-purpose Jacobian gradient.
 /*!
     Implements the rule
-    @f$ \partial_\alpha J = J \left(
-		\Gamma^1_{\alpha 1} + \Gamma^2_{\alpha 2} + \Gamma^3_{\alpha 3}
-	\right) @f$
+    ```
+    \partial_\alpha J = J \left(
+        \Gamma^1_{\alpha 1} + \Gamma^2_{\alpha 2} + \Gamma^3_{\alpha 3} \right)
+    ```
 */
 IR3 metric_connected::del_jacobian(const IR3& r) const {
-	double J = jacobian(r);
-	dIR3 ee = morph_->del_inverse(r);
-	ddIR3 de = morph_->ddel(r);
-	IR3 con = {
-		ee[dIR3::uu] * de[ddIR3::uuu] + ee[dIR3::uv] * de[ddIR3::vuu] + ee[dIR3::uw] * de[ddIR3::wuu] + 
-		ee[dIR3::vu] * de[ddIR3::uuv] + ee[dIR3::vv] * de[ddIR3::vuv] + ee[dIR3::vw] * de[ddIR3::wuv] + 
-		ee[dIR3::wu] * de[ddIR3::uuw] + ee[dIR3::wv] * de[ddIR3::vuw] + ee[dIR3::ww] * de[ddIR3::wuw],
-		ee[dIR3::uu] * de[ddIR3::uuv] + ee[dIR3::uv] * de[ddIR3::vuv] + ee[dIR3::uw] * de[ddIR3::wuv] + 
-		ee[dIR3::vu] * de[ddIR3::uvv] + ee[dIR3::vv] * de[ddIR3::vvv] + ee[dIR3::vw] * de[ddIR3::wvv] + 
-		ee[dIR3::wu] * de[ddIR3::uvw] + ee[dIR3::wv] * de[ddIR3::vvw] + ee[dIR3::ww] * de[ddIR3::wvw],
-		ee[dIR3::uu] * de[ddIR3::uuw] + ee[dIR3::uv] * de[ddIR3::vuw] + ee[dIR3::uw] * de[ddIR3::wuw] + 
-		ee[dIR3::vu] * de[ddIR3::uvw] + ee[dIR3::vv] * de[ddIR3::vvw] + ee[dIR3::vw] * de[ddIR3::wvw] + 
-		ee[dIR3::wu] * de[ddIR3::uww] + ee[dIR3::wv] * de[ddIR3::vww] + ee[dIR3::ww] * de[ddIR3::www]
-	};
-	return (J * con);
+  double J = jacobian(r);
+  dIR3 ee = my_morphism_->del_inverse(r);
+  ddIR3 de = my_morphism_->ddel(r);
+  IR3 con = {
+      ee[dIR3::uu] * de[ddIR3::uuu] + ee[dIR3::uv] * de[ddIR3::vuu] +
+          ee[dIR3::uw] * de[ddIR3::wuu] + ee[dIR3::vu] * de[ddIR3::uuv] +
+          ee[dIR3::vv] * de[ddIR3::vuv] + ee[dIR3::vw] * de[ddIR3::wuv] +
+          ee[dIR3::wu] * de[ddIR3::uuw] + ee[dIR3::wv] * de[ddIR3::vuw] +
+          ee[dIR3::ww] * de[ddIR3::wuw],
+      ee[dIR3::uu] * de[ddIR3::uuv] + ee[dIR3::uv] * de[ddIR3::vuv] +
+          ee[dIR3::uw] * de[ddIR3::wuv] + ee[dIR3::vu] * de[ddIR3::uvv] +
+          ee[dIR3::vv] * de[ddIR3::vvv] + ee[dIR3::vw] * de[ddIR3::wvv] +
+          ee[dIR3::wu] * de[ddIR3::uvw] + ee[dIR3::wv] * de[ddIR3::vvw] +
+          ee[dIR3::ww] * de[ddIR3::wvw],
+      ee[dIR3::uu] * de[ddIR3::uuw] + ee[dIR3::uv] * de[ddIR3::vuw] +
+          ee[dIR3::uw] * de[ddIR3::wuw] + ee[dIR3::vu] * de[ddIR3::uvw] +
+          ee[dIR3::vv] * de[ddIR3::vvw] + ee[dIR3::vw] * de[ddIR3::wvw] +
+          ee[dIR3::wu] * de[ddIR3::uww] + ee[dIR3::wv] * de[ddIR3::vww] +
+          ee[dIR3::ww] * de[ddIR3::www]};
+  return (J * con);
 }
 
-//! Implementation of Christoffel symbols of the first kind @f$ \Gamma_{\alpha\beta\gamma} @f$
+//! General-purpose Christoffel symbols of the first kind.
 /*!
     Implements the rule
-    @f$ \Gamma_{\alpha\beta\gamma} = \textbf{e}_\alpha \cdot 
-	\frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma} @f$
+    ```
+    \Gamma_{\alpha\beta\gamma} = \textbf{e}_\alpha \cdot
+        \frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma}
+    ```
 */
 ddIR3 metric_connected::christoffel_first_kind(const IR3& r) const {
-	dIR3 e = morph_->del(r);
-	ddIR3 ddR = morph_->ddel(r);
-	return contraction<first, first>(e, ddR);
+  dIR3 e = my_morphism_->del(r);
+  ddIR3 ddR = my_morphism_->ddel(r);
+  return contraction<first, first>(e, ddR);
 }
 
-//! Implementation of Christoffel symbols of the second kind @f$ \Gamma^\alpha_{\beta\gamma} @f$
+//! General-purpose Christoffel symbols of the second kind.
 /*!
     Implements the rule
-    @f$ \Gamma^\alpha_{\beta\gamma} = \textbf{e}^\alpha \cdot 
-	\frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma} @f$
+    ```
+    \Gamma^\alpha_{\beta\gamma} = \textbf{e}^\alpha \cdot
+        \frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma}
+    ```
 */
 ddIR3 metric_connected::christoffel_second_kind(const IR3& r) const {
-	dIR3 ee = morph_->del_inverse(r);
-	ddIR3 ddR = morph_->ddel(r);
-	return contraction<second, first>(ee, ddR);
+  return contraction<second, first>(
+      my_morphism_->del_inverse(r), my_morphism_->ddel(r));
 }
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.

--- a/gyronimo/metrics/metric_connected.cc
+++ b/gyronimo/metrics/metric_connected.cc
@@ -99,7 +99,7 @@ IR3 metric_connected::del_jacobian(const IR3& r) const {
 		ee[dIR3::vu] * de[ddIR3::uvw] + ee[dIR3::vv] * de[ddIR3::vvw] + ee[dIR3::vw] * de[ddIR3::wvw] + 
 		ee[dIR3::wu] * de[ddIR3::uww] + ee[dIR3::wv] * de[ddIR3::vww] + ee[dIR3::ww] * de[ddIR3::www]
 	};
-	return (J * contraction<first>(ee, con));
+	return (J * con);
 }
 
 //! Implementation of Christoffel symbols of the first kind @f$ \Gamma_{\alpha\beta\gamma} @f$

--- a/gyronimo/metrics/metric_connected.cc
+++ b/gyronimo/metrics/metric_connected.cc
@@ -15,13 +15,13 @@
 // You should have received a copy of the GNU General Public License
 // along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
 
-// @metric_nexus.cc, this file is part of ::gyronimo::
+// @metric_connected.cc, this file is part of ::gyronimo::
 
-#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/metric_connected.hh>
 
 namespace gyronimo {
 
-metric_nexus::metric_nexus(const morphism *morph) 
+metric_connected::metric_connected(const morphism *morph) 
 		: morph_(morph) {
 	
 	if(morph_ == nullptr)
@@ -33,7 +33,7 @@ metric_nexus::metric_nexus(const morphism *morph)
 	Implemented the rule
 	@f$ g_{\alpha\beta} = \textbf{e}_\alpha \cdot \textbf{e}_\beta @f$
 */
-SM3 metric_nexus::operator()(const IR3& r) const {
+SM3 metric_connected::operator()(const IR3& r) const {
 	dIR3 e = morph_->del(r);
 	IR3 e1 = {e[dIR3::uu], e[dIR3::vu], e[dIR3::wu]};
 	IR3 e2 = {e[dIR3::uv], e[dIR3::vv], e[dIR3::wv]};
@@ -43,12 +43,12 @@ SM3 metric_nexus::operator()(const IR3& r) const {
 	return g;
 }
 
-//! General implementation of `metric_nexus` derivatives
+//! General implementation of `metric_connected` derivatives
 /*!
 	Implemented the rule
 	@f$ \partial_\gamma \, g_{\alpha\beta} = \Gamma_{\alpha\beta\gamma} + \Gamma_{\beta\alpha\gamma} @f$
 */
-dSM3 metric_nexus::del(const IR3& r) const {
+dSM3 metric_connected::del(const IR3& r) const {
 	ddIR3 CF = christoffel_first_kind(r);
 	return {
 		CF[ddIR3::uuu] + CF[ddIR3::uuu], // uuu
@@ -73,7 +73,7 @@ dSM3 metric_nexus::del(const IR3& r) const {
 }
 
 //! General-purpose implementation of the Jacobian.
-double metric_nexus::jacobian(const IR3& r) const {
+double metric_connected::jacobian(const IR3& r) const {
 	return morph_->jacobian(r);
 }
 
@@ -84,7 +84,7 @@ double metric_nexus::jacobian(const IR3& r) const {
 		\Gamma^1_{\alpha 1} + \Gamma^2_{\alpha 2} + \Gamma^3_{\alpha 3}
 	\right) @f$
 */
-IR3 metric_nexus::del_jacobian(const IR3& r) const {
+IR3 metric_connected::del_jacobian(const IR3& r) const {
 	double J = jacobian(r);
 	dIR3 ee = morph_->del_inverse(r);
 	ddIR3 de = morph_->ddel(r);
@@ -108,7 +108,7 @@ IR3 metric_nexus::del_jacobian(const IR3& r) const {
     @f$ \Gamma_{\alpha\beta\gamma} = \textbf{e}_\alpha \cdot 
 	\frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma} @f$
 */
-ddIR3 metric_nexus::christoffel_first_kind(const IR3& r) const {
+ddIR3 metric_connected::christoffel_first_kind(const IR3& r) const {
 	dIR3 e = morph_->del(r);
 	ddIR3 ddR = morph_->ddel(r);
 	return contraction<first, first>(e, ddR);
@@ -120,7 +120,7 @@ ddIR3 metric_nexus::christoffel_first_kind(const IR3& r) const {
     @f$ \Gamma^\alpha_{\beta\gamma} = \textbf{e}^\alpha \cdot 
 	\frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma} @f$
 */
-ddIR3 metric_nexus::christoffel_second_kind(const IR3& r) const {
+ddIR3 metric_connected::christoffel_second_kind(const IR3& r) const {
 	dIR3 ee = morph_->del_inverse(r);
 	ddIR3 ddR = morph_->ddel(r);
 	return contraction<second, first>(ee, ddR);

--- a/gyronimo/metrics/metric_connected.hh
+++ b/gyronimo/metrics/metric_connected.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Manuel Assunção.
+// Copyright (C) 2022 Manuel Assunção and Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -21,32 +21,27 @@
 #define GYRONIMO_METRIC_CONNECTED
 
 #include <gyronimo/core/error.hh>
-#include <gyronimo/metrics/morphism.hh>
 #include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/morphism.hh>
 
 namespace gyronimo {
 
-//! Covariant metric that is connected to its respective `morphism`.
+//! Covariant metric connected to a defining `morphism`.
 class metric_connected : public metric_covariant {
-
-public:
-	metric_connected(const morphism *morph);
-	virtual ~metric_connected() override {};
-
-	virtual SM3 operator()(const IR3& r) const override;
-	virtual dSM3 del(const IR3& r) const override;
-	virtual double jacobian(const IR3& r) const override;
-	virtual IR3 del_jacobian(const IR3& r) const override;
-
-	virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
-	virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
-
-	virtual const morphism* morph() const {return morph_;};
-
-protected:
-	const morphism *morph_;
+ public:
+  metric_connected(const morphism* m) : my_morphism_(m) {};
+  virtual ~metric_connected() override {};
+  virtual SM3 operator()(const IR3& r) const override;
+  virtual dSM3 del(const IR3& r) const override;
+  virtual double jacobian(const IR3& r) const override;
+  virtual IR3 del_jacobian(const IR3& r) const override;
+  virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
+  virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
+  virtual const morphism* my_morphism() const { return my_morphism_; };
+ private:
+  const morphism* my_morphism_;
 };
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.
 
-#endif // GYRONIMO_METRIC_CONNECTED
+#endif  // GYRONIMO_METRIC_CONNECTED

--- a/gyronimo/metrics/metric_connected.hh
+++ b/gyronimo/metrics/metric_connected.hh
@@ -15,10 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
 
-// @metric_nexus.hh, this file is part of ::gyronimo::
+// @metric_connected.hh, this file is part of ::gyronimo::
 
-#ifndef GYRONIMO_METRIC_NEXUS
-#define GYRONIMO_METRIC_NEXUS
+#ifndef GYRONIMO_METRIC_CONNECTED
+#define GYRONIMO_METRIC_CONNECTED
 
 #include <gyronimo/core/error.hh>
 #include <gyronimo/metrics/morphism.hh>
@@ -26,20 +26,12 @@
 
 namespace gyronimo {
 
-// Naming options: 
-// metric_nexus 	// because of the connection between metric and morphism
-// metric_generator // because it is generated from morphism
-// metric_creator	// because it is created from morphism
-// metric_founder	// because it is founded from morphism
-// metric_calculator	// because it is calculated from morphism
-// metric_accessory	// because it is an accessory of morphism
-
 //! Covariant metric that is connected to its respective `morphism`.
-class metric_nexus : public metric_covariant {
+class metric_connected : public metric_covariant {
 
 public:
-	metric_nexus(const morphism *morph);
-	virtual ~metric_nexus() override {};
+	metric_connected(const morphism *morph);
+	virtual ~metric_connected() override {};
 
 	virtual SM3 operator()(const IR3& r) const override;
 	virtual dSM3 del(const IR3& r) const override;
@@ -57,4 +49,4 @@ private:
 
 } // end namespace gyronimo.
 
-#endif // GYRONIMO_METRIC_NEXUS
+#endif // GYRONIMO_METRIC_CONNECTED

--- a/gyronimo/metrics/metric_connected.hh
+++ b/gyronimo/metrics/metric_connected.hh
@@ -43,7 +43,7 @@ public:
 
 	virtual const morphism* morph() const {return morph_;};
 
-private:
+protected:
 	const morphism *morph_;
 };
 

--- a/gyronimo/metrics/metric_covariant.cc
+++ b/gyronimo/metrics/metric_covariant.cc
@@ -17,54 +17,61 @@
 
 // @metric_covariant.cc, this file is part of ::gyronimo::
 
-#include <cmath>
 #include <gyronimo/core/contraction.hh>
 #include <gyronimo/metrics/metric_covariant.hh>
 
+#include <cmath>
+
 namespace gyronimo {
 
-//! General-purpose implementation of the Jacobian.
 double metric_covariant::jacobian(const IR3& r) const {
   SM3 g = (*this)(r);
-  return std::sqrt(g[SM3::uu]*g[SM3::vv]*g[SM3::ww] +
-      2.0*g[SM3::uv]*g[SM3::uw]*g[SM3::vw] - g[SM3::uv]*g[SM3::uv]*g[SM3::ww] -
-          g[SM3::uu]*g[SM3::vw]*g[SM3::vw] - g[SM3::uw]*g[SM3::uw]*g[SM3::vv]);
+  return std::sqrt(
+      g[SM3::uu] * g[SM3::vv] * g[SM3::ww] +
+      2.0 * g[SM3::uv] * g[SM3::uw] * g[SM3::vw] -
+      g[SM3::uv] * g[SM3::uv] * g[SM3::ww] -
+      g[SM3::uu] * g[SM3::vw] * g[SM3::vw] -
+      g[SM3::uw] * g[SM3::uw] * g[SM3::vv]);
 }
-
-//! General-purpose implementation of the Jacobian gradient.
 IR3 metric_covariant::del_jacobian(const IR3& r) const {
-	SM3 g = (*this)(r);
-	dSM3 dg = this->del(r);
-	double ijacobian = 1.0 / this->jacobian(r);
-	
-	IR3 aux_1a = {g[SM3::uw]*g[SM3::vw], g[SM3::uv]*g[SM3::vw], g[SM3::uv]*g[SM3::uw]};
-	dIR3 aux_1b = {
-		dg[dSM3::uvu], dg[dSM3::uwu], dg[dSM3::vwu],
-		dg[dSM3::uvv], dg[dSM3::uwv], dg[dSM3::vwv],
-		dg[dSM3::uvw], dg[dSM3::uww], dg[dSM3::vww]
-	};
-	IR3 aux_1 = contraction<second>(aux_1b, aux_1a);
-	
-	IR3 aux_2a = {g[SM3::vv]*g[SM3::ww], g[SM3::uu]*g[SM3::ww], g[SM3::uu]*g[SM3::vv]};
-	dIR3 aux_2b = {
-		dg[dSM3::uuu], dg[dSM3::vvu], dg[dSM3::wwu],
-		dg[dSM3::uuv], dg[dSM3::vvv], dg[dSM3::wwv],
-		dg[dSM3::uuw], dg[dSM3::vvw], dg[dSM3::www]
-	};
-	IR3 aux_2 = contraction<second>(aux_2b, aux_2a);
-	
-	IR3 aux_3a = {g[SM3::uu]*g[SM3::vw], g[SM3::vv]*g[SM3::uw], g[SM3::ww]*g[SM3::uv]};
-	dIR3 aux_3b = {
-		dg[dSM3::vwu], dg[dSM3::uwu], dg[dSM3::uvu],
-		dg[dSM3::vwv], dg[dSM3::uwv], dg[dSM3::uvv],
-		dg[dSM3::vww], dg[dSM3::uww], dg[dSM3::uvw]
-	};
-	IR3 aux_3 = contraction<second>(aux_3b, aux_3a);
-	
-	IR3 aux_4a = {g[SM3::vw]*g[SM3::vw], g[SM3::uw]*g[SM3::uw], g[SM3::uv]*g[SM3::uv]};
-	IR3 aux_4 = contraction<second>(aux_2b, aux_4a);
+  SM3 g = (*this)(r);
+  dSM3 dg = this->del(r);
+  double ijacobian = 1.0 / this->jacobian(r);
 
-	return ijacobian * (aux_1 + 0.5*aux_2 - aux_3 - 0.5*aux_4);
+  IR3 aux_1a = {
+      g[SM3::uw] * g[SM3::vw], g[SM3::uv] * g[SM3::vw],
+      g[SM3::uv] * g[SM3::uw]};
+  dIR3 aux_1b = {dg[dSM3::uvu], dg[dSM3::uwu], dg[dSM3::vwu],
+                 dg[dSM3::uvv], dg[dSM3::uwv], dg[dSM3::vwv],
+                 dg[dSM3::uvw], dg[dSM3::uww], dg[dSM3::vww]};
+  IR3 aux_1 = contraction<second>(aux_1b, aux_1a);
+
+  IR3 aux_2a = {
+      g[SM3::vv] * g[SM3::ww], g[SM3::uu] * g[SM3::ww],
+      g[SM3::uu] * g[SM3::vv]};
+  dIR3 aux_2b = {dg[dSM3::uuu], dg[dSM3::vvu], dg[dSM3::wwu],
+                 dg[dSM3::uuv], dg[dSM3::vvv], dg[dSM3::wwv],
+                 dg[dSM3::uuw], dg[dSM3::vvw], dg[dSM3::www]};
+  IR3 aux_2 = contraction<second>(aux_2b, aux_2a);
+
+  IR3 aux_3a = {
+      g[SM3::uu] * g[SM3::vw], g[SM3::vv] * g[SM3::uw],
+      g[SM3::ww] * g[SM3::uv]};
+  dIR3 aux_3b = {dg[dSM3::vwu], dg[dSM3::uwu], dg[dSM3::uvu],
+                 dg[dSM3::vwv], dg[dSM3::uwv], dg[dSM3::uvv],
+                 dg[dSM3::vww], dg[dSM3::uww], dg[dSM3::uvw]};
+  IR3 aux_3 = contraction<second>(aux_3b, aux_3a);
+
+  IR3 aux_4a = {
+      g[SM3::vw] * g[SM3::vw], g[SM3::uw] * g[SM3::uw],
+      g[SM3::uv] * g[SM3::uv]};
+  IR3 aux_4 = contraction<second>(aux_2b, aux_4a);
+
+  return ijacobian * (aux_1 + 0.5 * aux_2 - aux_3 - 0.5 * aux_4);
+}
+SM3 metric_covariant::inverse(const IR3& r) const {
+  SM3 m = (*this)(r);
+  return gyronimo::inverse(m);
 }
 
 //! General-purpose product of a covariant metric and a contravariant vector.
@@ -74,12 +81,6 @@ IR3 metric_covariant::del_jacobian(const IR3& r) const {
 */
 IR3 metric_covariant::to_covariant(const IR3& B, const IR3& r) const {
   return contraction((*this)(r), B);
-}
-
-//! General-purpose implementation of the inverse (i.e., contravariant metric).
-SM3 metric_covariant::inverse(const IR3& r) const {
-  SM3 m = (*this)(r);
-  return gyronimo::inverse(m);
 }
 
 //! General-purpose product of a contravariant metric and a covariant vector.
@@ -93,65 +94,67 @@ IR3 metric_covariant::to_contravariant(const IR3& B, const IR3& r) const {
   return contraction(this->inverse(r), B);
 }
 
-//! General-purpose implementation of the inverse derivatives.
+//! General-purpose derivative of the inverse metric.
 /*!
     Implements the rule
-    @f$ \partial_k g^{ij} = - g^{im} \partial_k g_{mn} g^{nj} @f$
+    ```
+    \partial_k g^{ij} = - g^{im} \partial_k g_{mn} g^{nj}
+    ```
 */
 dSM3 metric_covariant::del_inverse(const IR3& r) const {
   SM3 ig = this->inverse(r);
   dSM3 dg = contraction(ig, this->del(r), ig);
-  return {
-    -dg[dSM3::uuu], -dg[dSM3::uuv], -dg[dSM3::uuw],
-    -dg[dSM3::uvu], -dg[dSM3::uvv], -dg[dSM3::uvw],
-    -dg[dSM3::uwu], -dg[dSM3::uwv], -dg[dSM3::uww],
-    -dg[dSM3::vvu], -dg[dSM3::vvv], -dg[dSM3::vvw],
-    -dg[dSM3::vwu], -dg[dSM3::vwv], -dg[dSM3::vww],
-    -dg[dSM3::wwu], -dg[dSM3::wwv], -dg[dSM3::www]};
+  return {-dg[dSM3::uuu], -dg[dSM3::uuv], -dg[dSM3::uuw], -dg[dSM3::uvu],
+          -dg[dSM3::uvv], -dg[dSM3::uvw], -dg[dSM3::uwu], -dg[dSM3::uwv],
+          -dg[dSM3::uww], -dg[dSM3::vvu], -dg[dSM3::vvv], -dg[dSM3::vvw],
+          -dg[dSM3::vwu], -dg[dSM3::vwv], -dg[dSM3::vww], -dg[dSM3::wwu],
+          -dg[dSM3::wwv], -dg[dSM3::www]};
 }
 
-//! Implementation of Christoffel symbols of the first kind @f$ \Gamma_{\alpha\beta\gamma} @f$
+//! General-purpose Christoffel symbols of the first kind.
 /*!
     Implements the rule
-    @f$ \Gamma_{\alpha\beta\gamma} = \frac{1}{2} \left( 
-		\frac{\partial g_{\alpha\beta}}{\partial q^\gamma} +
-		\frac{\partial g_{\alpha\gamma}}{\partial q^\beta} -
-		\frac{\partial g_{\beta\gamma}}{\partial q^\alpha}
-	\right) @f$
+    ```
+    \Gamma_{\alpha\beta\gamma} = \frac{1}{2} \left(
+                \frac{\partial g_{\alpha\beta}}{\partial q^\gamma} +
+                \frac{\partial g_{\alpha\gamma}}{\partial q^\beta} -
+                \frac{\partial g_{\beta\gamma}}{\partial q^\alpha} \right)
+    ```
 */
 ddIR3 metric_covariant::christoffel_first_kind(const IR3& r) const {
-	dSM3 dg = del(r);
-	return {
-		0.5 * (dg[dSM3::uuu] + dg[dSM3::uuu] - dg[dSM3::uuu]), // uuu
-		0.5 * (dg[dSM3::uuv] + dg[dSM3::uvu] - dg[dSM3::uvu]), // uuv
-		0.5 * (dg[dSM3::uuw] + dg[dSM3::uwu] - dg[dSM3::uwu]), // uuw
-		0.5 * (dg[dSM3::uvv] + dg[dSM3::uvv] - dg[dSM3::vvu]), // uvv
-		0.5 * (dg[dSM3::uvw] + dg[dSM3::uwv] - dg[dSM3::vwu]), // uvw
-		0.5 * (dg[dSM3::uww] + dg[dSM3::uww] - dg[dSM3::wwu]), // uww
-		0.5 * (dg[dSM3::uvu] + dg[dSM3::uvu] - dg[dSM3::uuv]), // vuu
-		0.5 * (dg[dSM3::uvv] + dg[dSM3::vvu] - dg[dSM3::uvv]), // vuv
-		0.5 * (dg[dSM3::uvw] + dg[dSM3::vwu] - dg[dSM3::uwv]), // vuw
-		0.5 * (dg[dSM3::vvv] + dg[dSM3::vvv] - dg[dSM3::vvv]), // vvv
-		0.5 * (dg[dSM3::vvw] + dg[dSM3::vwv] - dg[dSM3::vwv]), // vvw
-		0.5 * (dg[dSM3::vww] + dg[dSM3::vww] - dg[dSM3::wwv]), // vww
-    	0.5 * (dg[dSM3::uwu] + dg[dSM3::uwu] - dg[dSM3::uuw]), // wuu
-		0.5 * (dg[dSM3::uwv] + dg[dSM3::vwu] - dg[dSM3::uvw]), // wuv
-		0.5 * (dg[dSM3::uww] + dg[dSM3::wwu] - dg[dSM3::uww]), // wuw
-		0.5 * (dg[dSM3::vwv] + dg[dSM3::vwv] - dg[dSM3::vvw]), // wvv
-		0.5 * (dg[dSM3::vww] + dg[dSM3::wwv] - dg[dSM3::vww]), // wvw
-		0.5 * (dg[dSM3::www] + dg[dSM3::www] - dg[dSM3::www])  // www
-	};
+  dSM3 dg = del(r);
+  return {
+      0.5 * (dg[dSM3::uuu] + dg[dSM3::uuu] - dg[dSM3::uuu]),  // uuu
+      0.5 * (dg[dSM3::uuv] + dg[dSM3::uvu] - dg[dSM3::uvu]),  // uuv
+      0.5 * (dg[dSM3::uuw] + dg[dSM3::uwu] - dg[dSM3::uwu]),  // uuw
+      0.5 * (dg[dSM3::uvv] + dg[dSM3::uvv] - dg[dSM3::vvu]),  // uvv
+      0.5 * (dg[dSM3::uvw] + dg[dSM3::uwv] - dg[dSM3::vwu]),  // uvw
+      0.5 * (dg[dSM3::uww] + dg[dSM3::uww] - dg[dSM3::wwu]),  // uww
+      0.5 * (dg[dSM3::uvu] + dg[dSM3::uvu] - dg[dSM3::uuv]),  // vuu
+      0.5 * (dg[dSM3::uvv] + dg[dSM3::vvu] - dg[dSM3::uvv]),  // vuv
+      0.5 * (dg[dSM3::uvw] + dg[dSM3::vwu] - dg[dSM3::uwv]),  // vuw
+      0.5 * (dg[dSM3::vvv] + dg[dSM3::vvv] - dg[dSM3::vvv]),  // vvv
+      0.5 * (dg[dSM3::vvw] + dg[dSM3::vwv] - dg[dSM3::vwv]),  // vvw
+      0.5 * (dg[dSM3::vww] + dg[dSM3::vww] - dg[dSM3::wwv]),  // vww
+      0.5 * (dg[dSM3::uwu] + dg[dSM3::uwu] - dg[dSM3::uuw]),  // wuu
+      0.5 * (dg[dSM3::uwv] + dg[dSM3::vwu] - dg[dSM3::uvw]),  // wuv
+      0.5 * (dg[dSM3::uww] + dg[dSM3::wwu] - dg[dSM3::uww]),  // wuw
+      0.5 * (dg[dSM3::vwv] + dg[dSM3::vwv] - dg[dSM3::vvw]),  // wvv
+      0.5 * (dg[dSM3::vww] + dg[dSM3::wwv] - dg[dSM3::vww]),  // wvw
+      0.5 * (dg[dSM3::www] + dg[dSM3::www] - dg[dSM3::www])  // www
+  };
 }
 
-//! Implementation of Christoffel symbols of the second kind @f$ \Gamma^\alpha_{\beta\gamma} @f$
+//! General-purpose Christoffel symbols of the second kind.
 /*!
     Implements the rule
-    @f$ \Gamma^\alpha_{\beta\gamma} = g^{\alpha\mu} \, \Gamma_{\mu\beta\gamma} @f$
+    ```
+    \Gamma^\alpha_{\beta\gamma} = g^{\alpha\mu} \, \Gamma_{\mu\beta\gamma}
+    ```
 */
 ddIR3 metric_covariant::christoffel_second_kind(const IR3& r) const {
-	SM3 ig = inverse(r);
-	ddIR3 CF1 = christoffel_first_kind(r);
-	return contraction<second, first>(ig, CF1);
+  return contraction<second, first>(
+      this->inverse(r), this->christoffel_first_kind(r));
 }
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.

--- a/gyronimo/metrics/metric_covariant.cc
+++ b/gyronimo/metrics/metric_covariant.cc
@@ -114,4 +114,48 @@ dSM3 metric_covariant::del_inverse(const IR3& r) const {
     -dg[dSM3::wwu], -dg[dSM3::wwv], -dg[dSM3::www]};
 }
 
+//! Implementation of Christoffel symbols of the first kind @f$ \Gamma_{\alpha\beta\gamma} @f$
+/*!
+    Implements the rule
+    @f$ \Gamma_{\alpha\beta\gamma} = \frac{1}{2} \left( 
+		\frac{\partial g_{\alpha\beta}}{\partial q^\gamma} +
+		\frac{\partial g_{\alpha\gamma}}{\partial q^\beta} -
+		\frac{\partial g_{\beta\gamma}}{\partial q^\alpha}
+	\right) @f$
+*/
+ddIR3 metric_covariant::christoffel_first_kind(const IR3& r) const {
+	dSM3 dg = del(r);
+	return {
+		0.5 * (dg[dSM3::uuu] + dg[dSM3::uuu] - dg[dSM3::uuu]), // uuu
+		0.5 * (dg[dSM3::uuv] + dg[dSM3::uvu] - dg[dSM3::uvu]), // uuv
+		0.5 * (dg[dSM3::uuw] + dg[dSM3::uwu] - dg[dSM3::uwu]), // uuw
+		0.5 * (dg[dSM3::uvv] + dg[dSM3::uvv] - dg[dSM3::vvu]), // uvv
+		0.5 * (dg[dSM3::uvw] + dg[dSM3::uwv] - dg[dSM3::vwu]), // uvw
+		0.5 * (dg[dSM3::uww] + dg[dSM3::uww] - dg[dSM3::wwu]), // uww
+		0.5 * (dg[dSM3::uvu] + dg[dSM3::uvu] - dg[dSM3::uuv]), // vuu
+		0.5 * (dg[dSM3::uvv] + dg[dSM3::vvu] - dg[dSM3::uvv]), // vuv
+		0.5 * (dg[dSM3::uvw] + dg[dSM3::vwu] - dg[dSM3::uwv]), // vuw
+		0.5 * (dg[dSM3::vvv] + dg[dSM3::vvv] - dg[dSM3::vvv]), // vvv
+		0.5 * (dg[dSM3::vvw] + dg[dSM3::vwv] - dg[dSM3::vwv]), // vvw
+		0.5 * (dg[dSM3::vww] + dg[dSM3::vww] - dg[dSM3::wwv]), // vww
+    	0.5 * (dg[dSM3::uwu] + dg[dSM3::uwu] - dg[dSM3::uuw]), // wuu
+		0.5 * (dg[dSM3::uwv] + dg[dSM3::vwu] - dg[dSM3::uvw]), // wuv
+		0.5 * (dg[dSM3::uww] + dg[dSM3::wwu] - dg[dSM3::uww]), // wuw
+		0.5 * (dg[dSM3::vwv] + dg[dSM3::vwv] - dg[dSM3::vvw]), // wvv
+		0.5 * (dg[dSM3::vww] + dg[dSM3::wwv] - dg[dSM3::vww]), // wvw
+		0.5 * (dg[dSM3::www] + dg[dSM3::www] - dg[dSM3::www])  // www
+	};
+}
+
+//! Implementation of Christoffel symbols of the second kind @f$ \Gamma^\alpha_{\beta\gamma} @f$
+/*!
+    Implements the rule
+    @f$ \Gamma^\alpha_{\beta\gamma} = g^{\alpha\mu} \, \Gamma_{\mu\beta\gamma} @f$
+*/
+ddIR3 metric_covariant::christoffel_second_kind(const IR3& r) const {
+	SM3 ig = inverse(r);
+	ddIR3 CF1 = christoffel_first_kind(r);
+	return contraction<second, first>(ig, CF1);
+}
+
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_covariant.cc
+++ b/gyronimo/metrics/metric_covariant.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/metric_covariant.hh
+++ b/gyronimo/metrics/metric_covariant.hh
@@ -20,6 +20,7 @@
 #ifndef GYRONIMO_METRIC_COVARIANT
 #define GYRONIMO_METRIC_COVARIANT
 
+#include <gyronimo/core/contraction.hh>
 #include <gyronimo/core/IR3algebra.hh>
 #include <gyronimo/core/SM3algebra.hh>
 
@@ -53,6 +54,9 @@ class metric_covariant {
   virtual IR3 to_contravariant(const IR3& B, const IR3& r) const;
   virtual SM3 inverse(const IR3& r) const;
   virtual dSM3 del_inverse(const IR3& r) const;
+  
+  virtual ddIR3 christoffel_first_kind(const IR3& r) const;
+  virtual ddIR3 christoffel_second_kind(const IR3& r) const;
 };
 
 }

--- a/gyronimo/metrics/metric_covariant.hh
+++ b/gyronimo/metrics/metric_covariant.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/metric_covariant.hh
+++ b/gyronimo/metrics/metric_covariant.hh
@@ -20,7 +20,6 @@
 #ifndef GYRONIMO_METRIC_COVARIANT
 #define GYRONIMO_METRIC_COVARIANT
 
-#include <gyronimo/core/contraction.hh>
 #include <gyronimo/core/IR3algebra.hh>
 #include <gyronimo/core/SM3algebra.hh>
 

--- a/gyronimo/metrics/metric_covariant.hh
+++ b/gyronimo/metrics/metric_covariant.hh
@@ -53,7 +53,6 @@ class metric_covariant {
   virtual IR3 to_contravariant(const IR3& B, const IR3& r) const;
   virtual SM3 inverse(const IR3& r) const;
   virtual dSM3 del_inverse(const IR3& r) const;
-  
   virtual ddIR3 christoffel_first_kind(const IR3& r) const;
   virtual ddIR3 christoffel_second_kind(const IR3& r) const;
 };

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -22,6 +22,13 @@
 
 namespace gyronimo {
 
+metric_cylindrical::metric_cylindrical(const morphism_cylindrical *morph) 
+		: metric_nexus(morph),
+		L0_(morph->L0()), L0_2_(L0_*L0_), 
+		iL0_2_(1/L0_2_), L0_3_(L0_*L0_*L0_) {
+	
+}
+
 SM3 metric_cylindrical::operator()(const IR3& q) const {
 	return {L0_2_, 0.0, 0.0, L0_2_*q[IR3::u]*q[IR3::u], 0.0, L0_2_};
 }
@@ -49,6 +56,22 @@ IR3 metric_cylindrical::to_covariant(const IR3& B, const IR3& q) const {
 
 IR3 metric_cylindrical::to_contravariant(const IR3& B, const IR3& q) const {
 	return {iL0_2_*B[IR3::u], iL0_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iL0_2_*B[IR3::w]};
+}
+
+ddIR3 metric_cylindrical::christoffel_first_kind(const IR3& q) const {
+	return {
+		0, 0, 0, -L0_2_*q[IR3::u], 0, 0,
+		0,  L0_2_*q[IR3::u], 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0
+	};
+}
+
+ddIR3 metric_cylindrical::christoffel_second_kind(const IR3& q) const {
+	return {
+		0, 0, 0,  -q[IR3::u], 0, 0,
+		0, 1/q[IR3::u], 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0
+	};
 }
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -23,7 +23,7 @@
 namespace gyronimo {
 
 metric_cylindrical::metric_cylindrical(const morphism_cylindrical *morph) 
-		: metric_nexus(morph),
+		: metric_connected(morph),
 		Lref_(morph->Lref()), Lref_2_(Lref_*Lref_), 
 		iLref_2_(1/Lref_2_), Lref_3_(Lref_*Lref_*Lref_) {
 	

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -17,89 +17,47 @@
 
 // @metric_cylindrical.cc, this file is part of ::gyronimo::
 
-#include <cmath>
 #include <gyronimo/metrics/metric_cylindrical.hh>
+
+#include <cmath>
 
 namespace gyronimo {
 
-metric_cylindrical::metric_cylindrical(const morphism_cylindrical *morph) 
-		: metric_connected(morph),
-		Lref_(morph->Lref()), Lref_2_(Lref_*Lref_), 
-		iLref_2_(1/Lref_2_), Lref_3_(Lref_*Lref_*Lref_) {
-	
-}
-
-//! General-purpose implementation of the covariant metric.
-/*!
-	Implements the covariant metric in cylindrical coordinates: 
-	@f$ g_{\alpha\beta} = \left(\begin{matrix}
-		L_{ref}^2 && 0 && 0 \\
-		0 && L_{ref}^2 \, R^2 && 0 \\
-		0 && 0 && L_{ref}^2
-	\end{matrix}\right) @f$
-*/
+metric_cylindrical::metric_cylindrical(const morphism_cylindrical* morph)
+    : metric_connected(morph), Lref_(morph->Lref()), Lref_2_(Lref_ * Lref_),
+      iLref_2_(1 / Lref_2_), Lref_3_(Lref_ * Lref_ * Lref_) {}
 SM3 metric_cylindrical::operator()(const IR3& q) const {
-	return {Lref_2_, 0.0, 0.0, Lref_2_*q[IR3::u]*q[IR3::u], 0.0, Lref_2_};
+  return {Lref_2_, 0.0, 0.0, Lref_2_ * q[IR3::u] * q[IR3::u], 0.0, Lref_2_};
 }
-
-//! General-purpose implementation of the inverse (i.e., contravariant metric).
-/*!
-	Implements the contravariant metric in cylindrical coordinates: 
-	@f$ g^{\alpha\beta} = \left(\begin{matrix}
-		\frac{1}{L_{ref}^2} && 0 && 0 \\
-		0 && \frac{1}{L_{ref}^2 \, R^2} && 0 \\
-		0 && 0 && \frac{1}{L_{ref}^2}
-	\end{matrix}\right) @f$
-*/
 SM3 metric_cylindrical::inverse(const IR3& q) const {
-	return {iLref_2_, 0.0, 0.0, iLref_2_/(q[IR3::u]*q[IR3::u]), 0.0, iLref_2_};
+  return {
+      iLref_2_, 0.0, 0.0, iLref_2_ / (q[IR3::u] * q[IR3::u]), 0.0, iLref_2_};
 }
-
 dSM3 metric_cylindrical::del(const IR3& q) const {
-	return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 2*q[IR3::u]*Lref_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      2 * q[IR3::u] * Lref_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian in cylindrical coordinates: 
-	@f$ J = L_{ref}^3 \, R @f$
-*/
 double metric_cylindrical::jacobian(const IR3& q) const {
-	return Lref_3_*q[IR3::u];
+  return Lref_3_ * q[IR3::u];
 }
-
-//! General-purpose implementation of the Jacobian gradient in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian gradient in cylindrical coordinates: 
-	@f$ \nabla J = \left( L_{ref}^2\,\cos\phi, L_{ref}^2\,\sin\phi, 0 \right) @f$
-*/
 IR3 metric_cylindrical::del_jacobian(const IR3& q) const {
-	return {Lref_3_, 0.0, 0.0};
+  return {Lref_3_, 0.0, 0.0};
 }
-
 IR3 metric_cylindrical::to_covariant(const IR3& B, const IR3& q) const {
-	return {Lref_2_*B[IR3::u], Lref_2_*B[IR3::v]*q[IR3::u]*q[IR3::u], Lref_2_*B[IR3::w]};
+  return {Lref_2_ * B[IR3::u],
+      Lref_2_ * B[IR3::v] * q[IR3::u] * q[IR3::u], Lref_2_ * B[IR3::w]};
 }
-
 IR3 metric_cylindrical::to_contravariant(const IR3& B, const IR3& q) const {
-	return {iLref_2_*B[IR3::u], iLref_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iLref_2_*B[IR3::w]};
+  return {iLref_2_ * B[IR3::u],
+      iLref_2_ * B[IR3::v] / (q[IR3::u] * q[IR3::u]), iLref_2_ * B[IR3::w]};
 }
-
 ddIR3 metric_cylindrical::christoffel_first_kind(const IR3& q) const {
-	return {
-		0, 0, 0, -Lref_2_*q[IR3::u], 0, 0,
-		0,  Lref_2_*q[IR3::u], 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0
-	};
+  return {0, 0, 0, -Lref_2_ * q[IR3::u], 0, 0, 0,
+      Lref_2_ * q[IR3::u], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 }
-
 ddIR3 metric_cylindrical::christoffel_second_kind(const IR3& q) const {
-	return {
-		0, 0, 0,  -q[IR3::u], 0, 0,
-		0, 1/q[IR3::u], 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0
-	};
+  return {0, 0, 0, -q[IR3::u], 0, 0, 0,
+      1 / q[IR3::u], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 }
 
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -24,44 +24,44 @@ namespace gyronimo {
 
 metric_cylindrical::metric_cylindrical(const morphism_cylindrical *morph) 
 		: metric_nexus(morph),
-		L0_(morph->L0()), L0_2_(L0_*L0_), 
-		iL0_2_(1/L0_2_), L0_3_(L0_*L0_*L0_) {
+		Lref_(morph->Lref()), Lref_2_(Lref_*Lref_), 
+		iLref_2_(1/Lref_2_), Lref_3_(Lref_*Lref_*Lref_) {
 	
 }
 
 SM3 metric_cylindrical::operator()(const IR3& q) const {
-	return {L0_2_, 0.0, 0.0, L0_2_*q[IR3::u]*q[IR3::u], 0.0, L0_2_};
+	return {Lref_2_, 0.0, 0.0, Lref_2_*q[IR3::u]*q[IR3::u], 0.0, Lref_2_};
 }
 
 SM3 metric_cylindrical::inverse(const IR3& q) const {
-	return {iL0_2_, 0.0, 0.0, iL0_2_/(q[IR3::u]*q[IR3::u]), 0.0, iL0_2_};
+	return {iLref_2_, 0.0, 0.0, iLref_2_/(q[IR3::u]*q[IR3::u]), 0.0, iLref_2_};
 }
 
 dSM3 metric_cylindrical::del(const IR3& q) const {
 	return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 2*q[IR3::u]*L0_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+		0.0, 2*q[IR3::u]*Lref_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
 
 double metric_cylindrical::jacobian(const IR3& q) const {
-	return L0_3_*q[IR3::u];
+	return Lref_3_*q[IR3::u];
 }
 
 IR3 metric_cylindrical::del_jacobian(const IR3& q) const {
-	return {L0_2_*std::cos(q[IR3::v]), L0_2_*std::sin(q[IR3::v]), 0.0};
+	return {Lref_2_*std::cos(q[IR3::v]), Lref_2_*std::sin(q[IR3::v]), 0.0};
 }
 
 IR3 metric_cylindrical::to_covariant(const IR3& B, const IR3& q) const {
-	return {L0_2_*B[IR3::u], L0_2_*B[IR3::v]*q[IR3::u]*q[IR3::u], L0_2_*B[IR3::w]};
+	return {Lref_2_*B[IR3::u], Lref_2_*B[IR3::v]*q[IR3::u]*q[IR3::u], Lref_2_*B[IR3::w]};
 }
 
 IR3 metric_cylindrical::to_contravariant(const IR3& B, const IR3& q) const {
-	return {iL0_2_*B[IR3::u], iL0_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iL0_2_*B[IR3::w]};
+	return {iLref_2_*B[IR3::u], iLref_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iLref_2_*B[IR3::w]};
 }
 
 ddIR3 metric_cylindrical::christoffel_first_kind(const IR3& q) const {
 	return {
-		0, 0, 0, -L0_2_*q[IR3::u], 0, 0,
-		0,  L0_2_*q[IR3::u], 0, 0, 0, 0,
+		0, 0, 0, -Lref_2_*q[IR3::u], 0, 0,
+		0,  Lref_2_*q[IR3::u], 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 0
 	};
 }

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -1,0 +1,54 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @metric_cylindrical.cc, this file is part of ::gyronimo::
+
+#include <cmath>
+#include <gyronimo/metrics/metric_cylindrical.hh>
+
+namespace gyronimo {
+
+SM3 metric_cylindrical::operator()(const IR3& q) const {
+	return {L0_2_, 0.0, 0.0, L0_2_*q[IR3::u]*q[IR3::u], 0.0, L0_2_};
+}
+
+SM3 metric_cylindrical::inverse(const IR3& q) const {
+	return {iL0_2_, 0.0, 0.0, iL0_2_/(q[IR3::u]*q[IR3::u]), 0.0, iL0_2_};
+}
+
+dSM3 metric_cylindrical::del(const IR3& q) const {
+	return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 2*q[IR3::u]*L0_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+}
+
+double metric_cylindrical::jacobian(const IR3& q) const {
+	return L0_3_*q[IR3::u];
+}
+
+IR3 metric_cylindrical::del_jacobian(const IR3& q) const {
+	return {L0_2_*std::cos(q[IR3::v]), L0_2_*std::sin(q[IR3::v]), 0.0};
+}
+
+IR3 metric_cylindrical::to_covariant(const IR3& B, const IR3& q) const {
+	return {L0_2_*B[IR3::u], L0_2_*B[IR3::v]*q[IR3::u]*q[IR3::u], L0_2_*B[IR3::w]};
+}
+
+IR3 metric_cylindrical::to_contravariant(const IR3& B, const IR3& q) const {
+	return {iL0_2_*B[IR3::u], iL0_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iL0_2_*B[IR3::w]};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -29,10 +29,28 @@ metric_cylindrical::metric_cylindrical(const morphism_cylindrical *morph)
 	
 }
 
+//! General-purpose implementation of the covariant metric.
+/*!
+	Implements the covariant metric in cylindrical coordinates: 
+	@f$ g_{\alpha\beta} = \left(\begin{matrix}
+		L_{ref}^2 && 0 && 0 \\
+		0 && L_{ref}^2 \, R^2 && 0 \\
+		0 && 0 && L_{ref}^2
+	\end{matrix}\right) @f$
+*/
 SM3 metric_cylindrical::operator()(const IR3& q) const {
 	return {Lref_2_, 0.0, 0.0, Lref_2_*q[IR3::u]*q[IR3::u], 0.0, Lref_2_};
 }
 
+//! General-purpose implementation of the inverse (i.e., contravariant metric).
+/*!
+	Implements the contravariant metric in cylindrical coordinates: 
+	@f$ g^{\alpha\beta} = \left(\begin{matrix}
+		\frac{1}{L_{ref}^2} && 0 && 0 \\
+		0 && \frac{1}{L_{ref}^2 \, R^2} && 0 \\
+		0 && 0 && \frac{1}{L_{ref}^2}
+	\end{matrix}\right) @f$
+*/
 SM3 metric_cylindrical::inverse(const IR3& q) const {
 	return {iLref_2_, 0.0, 0.0, iLref_2_/(q[IR3::u]*q[IR3::u]), 0.0, iLref_2_};
 }
@@ -42,10 +60,20 @@ dSM3 metric_cylindrical::del(const IR3& q) const {
 		0.0, 2*q[IR3::u]*Lref_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
 
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian in cylindrical coordinates: 
+	@f$ J = L_{ref}^3 \, R @f$
+*/
 double metric_cylindrical::jacobian(const IR3& q) const {
 	return Lref_3_*q[IR3::u];
 }
 
+//! General-purpose implementation of the Jacobian gradient in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian gradient in cylindrical coordinates: 
+	@f$ \nabla J = \left( L_{ref}^2\,\cos\phi, L_{ref}^2\,\sin\phi, 0 \right) @f$
+*/
 IR3 metric_cylindrical::del_jacobian(const IR3& q) const {
 	return {Lref_2_*std::cos(q[IR3::v]), Lref_2_*std::sin(q[IR3::v]), 0.0};
 }

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -23,32 +23,32 @@
 namespace gyronimo {
 
 SM3 metric_cylindrical::operator()(const IR3& q) const {
-	return {L0_2_, 0.0, 0.0, L0_2_*q[IR3::u]*q[IR3::u], 0.0, L0_2_};
+	return {Lref_2_, 0.0, 0.0, Lref_2_*q[IR3::u]*q[IR3::u], 0.0, Lref_2_};
 }
 
 SM3 metric_cylindrical::inverse(const IR3& q) const {
-	return {iL0_2_, 0.0, 0.0, iL0_2_/(q[IR3::u]*q[IR3::u]), 0.0, iL0_2_};
+	return {iLref_2_, 0.0, 0.0, iLref_2_/(q[IR3::u]*q[IR3::u]), 0.0, iLref_2_};
 }
 
 dSM3 metric_cylindrical::del(const IR3& q) const {
 	return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 2*q[IR3::u]*L0_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+		0.0, 2*q[IR3::u]*Lref_2_, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
 
 double metric_cylindrical::jacobian(const IR3& q) const {
-	return L0_3_*q[IR3::u];
+	return Lref_3_*q[IR3::u];
 }
 
 IR3 metric_cylindrical::del_jacobian(const IR3& q) const {
-	return {L0_2_*std::cos(q[IR3::v]), L0_2_*std::sin(q[IR3::v]), 0.0};
+	return {Lref_2_*std::cos(q[IR3::v]), Lref_2_*std::sin(q[IR3::v]), 0.0};
 }
 
 IR3 metric_cylindrical::to_covariant(const IR3& B, const IR3& q) const {
-	return {L0_2_*B[IR3::u], L0_2_*B[IR3::v]*q[IR3::u]*q[IR3::u], L0_2_*B[IR3::w]};
+	return {Lref_2_*B[IR3::u], Lref_2_*B[IR3::v]*q[IR3::u]*q[IR3::u], Lref_2_*B[IR3::w]};
 }
 
 IR3 metric_cylindrical::to_contravariant(const IR3& B, const IR3& q) const {
-	return {iL0_2_*B[IR3::u], iL0_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iL0_2_*B[IR3::w]};
+	return {iLref_2_*B[IR3::u], iLref_2_*B[IR3::v]/(q[IR3::u]*q[IR3::u]), iLref_2_*B[IR3::w]};
 }
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -75,7 +75,7 @@ double metric_cylindrical::jacobian(const IR3& q) const {
 	@f$ \nabla J = \left( L_{ref}^2\,\cos\phi, L_{ref}^2\,\sin\phi, 0 \right) @f$
 */
 IR3 metric_cylindrical::del_jacobian(const IR3& q) const {
-	return {Lref_2_*std::cos(q[IR3::v]), Lref_2_*std::sin(q[IR3::v]), 0.0};
+	return {Lref_3_, 0.0, 0.0};
 }
 
 IR3 metric_cylindrical::to_covariant(const IR3& B, const IR3& q) const {

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -20,13 +20,13 @@
 #ifndef GYRONIMO_METRIC_CYLINDRICAL
 #define GYRONIMO_METRIC_CYLINDRICAL
 
-#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/metric_connected.hh>
 #include <gyronimo/metrics/morphism_cylindrical.hh>
 
 namespace gyronimo {
 
 //! Trivial covariant metric for cylindrical space.
-class metric_cylindrical : public metric_nexus {
+class metric_cylindrical : public metric_connected {
 public:
 	metric_cylindrical(const morphism_cylindrical *morph);
 	virtual ~metric_cylindrical() override {};

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -27,8 +27,8 @@ namespace gyronimo {
 //! Trivial covariant metric for cylindrical space.
 class metric_cylindrical : public metric_covariant {
 public:
-	metric_cylindrical(const double &L0) 
-		: L0_(L0), L0_2_(L0*L0), iL0_2_(1/L0_2_), L0_3_(L0*L0*L0){};
+	metric_cylindrical(const double &Lref) 
+		: Lref_(Lref), Lref_2_(Lref*Lref), iLref_2_(1/Lref_2_), Lref_3_(Lref*Lref*Lref){};
 	virtual ~metric_cylindrical() override {};
 
 	virtual SM3 operator()(const IR3& q) const override;
@@ -40,10 +40,10 @@ public:
 	virtual IR3 to_covariant(const IR3& B, const IR3& q) const override;
 	virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override;
 
-	double L0() {return L0_;};
+	double Lref() {return Lref_;};
 
 private:
-	const double L0_, L0_2_, iL0_2_, L0_3_;
+	const double Lref_, Lref_2_, iLref_2_, Lref_3_;
 
 }; // end class metric_cylindrical
 

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -27,33 +27,32 @@ namespace gyronimo {
 
 //! Trivial covariant metric for cylindrical space.
 class metric_cylindrical : public metric_connected {
-public:
-	metric_cylindrical(const morphism_cylindrical *morph);
-	virtual ~metric_cylindrical() override {};
+ public:
+  metric_cylindrical(const morphism_cylindrical* morph);
+  virtual ~metric_cylindrical() override {};
 
-	virtual SM3 operator()(const IR3& q) const override;
-	virtual SM3 inverse(const IR3& q) const override;
+  virtual SM3 operator()(const IR3& q) const override;
+  virtual SM3 inverse(const IR3& q) const override;
 
-	virtual dSM3 del(const IR3& q) const override;
-	virtual double jacobian(const IR3& q) const override;
-	virtual IR3 del_jacobian(const IR3& q) const override;
-	virtual IR3 to_covariant(const IR3& B, const IR3& q) const override;
-	virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override;
+  virtual dSM3 del(const IR3& q) const override;
+  virtual double jacobian(const IR3& q) const override;
+  virtual IR3 del_jacobian(const IR3& q) const override;
+  virtual IR3 to_covariant(const IR3& B, const IR3& q) const override;
+  virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override;
 
-	virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
-	virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
+  virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
+  virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
 
-	double Lref() {return Lref_;};
+  double Lref() { return Lref_; };
 
-	virtual const morphism_cylindrical* morph() const override {
-		return static_cast<const morphism_cylindrical*>(morph_);
-	};
+  virtual const morphism_cylindrical* my_morphism() const override {
+    return static_cast<const morphism_cylindrical*>(
+        metric_connected::my_morphism());
+  };
+ private:
+  const double Lref_, Lref_2_, iLref_2_, Lref_3_;
+};
 
-private:
-	const double Lref_, Lref_2_, iLref_2_, Lref_3_;
+}  // end namespace gyronimo.
 
-}; // end class metric_cylindrical
-
-} // end namespace gyronimo.
-
-#endif // GYRONIMO_METRIC_CARTESIAN
+#endif  // GYRONIMO_METRIC_CYLINDRICAL

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -43,10 +43,10 @@ public:
 	virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
 	virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
 
-	double L0() {return L0_;};
+	double Lref() {return Lref_;};
 
 private:
-	const double L0_, L0_2_, iL0_2_, L0_3_;
+	const double Lref_, Lref_2_, iLref_2_, Lref_3_;
 
 }; // end class metric_cylindrical
 

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -20,15 +20,15 @@
 #ifndef GYRONIMO_METRIC_CYLINDRICAL
 #define GYRONIMO_METRIC_CYLINDRICAL
 
-#include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/morphism_cylindrical.hh>
 
 namespace gyronimo {
 
 //! Trivial covariant metric for cylindrical space.
-class metric_cylindrical : public metric_covariant {
+class metric_cylindrical : public metric_nexus {
 public:
-	metric_cylindrical(const double &L0) 
-		: L0_(L0), L0_2_(L0*L0), iL0_2_(1/L0_2_), L0_3_(L0*L0*L0){};
+	metric_cylindrical(const morphism_cylindrical *morph);
 	virtual ~metric_cylindrical() override {};
 
 	virtual SM3 operator()(const IR3& q) const override;
@@ -39,6 +39,9 @@ public:
 	virtual IR3 del_jacobian(const IR3& q) const override;
 	virtual IR3 to_covariant(const IR3& B, const IR3& q) const override;
 	virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override;
+
+	virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
+	virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
 
 	double L0() {return L0_;};
 

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -1,3 +1,21 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @metric_cylindrical.hh, this file is part of ::gyronimo::
 
 #ifndef GYRONIMO_METRIC_CYLINDRICAL
 #define GYRONIMO_METRIC_CYLINDRICAL
@@ -8,29 +26,25 @@ namespace gyronimo {
 
 //! Trivial covariant metric for cylindrical space.
 class metric_cylindrical : public metric_covariant {
- public:
-  metric_cylindrical() {};
-  virtual ~metric_cylindrical() override {};
+public:
+	metric_cylindrical(const double &L0) 
+		: L0_(L0), L0_2_(L0*L0), iL0_2_(1/L0_2_), L0_3_(L0*L0*L0){};
+	virtual ~metric_cylindrical() override {};
 
-  virtual SM3 operator()(const IR3& q) const override {
-    return {1.0, 0.0, 0.0, q[IR3::u]*q[IR3::u], 0.0, 1.0};
-  };
-  virtual dSM3 del(const IR3& q) const override {
-    return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-        0.0, 2*q[IR3::u], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  };
-  virtual double jacobian(const IR3& q) const override {
-    return q[IR3::u];
-  };
-  virtual IR3 del_jacobian(const IR3& q) const override {
-    return {std::cos(q[IR3::v]), std::sin(q[IR3::v]), 0.0};
-  };
-  virtual IR3 to_covariant(const IR3& B, const IR3& q) const override {
-    return {B[IR3::u], B[IR3::v]*q[IR3::u]*q[IR3::u], B[IR3::w]};
-  };
-  virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override {
-    return {B[IR3::u], B[IR3::v]/(q[IR3::u]*q[IR3::u]), B[IR3::w]};
-  };
+	virtual SM3 operator()(const IR3& q) const override;
+	virtual SM3 inverse(const IR3& q) const override;
+
+	virtual dSM3 del(const IR3& q) const override;
+	virtual double jacobian(const IR3& q) const override;
+	virtual IR3 del_jacobian(const IR3& q) const override;
+	virtual IR3 to_covariant(const IR3& B, const IR3& q) const override;
+	virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override;
+
+	double L0() {return L0_;};
+
+private:
+	const double L0_, L0_2_, iL0_2_, L0_3_;
+
 }; // end class metric_cylindrical
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -46,7 +46,7 @@ public:
 	double Lref() {return Lref_;};
 
 	virtual const morphism_cylindrical* morph() const override {
-		return static_cast<const morphism_cylindrical*>(this->metric_connected::morph());
+		return static_cast<const morphism_cylindrical*>(morph_);
 	};
 
 private:

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -1,0 +1,38 @@
+
+#ifndef GYRONIMO_METRIC_CYLINDRICAL
+#define GYRONIMO_METRIC_CYLINDRICAL
+
+#include <gyronimo/metrics/metric_covariant.hh>
+
+namespace gyronimo {
+
+//! Trivial covariant metric for cylindrical space.
+class metric_cylindrical : public metric_covariant {
+ public:
+  metric_cylindrical() {};
+  virtual ~metric_cylindrical() override {};
+
+  virtual SM3 operator()(const IR3& q) const override {
+    return {1.0, 0.0, 0.0, q[IR3::u]*q[IR3::u], 0.0, 1.0};
+  };
+  virtual dSM3 del(const IR3& q) const override {
+    return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 2*q[IR3::u], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  };
+  virtual double jacobian(const IR3& q) const override {
+    return q[IR3::u];
+  };
+  virtual IR3 del_jacobian(const IR3& q) const override {
+    return {std::cos(q[IR3::v]), std::sin(q[IR3::v]), 0.0};
+  };
+  virtual IR3 to_covariant(const IR3& B, const IR3& q) const override {
+    return {B[IR3::u], B[IR3::v]*q[IR3::u]*q[IR3::u], B[IR3::w]};
+  };
+  virtual IR3 to_contravariant(const IR3& B, const IR3& q) const override {
+    return {B[IR3::u], B[IR3::v]/(q[IR3::u]*q[IR3::u]), B[IR3::w]};
+  };
+}; // end class metric_cylindrical
+
+} // end namespace gyronimo.
+
+#endif // GYRONIMO_METRIC_CARTESIAN

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -45,6 +45,10 @@ public:
 
 	double Lref() {return Lref_;};
 
+	virtual const morphism_cylindrical* morph() const override {
+		return static_cast<const morphism_cylindrical*>(this->metric_connected::morph());
+	};
+
 private:
 	const double Lref_, Lref_2_, iLref_2_, Lref_3_;
 

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -47,14 +47,14 @@ metric_helena::~metric_helena() {
 }
 SM3 metric_helena::operator()(const IR3& position) const {
   double s = position[IR3::u];
-  double chi = this->reduce_chi(position[IR3::v]);
+  double chi = parser_->reduce_chi(position[IR3::v]);
   return {
       squaredR0_*(*guu_)(s, chi), squaredR0_*(*guv_)(s, chi), 0.0,
       squaredR0_*(*gvv_)(s, chi), 0.0, squaredR0_*(*gww_)(s, chi)};
 }
 dSM3 metric_helena::del(const IR3& position) const {
   double s = position[IR3::u];
-  double chi = this->reduce_chi(position[IR3::v]);
+  double chi = parser_->reduce_chi(position[IR3::v]);
   return {
       squaredR0_*(*guu_).partial_u(s, chi),
       squaredR0_*(*guu_).partial_v(s, chi), 0.0, // d_i g_uu
@@ -66,14 +66,6 @@ dSM3 metric_helena::del(const IR3& position) const {
       0.0, 0.0, 0.0, // d_i g_vw
       squaredR0_*(*gww_).partial_u(s, chi),
       squaredR0_*(*gww_).partial_v(s, chi), 0.0}; // d_i g_ww
-}
-
-//! Reduces an arbitrary angle chi to the interval [0:pi].
-double metric_helena::reduce_chi(double chi) const {
-  chi -= 2*std::numbers::pi*std::floor(chi/(2*std::numbers::pi));
-  if(parser_->is_symmetric() && chi > std::numbers::pi)
-      chi = 2*std::numbers::pi - chi;
-  return chi;
 }
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -23,20 +23,19 @@
 
 namespace gyronimo{
 
-metric_helena::metric_helena(const morphism_helena *morph)
-    : metric_connected(morph),
-	  parser_(morph->parser()), ifactory_(morph->ifactory()), 
-	  R0_(parser_->rmag()), 
-	  squaredR0_(parser_->rmag()*parser_->rmag()),
+metric_helena::metric_helena(const morphism_helena *morph, const interpolator2d_factory *ifactory)
+    : metric_connected(morph), parser_(morph->parser()), 
+      R0_(parser_->rmag()), 
+      squaredR0_(parser_->rmag()*parser_->rmag()),
       guu_(nullptr), guv_(nullptr), gvv_(nullptr), gww_(nullptr) {
   dblock_adapter s_range(parser_->s()), chi_range(parser_->chi());
-  guu_ = ifactory_->interpolate_data(
+  guu_ = ifactory->interpolate_data(
       s_range, chi_range, dblock_adapter(parser_->covariant_g11()));
-  guv_ = ifactory_->interpolate_data(
+  guv_ = ifactory->interpolate_data(
       s_range, chi_range, dblock_adapter(parser_->covariant_g12()));
-  gvv_ = ifactory_->interpolate_data(
+  gvv_ = ifactory->interpolate_data(
       s_range, chi_range, dblock_adapter(parser_->covariant_g22()));
-  gww_ = ifactory_->interpolate_data(
+  gww_ = ifactory->interpolate_data(
       s_range, chi_range, dblock_adapter(parser_->covariant_g33()));
 }
 metric_helena::~metric_helena() {

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -24,7 +24,7 @@
 namespace gyronimo{
 
 metric_helena::metric_helena(const morphism_helena *morph)
-    : metric_nexus(morph),
+    : metric_connected(morph),
 	  parser_(morph->parser()), ifactory_(morph->ifactory()), 
 	  R0_(parser_->rmag()), 
 	  squaredR0_(parser_->rmag()*parser_->rmag()),

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -67,5 +67,11 @@ dSM3 metric_helena::del(const IR3& position) const {
       squaredR0_*(*gww_).partial_u(s, chi),
       squaredR0_*(*gww_).partial_v(s, chi), 0.0}; // d_i g_ww
 }
+ddIR3 metric_helena::christoffel_first_kind(const IR3& r) const {
+	return this->gyronimo::metric_covariant::christoffel_first_kind(r);
+}
+ddIR3 metric_helena::christoffel_second_kind(const IR3& r) const {
+	return this->gyronimo::metric_covariant::christoffel_second_kind(r);
+}
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -17,17 +17,18 @@
 
 // @metric_helena.cc, this file is part of ::gyronimo::
 
-#include <numbers>
 #include <gyronimo/core/transpose.hh>
 #include <gyronimo/metrics/metric_helena.hh>
 
-namespace gyronimo{
+#include <numbers>
 
-metric_helena::metric_helena(const morphism_helena *morph, const interpolator2d_factory *ifactory)
-    : metric_connected(morph), parser_(morph->parser()), 
-      R0_(parser_->rmag()), 
-      squaredR0_(parser_->rmag()*parser_->rmag()),
-      guu_(nullptr), guv_(nullptr), gvv_(nullptr), gww_(nullptr) {
+namespace gyronimo {
+
+metric_helena::metric_helena(
+    const morphism_helena* morph, const interpolator2d_factory* ifactory)
+    : metric_connected(morph), parser_(morph->parser()), R0_(parser_->rmag()),
+      squaredR0_(parser_->rmag() * parser_->rmag()), guu_(nullptr),
+      guv_(nullptr), gvv_(nullptr), gww_(nullptr) {
   dblock_adapter s_range(parser_->s()), chi_range(parser_->chi());
   guu_ = ifactory->interpolate_data(
       s_range, chi_range, dblock_adapter(parser_->covariant_g11()));
@@ -39,38 +40,38 @@ metric_helena::metric_helena(const morphism_helena *morph, const interpolator2d_
       s_range, chi_range, dblock_adapter(parser_->covariant_g33()));
 }
 metric_helena::~metric_helena() {
-  if(guu_) delete guu_;
-  if(guv_) delete guv_;
-  if(gvv_) delete gvv_;
-  if(gww_) delete gww_;
+  if (guu_) delete guu_;
+  if (guv_) delete guv_;
+  if (gvv_) delete gvv_;
+  if (gww_) delete gww_;
 }
 SM3 metric_helena::operator()(const IR3& position) const {
   double s = position[IR3::u];
   double chi = parser_->reduce_chi(position[IR3::v]);
   return {
-      squaredR0_*(*guu_)(s, chi), squaredR0_*(*guv_)(s, chi), 0.0,
-      squaredR0_*(*gvv_)(s, chi), 0.0, squaredR0_*(*gww_)(s, chi)};
+      squaredR0_ * (*guu_)(s, chi), squaredR0_ * (*guv_)(s, chi), 0.0,
+      squaredR0_ * (*gvv_)(s, chi), 0.0, squaredR0_ * (*gww_)(s, chi)};
 }
 dSM3 metric_helena::del(const IR3& position) const {
   double s = position[IR3::u];
   double chi = parser_->reduce_chi(position[IR3::v]);
   return {
-      squaredR0_*(*guu_).partial_u(s, chi),
-      squaredR0_*(*guu_).partial_v(s, chi), 0.0, // d_i g_uu
-      squaredR0_*(*guv_).partial_u(s, chi),
-      squaredR0_*(*guv_).partial_v(s, chi), 0.0, // d_i g_uv
-      0.0, 0.0, 0.0, // d_i g_uw
-      squaredR0_*(*gvv_).partial_u(s, chi),
-      squaredR0_*(*gvv_).partial_v(s, chi), 0.0, //d_i g_vv
-      0.0, 0.0, 0.0, // d_i g_vw
-      squaredR0_*(*gww_).partial_u(s, chi),
-      squaredR0_*(*gww_).partial_v(s, chi), 0.0}; // d_i g_ww
+      squaredR0_ * (*guu_).partial_u(s, chi),
+      squaredR0_ * (*guu_).partial_v(s, chi), 0.0,  // d_i g_uu
+      squaredR0_ * (*guv_).partial_u(s, chi),
+      squaredR0_ * (*guv_).partial_v(s, chi), 0.0,  // d_i g_uv
+      0.0, 0.0, 0.0,  // d_i g_uw
+      squaredR0_ * (*gvv_).partial_u(s, chi),
+      squaredR0_ * (*gvv_).partial_v(s, chi), 0.0,  // d_i g_vv
+      0.0, 0.0, 0.0,  // d_i g_vw
+      squaredR0_ * (*gww_).partial_u(s, chi),
+      squaredR0_ * (*gww_).partial_v(s, chi), 0.0};  // d_i g_ww
 }
 ddIR3 metric_helena::christoffel_first_kind(const IR3& r) const {
-	return this->gyronimo::metric_covariant::christoffel_first_kind(r);
+  return this->gyronimo::metric_covariant::christoffel_first_kind(r);
 }
 ddIR3 metric_helena::christoffel_second_kind(const IR3& r) const {
-	return this->gyronimo::metric_covariant::christoffel_second_kind(r);
+  return this->gyronimo::metric_covariant::christoffel_second_kind(r);
 }
 
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/metric_helena.cc
+++ b/gyronimo/metrics/metric_helena.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -23,19 +23,21 @@
 
 namespace gyronimo{
 
-metric_helena::metric_helena(
-    const parser_helena *p, const interpolator2d_factory *ifactory)
-    : parser_(p), R0_(p->rmag()), squaredR0_(p->rmag()*p->rmag()),
+metric_helena::metric_helena(const morphism_helena *morph)
+    : metric_nexus(morph),
+	  parser_(morph->parser()), ifactory_(morph->ifactory()), 
+	  R0_(parser_->rmag()), 
+	  squaredR0_(parser_->rmag()*parser_->rmag()),
       guu_(nullptr), guv_(nullptr), gvv_(nullptr), gww_(nullptr) {
-  dblock_adapter s_range(p->s()), chi_range(p->chi());
-  guu_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g11()));
-  guv_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g12()));
-  gvv_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g22()));
-  gww_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g33()));
+  dblock_adapter s_range(parser_->s()), chi_range(parser_->chi());
+  guu_ = ifactory_->interpolate_data(
+      s_range, chi_range, dblock_adapter(parser_->covariant_g11()));
+  guv_ = ifactory_->interpolate_data(
+      s_range, chi_range, dblock_adapter(parser_->covariant_g12()));
+  gvv_ = ifactory_->interpolate_data(
+      s_range, chi_range, dblock_adapter(parser_->covariant_g22()));
+  gww_ = ifactory_->interpolate_data(
+      s_range, chi_range, dblock_adapter(parser_->covariant_g33()));
 }
 metric_helena::~metric_helena() {
   if(guu_) delete guu_;

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -20,18 +20,18 @@
 #ifndef GYRONIMO_METRIC_HELENA
 #define GYRONIMO_METRIC_HELENA
 
+#include <gyronimo/interpolators/interpolator2d.hh>
 #include <gyronimo/metrics/metric_connected.hh>
 #include <gyronimo/metrics/morphism_helena.hh>
-#include <gyronimo/interpolators/interpolator2d.hh>
 
-namespace gyronimo{
+namespace gyronimo {
 
 //! Covariant metric in `HELENA` curvilinear coordinates.
 /*!
     Builds the metric from the information provided by a `parser_helena` object.
     The actual type of 2d interpolators to use is set by the specific
     `interpolator2d_factory` object pointer provided to the constructor.
-    
+
     The right-handed coordinates are the square root of the poloidal flux per
     radian normalised to its value at the boundary (`u`, or `HELENA`
     @f$s=\sqrt{\Psi/\Psi_b}@f$), an angle on the poloidal cross section (`v`, or
@@ -45,27 +45,24 @@ namespace gyronimo{
 */
 class metric_helena : public metric_connected {
  public:
-  metric_helena(const morphism_helena *morph, const interpolator2d_factory *ifactory);
+  metric_helena(
+      const morphism_helena* morph, const interpolator2d_factory* ifactory);
   virtual ~metric_helena() override;
-
   virtual SM3 operator()(const IR3& position) const override;
   virtual dSM3 del(const IR3& position) const override;
-
-  virtual ddIR3 christoffel_first_kind (const IR3& r) const override;
+  virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
 
-  const parser_helena* parser() const {return parser_;};
-
-  virtual const morphism_helena* morph() const override {
-    return static_cast<const morphism_helena*>(morph_);
+  const parser_helena* parser() const { return parser_; };
+  virtual const morphism_helena* my_morphism() const override {
+    return static_cast<const morphism_helena*>(metric_connected::my_morphism());
   };
-
  private:
   const parser_helena* parser_;
   interpolator2d *guu_, *guv_, *gvv_, *gww_;
   double R0_, squaredR0_;
 };
 
-} // end namespace gyronimo
+}  // end namespace gyronimo
 
-#endif // GYRONIMO_METRIC_HELENA
+#endif  // GYRONIMO_METRIC_HELENA

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -56,6 +56,10 @@ class metric_helena : public metric_connected {
 
   const parser_helena* parser() const {return parser_;};
 
+  virtual const morphism_helena* morph() const override {
+    return static_cast<const morphism_helena*>(this->metric_connected::morph());
+  };
+
  private:
   const parser_helena* parser_;
   const interpolator2d_factory *ifactory_;

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,8 +20,8 @@
 #ifndef GYRONIMO_METRIC_HELENA
 #define GYRONIMO_METRIC_HELENA
 
-#include <gyronimo/parsers/parser_helena.hh>
-#include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/morphism_helena.hh>
 #include <gyronimo/interpolators/interpolator2d.hh>
 
 namespace gyronimo{
@@ -43,10 +43,9 @@ namespace gyronimo{
     @todo override to_contravariant to use the contravariant metric (it is
     available, right?) instead of the more costly default inversion.
 */
-class metric_helena : public metric_covariant {
+class metric_helena : public metric_nexus {
  public:
-  metric_helena(
-      const parser_helena *parser, const interpolator2d_factory *ifactory);
+  metric_helena(const morphism_helena *morph);
   virtual ~metric_helena() override;
 
   virtual SM3 operator()(const IR3& position) const override;
@@ -57,6 +56,7 @@ class metric_helena : public metric_covariant {
 
  private:
   const parser_helena* parser_;
+  const interpolator2d_factory *ifactory_;
   interpolator2d *guu_, *guv_, *gvv_, *gww_;
   double R0_, squaredR0_;
 };

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -51,6 +51,9 @@ class metric_helena : public metric_connected {
   virtual SM3 operator()(const IR3& position) const override;
   virtual dSM3 del(const IR3& position) const override;
 
+  virtual ddIR3 christoffel_first_kind (const IR3& r) const override;
+  virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
+
   const parser_helena* parser() const {return parser_;};
 
  private:

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
+// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -45,7 +45,7 @@ namespace gyronimo{
 */
 class metric_helena : public metric_connected {
  public:
-  metric_helena(const morphism_helena *morph);
+  metric_helena(const morphism_helena *morph, const interpolator2d_factory *ifactory);
   virtual ~metric_helena() override;
 
   virtual SM3 operator()(const IR3& position) const override;
@@ -62,7 +62,6 @@ class metric_helena : public metric_connected {
 
  private:
   const parser_helena* parser_;
-  const interpolator2d_factory *ifactory_;
   interpolator2d *guu_, *guv_, *gvv_, *gww_;
   double R0_, squaredR0_;
 };

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -52,7 +52,6 @@ class metric_helena : public metric_nexus {
   virtual dSM3 del(const IR3& position) const override;
 
   const parser_helena* parser() const {return parser_;};
-  double reduce_chi(double chi) const;
 
  private:
   const parser_helena* parser_;

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -57,7 +57,7 @@ class metric_helena : public metric_connected {
   const parser_helena* parser() const {return parser_;};
 
   virtual const morphism_helena* morph() const override {
-    return static_cast<const morphism_helena*>(this->metric_connected::morph());
+    return static_cast<const morphism_helena*>(morph_);
   };
 
  private:

--- a/gyronimo/metrics/metric_helena.hh
+++ b/gyronimo/metrics/metric_helena.hh
@@ -20,7 +20,7 @@
 #ifndef GYRONIMO_METRIC_HELENA
 #define GYRONIMO_METRIC_HELENA
 
-#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/metric_connected.hh>
 #include <gyronimo/metrics/morphism_helena.hh>
 #include <gyronimo/interpolators/interpolator2d.hh>
 
@@ -43,7 +43,7 @@ namespace gyronimo{
     @todo override to_contravariant to use the contravariant metric (it is
     available, right?) instead of the more costly default inversion.
 */
-class metric_helena : public metric_nexus {
+class metric_helena : public metric_connected {
  public:
   metric_helena(const morphism_helena *morph);
   virtual ~metric_helena() override;

--- a/gyronimo/metrics/metric_nexus.cc
+++ b/gyronimo/metrics/metric_nexus.cc
@@ -1,0 +1,121 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2021 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @metric_nexus.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/metrics/metric_nexus.hh>
+
+namespace gyronimo {
+
+metric_nexus::metric_nexus(const morphism *morph) 
+		: morph_(morph) {
+	
+	if(morph_ == nullptr)
+		error(__func__, __FILE__, __LINE__, " morphism is nullptr.", 1);
+}
+
+//! General-purpose implementation of the local metric matrix `SM3`.
+/*!
+	Implemented the rule
+	@f$ g_{\alpha\beta} = \textbf{e}_\alpha \cdot \textbf{e}_\beta @f$
+*/
+SM3 metric_nexus::operator()(const IR3& r) const {
+	dIR3 e = morph_->del(r);
+	IR3 e1 = {e[dIR3::uu], e[dIR3::vu], e[dIR3::wu]};
+	IR3 e2 = {e[dIR3::uv], e[dIR3::vv], e[dIR3::wv]};
+	IR3 e3 = {e[dIR3::uw], e[dIR3::vw], e[dIR3::ww]};
+	SM3 g = {inner_product(e1, e1), inner_product(e1, e2), inner_product(e1, e3),
+			 inner_product(e2, e2), inner_product(e2, e3), inner_product(e3, e3)};
+	return g;
+}
+
+//! General implementation of `metric_nexus` derivatives
+/*!
+	Implemented the rule
+	@f$ \partial_\gamma \, g_{\alpha\beta} = \Gamma_{\alpha\beta\gamma} + \Gamma_{\beta\alpha\gamma} @f$
+*/
+dSM3 metric_nexus::del(const IR3& r) const {
+	ddIR3 CF = christoffel_first_kind(r);
+	return {
+		CF[ddIR3::uuu] + CF[ddIR3::uuu], // uuu
+		CF[ddIR3::uuv] + CF[ddIR3::uuv], // uuv
+		CF[ddIR3::uuw] + CF[ddIR3::uuw], // uuw
+		CF[ddIR3::uuv] + CF[ddIR3::vuu], // uvu
+		CF[ddIR3::uvv] + CF[ddIR3::vuv], // uvv
+		CF[ddIR3::uvw] + CF[ddIR3::vuw], // uvw
+    	CF[ddIR3::uuw] + CF[ddIR3::wuu], // uwu
+		CF[ddIR3::uvw] + CF[ddIR3::wuv], // uwv
+		CF[ddIR3::uww] + CF[ddIR3::wuw], // uww
+		CF[ddIR3::vuv] + CF[ddIR3::vuv], // vvu
+		CF[ddIR3::vvv] + CF[ddIR3::vvv], // vvv
+		CF[ddIR3::vvw] + CF[ddIR3::vvw], // vvw
+    	CF[ddIR3::vuw] + CF[ddIR3::wuv], // vwu
+		CF[ddIR3::vvw] + CF[ddIR3::wvv], // vwv
+		CF[ddIR3::vww] + CF[ddIR3::wvw], // vww
+		CF[ddIR3::wuw] + CF[ddIR3::wuw], // wwu
+		CF[ddIR3::wvw] + CF[ddIR3::wvw], // wwv
+		CF[ddIR3::www] + CF[ddIR3::www]  // www
+	};
+}
+
+//! General-purpose implementation of the Jacobian.
+double metric_nexus::jacobian(const IR3& r) const {
+	return morph_->jacobian(r);
+}
+
+//! General-purpose implementation of the Jacobian gradient.
+/*!
+    Implements the rule
+    @f$ \partial_\alpha J = J \left(
+		\Gamma^1_{\alpha 1} + \Gamma^2_{\alpha 2} + \Gamma^3_{\alpha 3}
+	\right) @f$
+*/
+IR3 metric_nexus::del_jacobian(const IR3& r) const {
+	double J = jacobian(r);
+	ddIR3 CF2 = christoffel_second_kind(r);
+	return {
+		J * (CF2[ddIR3::uuu] + CF2[ddIR3::vuv] + CF2[ddIR3::wuw]),
+		J * (CF2[ddIR3::uuv] + CF2[ddIR3::vvv] + CF2[ddIR3::wvw]),
+		J * (CF2[ddIR3::uuw] + CF2[ddIR3::vvw] + CF2[ddIR3::www])
+	};
+}
+
+//! Implementation of Christoffel symbols of the first kind @f$ \Gamma_{\alpha\beta\gamma} @f$
+/*!
+    Implements the rule
+    @f$ \Gamma_{\alpha\beta\gamma} = \textbf{e}_\alpha \cdot 
+	\frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma} @f$
+*/
+ddIR3 metric_nexus::christoffel_first_kind(const IR3& r) const {
+	dIR3 e = morph_->del(r);
+	ddIR3 ddR = morph_->del2(r);
+	return contraction<first, first>(e, ddR);
+}
+
+//! Implementation of Christoffel symbols of the second kind @f$ \Gamma^\alpha_{\beta\gamma} @f$
+/*!
+    Implements the rule
+    @f$ \Gamma^\alpha_{\beta\gamma} = \textbf{e}^\alpha \cdot 
+	\frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\gamma} @f$
+*/
+ddIR3 metric_nexus::christoffel_second_kind(const IR3& r) const {
+	dIR3 ee = morph_->del_inverse(r);
+	ddIR3 ddR = morph_->del2(r);
+	return contraction<second, first>(ee, ddR);
+}
+
+} // end namespace gyronimo.

--- a/gyronimo/metrics/metric_nexus.hh
+++ b/gyronimo/metrics/metric_nexus.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2022 Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/metric_nexus.hh
+++ b/gyronimo/metrics/metric_nexus.hh
@@ -1,0 +1,60 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2021 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @metric_nexus.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_METRIC_NEXUS
+#define GYRONIMO_METRIC_NEXUS
+
+#include <gyronimo/core/error.hh>
+#include <gyronimo/metrics/morphism.hh>
+#include <gyronimo/metrics/metric_covariant.hh>
+
+namespace gyronimo {
+
+// Naming options: 
+// metric_nexus 	// because of the connection between metric and morphism
+// metric_generator // because it is generated from morphism
+// metric_creator	// because it is created from morphism
+// metric_founder	// because it is founded from morphism
+// metric_calculator	// because it is calculated from morphism
+// metric_accessory	// because it is an accessory of morphism
+
+//! Covariant metric that is connected to its respective `morphism`.
+class metric_nexus : public metric_covariant {
+
+public:
+	metric_nexus(const morphism *morph);
+	virtual ~metric_nexus() override {};
+
+	virtual SM3 operator()(const IR3& r) const override;
+	virtual dSM3 del(const IR3& r) const override;
+	virtual double jacobian(const IR3& r) const override;
+	virtual IR3 del_jacobian(const IR3& r) const override;
+
+	virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
+	virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
+
+	virtual const morphism* morph() const {return morph_;};
+
+private:
+	const morphism *morph_;
+};
+
+} // end namespace gyronimo.
+
+#endif // GYRONIMO_METRIC_NEXUS

--- a/gyronimo/metrics/metric_polar_torus.cc
+++ b/gyronimo/metrics/metric_polar_torus.cc
@@ -22,13 +22,25 @@
 
 namespace gyronimo {
 
-metric_polar_torus::metric_polar_torus(
-    const double minor_radius, double major_radius)
-    : minor_radius_(minor_radius), major_radius_(major_radius),
+metric_polar_torus::metric_polar_torus(const morphism_polar_torus *morph)
+    : metric_connected(morph),
+      minor_radius_(morph->minor_radius()), 
+      major_radius_(morph->major_radius()),
       minor_radius_squared_(minor_radius_*minor_radius_),
+      iminor_radius_squared_(1.0/minor_radius_squared_),
       major_radius_squared_(major_radius_*major_radius_),
-      iaspect_ratio_(minor_radius_/major_radius_) {
+      iaspect_ratio_(morph->iaspect_ratio()) {
 }
+
+//! General-purpose implementation of the covariant metric.
+/*!
+	Implements the covariant metric in polar torus coordinates: 
+	@f$ g_{\alpha\beta} = \left(\begin{matrix}
+		a^2 && 0 && 0 \\
+		0 && a^2 \, r^2 && 0 \\
+		0 && 0 && \left( R_0 + a \, r \, \cos \theta \right)^2
+	\end{matrix}\right) @f$
+*/
 SM3 metric_polar_torus::operator()(const IR3& r) const {
   double u = r[IR3::u], v = r[IR3::v];
   double R = major_radius_*(1.0 + iaspect_ratio_*u*std::cos(v));
@@ -36,6 +48,23 @@ SM3 metric_polar_torus::operator()(const IR3& r) const {
            minor_radius_squared_*u*u, 0.0,
                                       R*R};
 }
+
+//! General-purpose implementation of the covariant metric.
+/*!
+	Implements the covariant metric in polar torus coordinates: 
+	@f$ g_{\alpha\beta} = \left(\begin{matrix}
+		\frac{1}{a^2} && 0 && 0 \\
+		0 && \frac{1}{a^2 \, r^2} && 0 \\
+		0 && 0 && \frac{1}{\left( R_0 + a \, r \, \cos \theta \right)^2}
+	\end{matrix}\right) @f$
+*/
+SM3 metric_polar_torus::inverse(const IR3& r) const {
+  double u = r[IR3::u], v = r[IR3::v];
+  double R = major_radius_*(1.0 + iaspect_ratio_*u*std::cos(v));
+  return {iminor_radius_squared_, 0.0, 0.0,
+          iminor_radius_squared_/(u*u), 0.0, 1.0/(R*R)};
+}
+
 dSM3 metric_polar_torus::del(const IR3& r) const {
   double u = r[IR3::u];
   double v = r[IR3::v];

--- a/gyronimo/metrics/metric_polar_torus.cc
+++ b/gyronimo/metrics/metric_polar_torus.cc
@@ -17,88 +17,68 @@
 
 // @metric_polar_torus.cc, this file is part of ::gyronimo::
 
-#include <cmath>
 #include <gyronimo/metrics/metric_polar_torus.hh>
+
+#include <cmath>
 
 namespace gyronimo {
 
-metric_polar_torus::metric_polar_torus(const morphism_polar_torus *morph)
-    : metric_connected(morph),
-      minor_radius_(morph->minor_radius()), 
+metric_polar_torus::metric_polar_torus(const morphism_polar_torus* morph)
+    : metric_connected(morph), minor_radius_(morph->minor_radius()),
       major_radius_(morph->major_radius()),
-      minor_radius_squared_(minor_radius_*minor_radius_),
-      iminor_radius_squared_(1.0/minor_radius_squared_),
-      major_radius_squared_(major_radius_*major_radius_),
-      iaspect_ratio_(morph->iaspect_ratio()) {
-}
-
-//! General-purpose implementation of the covariant metric.
-/*!
-	Implements the covariant metric in polar torus coordinates: 
-	@f$ g_{\alpha\beta} = \left(\begin{matrix}
-		a^2 && 0 && 0 \\
-		0 && a^2 \, r^2 && 0 \\
-		0 && 0 && \left( R_0 + a \, r \, \cos \theta \right)^2
-	\end{matrix}\right) @f$
-*/
+      minor_radius_squared_(minor_radius_ * minor_radius_),
+      iminor_radius_squared_(1.0 / minor_radius_squared_),
+      major_radius_squared_(major_radius_ * major_radius_),
+      iaspect_ratio_(morph->iaspect_ratio()) {}
 SM3 metric_polar_torus::operator()(const IR3& r) const {
   double u = r[IR3::u], v = r[IR3::v];
-  double R = major_radius_*(1.0 + iaspect_ratio_*u*std::cos(v));
+  double R = major_radius_ * (1.0 + iaspect_ratio_ * u * std::cos(v));
   return {minor_radius_squared_, 0.0, 0.0,
-           minor_radius_squared_*u*u, 0.0,
-                                      R*R};
+      minor_radius_squared_ * u * u, 0.0, R * R};
 }
-
-//! General-purpose implementation of the covariant metric.
-/*!
-	Implements the covariant metric in polar torus coordinates: 
-	@f$ g_{\alpha\beta} = \left(\begin{matrix}
-		\frac{1}{a^2} && 0 && 0 \\
-		0 && \frac{1}{a^2 \, r^2} && 0 \\
-		0 && 0 && \frac{1}{\left( R_0 + a \, r \, \cos \theta \right)^2}
-	\end{matrix}\right) @f$
-*/
 SM3 metric_polar_torus::inverse(const IR3& r) const {
   double u = r[IR3::u], v = r[IR3::v];
-  double R = major_radius_*(1.0 + iaspect_ratio_*u*std::cos(v));
+  double R = major_radius_ * (1.0 + iaspect_ratio_ * u * std::cos(v));
   return {iminor_radius_squared_, 0.0, 0.0,
-          iminor_radius_squared_/(u*u), 0.0, 1.0/(R*R)};
+      iminor_radius_squared_ / (u * u), 0.0, 1.0 / (R * R)};
 }
-
 dSM3 metric_polar_torus::del(const IR3& r) const {
   double u = r[IR3::u];
   double v = r[IR3::v];
   double cosv = std::cos(v), sinv = std::sin(v);
-  double R = major_radius_*(1.0 + iaspect_ratio_*u*cosv);
-  double factor = 2.0*R*minor_radius_;
+  double R = major_radius_ * (1.0 + iaspect_ratio_ * u * cosv);
+  double factor = 2.0 * R * minor_radius_;
   return {
-      0.0, 0.0, 0.0, // d_i g_uu
-      0.0, 0.0, 0.0, // d_i g_uv
-      0.0, 0.0, 0.0, // d_i g_uw
-      2.0 * u * minor_radius_squared_, 0.0, 0.0, //d_i g_vv
-      0.0, 0.0, 0.0, // d_i g_vw
-      factor * cosv, - factor * u * sinv, 0.0}; // d_i g_ww
+      0.0, 0.0, 0.0,  // d_i g_uu
+      0.0, 0.0, 0.0,  // d_i g_uv
+      0.0, 0.0, 0.0,  // d_i g_uw
+      2.0 * u * minor_radius_squared_, 0.0, 0.0,  // d_i g_vv
+      0.0, 0.0, 0.0,  // d_i g_vw
+      factor * cosv, -factor * u * sinv, 0.0};  // d_i g_ww
 }
 double metric_polar_torus::jacobian(const IR3& r) const {
   double u = r[IR3::u], v = r[IR3::v];
-  return minor_radius_squared_*major_radius_*
-      u*(1.0 + iaspect_ratio_*u*std::cos(v));
+  return minor_radius_squared_ * major_radius_ * u *
+      (1.0 + iaspect_ratio_ * u * std::cos(v));
 }
 IR3 metric_polar_torus::to_covariant(const IR3& B, const IR3& r) const {
   double u = r[IR3::u];
   double v = r[IR3::v];
   return {
-    minor_radius_squared_*B[IR3::u],
-    minor_radius_squared_*u*u*B[IR3::v],
-    std::pow(major_radius_*(1.0 + iaspect_ratio_*u*std::cos(v)), 2)*B[IR3::w]};
+      minor_radius_squared_ * B[IR3::u],
+      minor_radius_squared_ * u * u * B[IR3::v],
+      std::pow(major_radius_ * (1.0 + iaspect_ratio_ * u * std::cos(v)), 2) *
+          B[IR3::w]};
 }
 IR3 metric_polar_torus::to_contravariant(const IR3& B, const IR3& r) const {
   double u = r[IR3::u];
   double v = r[IR3::v];
   return {
-    B[IR3::u]/minor_radius_squared_,
-    B[IR3::v]/(minor_radius_squared_*u*u),
-    B[IR3::w]/std::pow(major_radius_*(1.0 + iaspect_ratio_*u*std::cos(v)), 2)};
+      B[IR3::u] / minor_radius_squared_,
+      B[IR3::v] / (minor_radius_squared_ * u * u),
+      B[IR3::w] /
+          std::pow(
+              major_radius_ * (1.0 + iaspect_ratio_ * u * std::cos(v)), 2)};
 }
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.

--- a/gyronimo/metrics/metric_polar_torus.hh
+++ b/gyronimo/metrics/metric_polar_torus.hh
@@ -20,7 +20,8 @@
 #ifndef GYRONIMO_METRIC_POLAR_TORUS
 #define GYRONIMO_METRIC_POLAR_TORUS
 
-#include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/metric_connected.hh>
+#include <gyronimo/metrics/morphism_polar_torus.hh>
 
 namespace gyronimo {
 
@@ -34,12 +35,13 @@ namespace gyronimo {
     units. Inherited methods `Jacobian`, `to_covariant`, and `to_contravariant`
     are overriden for efficiency.
 */
-class metric_polar_torus : public metric_covariant {
+class metric_polar_torus : public metric_connected {
  public:
-  metric_polar_torus(const double minor_radius, double major_radius);
+  metric_polar_torus(const morphism_polar_torus *morph);
   virtual ~metric_polar_torus() override {};
 
   virtual SM3 operator()(const IR3& r) const override;
+  virtual SM3 inverse(const IR3& r) const override;
   virtual dSM3 del(const IR3& r) const override;
 
   virtual double jacobian(const IR3& r) const override;
@@ -52,7 +54,8 @@ class metric_polar_torus : public metric_covariant {
 
  private:
   const double minor_radius_, major_radius_;
-  const double minor_radius_squared_, major_radius_squared_, iaspect_ratio_;
+  const double minor_radius_squared_, iminor_radius_squared_;
+  const double major_radius_squared_, iaspect_ratio_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,10 +22,11 @@
 
 namespace gyronimo {
 
-metric_spherical::metric_spherical(double radius_norm)
-    : radius_norm_(radius_norm),
-      radius_norm_squared_(radius_norm*radius_norm),
-      radius_norm_cube_(radius_norm*radius_norm*radius_norm), 
+metric_spherical::metric_spherical(const morphism_spherical *morph)
+    : metric_nexus(morph),
+	  radius_norm_(morph->r0()),
+      radius_norm_squared_(radius_norm_*radius_norm_),
+      radius_norm_cube_(radius_norm_*radius_norm_*radius_norm_), 
 	  iradius_norm_squared_(1/radius_norm_squared_) {
 }
 SM3 metric_spherical::operator()(const IR3& r) const {
@@ -68,6 +69,29 @@ IR3 metric_spherical::to_contravariant(const IR3& B, const IR3& r) const {
   double sinv = std::sin(r[IR3::v]);
   return {B[IR3::u]/radius_norm_squared_,
       B[IR3::v]/factor, B[IR3::w]/(factor*sinv*sinv)};
+}
+ddIR3 metric_spherical::christoffel_first_kind(const IR3& q) const {
+	double r = radius_norm_squared_*q[IR3::u];
+	double s = std::sin(q[IR3::v]);
+	double c = std::cos(q[IR3::v]);
+	double rss = r*s*s;
+	double r2sc = r*q[IR3::u]*s*c;
+	return {
+		0, 0, 0, -r, 0, -rss,
+		0, r, 0, 0, 0, -r2sc,
+		0, 0, rss, 0, r2sc, 0
+	};
+}
+ddIR3 metric_spherical::christoffel_second_kind(const IR3& q) const {
+	double r = q[IR3::u];
+	double ir = 1/q[IR3::u];
+	double s = std::sin(q[IR3::v]);
+	double c = std::cos(q[IR3::v]);
+	return {
+		0, 0, 0, -r, 0, -r*s*s,
+		0, ir, 0, 0, 0, -s*c,
+		0, 0, ir, 0, c/s, 0
+	};
 }
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -17,115 +17,74 @@
 
 // @metric_spherical.cc, this file is part of ::gyronimo::
 
-#include <cmath>
 #include <gyronimo/metrics/metric_spherical.hh>
+
+#include <cmath>
 
 namespace gyronimo {
 
-metric_spherical::metric_spherical(const morphism_spherical *morph)
-    : metric_connected(morph),
-	  Lref_(morph->Lref()),
-      Lref_squared_(Lref_*Lref_),
-      Lref_cube_(Lref_*Lref_*Lref_), 
-	  iLref_squared_(1/Lref_squared_) {
-}
-
-//! General-purpose implementation of the covariant metric.
-/*!
-	Implements the covariant metric in spherical coordinates: 
-	@f$ g_{\alpha\beta} = \left(\begin{matrix}
-		L_{ref}^2 && 0 && 0 \\
-		0 && L_{ref}^2 \, R^2 && 0 \\
-		0 && 0 && L_{ref}^2 \, R^2 \, \sin^2 \theta
-	\end{matrix}\right) @f$
-*/
+metric_spherical::metric_spherical(const morphism_spherical* morph)
+    : metric_connected(morph), Lref_(morph->Lref()),
+      Lref_squared_(Lref_ * Lref_), Lref_cube_(Lref_ * Lref_ * Lref_),
+      iLref_squared_(1 / Lref_squared_) {}
 SM3 metric_spherical::operator()(const IR3& r) const {
-  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_ * r[IR3::u] * r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {Lref_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
+  return {Lref_squared_, 0.0, 0.0, factor, 0.0, factor * sinv * sinv};
 }
-
-//! General-purpose implementation of the inverse (i.e., contravariant metric).
-/*!
-	Implements the contravariant metric in spherical coordinates: 
-	@f$ g^{\alpha\beta} = \left(\begin{matrix}
-		\frac{1}{L_{ref}^2} && 0 && 0 \\
-		0 && \frac{1}{L_{ref}^2 \, R^2} && 0 \\
-		0 && 0 && \frac{1}{L_{ref}^2 \, R^2 \, \sin^2 \theta}
-	\end{matrix}\right) @f$
-*/
 SM3 metric_spherical::inverse(const IR3& r) const {
-  double ifactor = iLref_squared_/(r[IR3::u]*r[IR3::u]);
-  double isinv = 1/std::sin(r[IR3::v]);
-  return {iLref_squared_, 0.0, 0.0, ifactor, 0.0, ifactor*isinv*isinv};
+  double ifactor = iLref_squared_ / (r[IR3::u] * r[IR3::u]);
+  double isinv = 1 / std::sin(r[IR3::v]);
+  return {iLref_squared_, 0.0, 0.0, ifactor, 0.0, ifactor * isinv * isinv};
 }
 dSM3 metric_spherical::del(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double factor = 2.0*Lref_squared_*r[IR3::u];
-  return {
-      0.0, 0.0, 0.0, // d_i g_uu (i=u,v,w)
-      0.0, 0.0, 0.0, // d_i g_uv
-      0.0, 0.0, 0.0, // d_i g_uw
-      factor, 0.0, 0.0, //d_i g_vv
-      0.0, 0.0, 0.0, // d_i g_vw
-      factor*sinv*sinv, factor*r[IR3::u]*sinv*cosv, 0.0}; // d_i g_ww
+  double factor = 2.0 * Lref_squared_ * r[IR3::u];
+  return {0.0, 0.0, 0.0,  // d_i g_uu (i=u,v,w)
+      0.0, 0.0, 0.0,  // d_i g_uv
+      0.0, 0.0, 0.0,  // d_i g_uw
+      factor, 0.0, 0.0,  // d_i g_vv
+      0.0, 0.0, 0.0,  // d_i g_vw
+      factor * sinv * sinv, factor * r[IR3::u] * sinv * cosv, 0.0};  // d_i g_ww
 }
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian in spherical coordinates: 
-	@f$ J = L_{ref}^3 \, R^2 \, \sin \theta @f$
-*/
 double metric_spherical::jacobian(const IR3& r) const {
-  return Lref_cube_*r[IR3::u]*r[IR3::u]*std::sin(r[IR3::v]);
+  return Lref_cube_ * r[IR3::u] * r[IR3::u] * std::sin(r[IR3::v]);
 }
-
-//! General-purpose implementation of the Jacobian gradient in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian gradient in spherical coordinates: 
-	@f$ \nabla J = \left( L_{ref}\,r\,\cos\phi\,(1+\sin^2\theta), 
-	L_{ref}\,r\,\sin\phi\,(1+\sin^2\theta), 
-	L_{ref}\,r\,\sin\theta\,\cos\theta \right) @f$
-*/
 IR3 metric_spherical::del_jacobian(const IR3& r) const {
   double cos = std::cos(r[IR3::v]), sin = std::sin(r[IR3::v]);
   double radius = r[IR3::u];
-  return {Lref_cube_*2*radius*sin, Lref_cube_*radius*radius*cos, 0.0};
+  return {
+      Lref_cube_ * 2 * radius * sin, Lref_cube_ * radius * radius * cos, 0.0};
 }
 IR3 metric_spherical::to_covariant(const IR3& B, const IR3& r) const {
-  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_ * r[IR3::u] * r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {Lref_squared_*B[IR3::u],
-      factor*B[IR3::v], factor*sinv*sinv*B[IR3::w]};
+  return {
+      Lref_squared_ * B[IR3::u], factor * B[IR3::v],
+      factor * sinv * sinv * B[IR3::w]};
 }
 IR3 metric_spherical::to_contravariant(const IR3& B, const IR3& r) const {
-  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_ * r[IR3::u] * r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {B[IR3::u]/Lref_squared_,
-      B[IR3::v]/factor, B[IR3::w]/(factor*sinv*sinv)};
+  return {
+      B[IR3::u] / Lref_squared_, B[IR3::v] / factor,
+      B[IR3::w] / (factor * sinv * sinv)};
 }
 ddIR3 metric_spherical::christoffel_first_kind(const IR3& q) const {
-	double r = Lref_squared_*q[IR3::u];
-	double s = std::sin(q[IR3::v]);
-	double c = std::cos(q[IR3::v]);
-	double rss = r*s*s;
-	double r2sc = r*q[IR3::u]*s*c;
-	return {
-		0, 0, 0, -r, 0, -rss,
-		0, r, 0, 0, 0, -r2sc,
-		0, 0, rss, 0, r2sc, 0
-	};
+  double r = Lref_squared_ * q[IR3::u];
+  double s = std::sin(q[IR3::v]);
+  double c = std::cos(q[IR3::v]);
+  double rss = r * s * s;
+  double r2sc = r * q[IR3::u] * s * c;
+  return {0, 0, 0, -r, 0, -rss, 0, r, 0, 0, 0, -r2sc, 0, 0, rss, 0, r2sc, 0};
 }
 ddIR3 metric_spherical::christoffel_second_kind(const IR3& q) const {
-	double r = q[IR3::u];
-	double ir = 1/q[IR3::u];
-	double s = std::sin(q[IR3::v]);
-	double c = std::cos(q[IR3::v]);
-	return {
-		0, 0, 0, -r, 0, -r*s*s,
-		0, ir, 0, 0, 0, -s*c,
-		0, 0, ir, 0, c/s, 0
-	};
+  double r = q[IR3::u];
+  double ir = 1 / q[IR3::u];
+  double s = std::sin(q[IR3::v]);
+  double c = std::cos(q[IR3::v]);
+  return {0, 0, 0, -r, 0, -r * s * s,
+      0, ir, 0, 0, 0, -s * c, 0,  0, ir, 0, c / s, 0};
 }
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -24,24 +24,24 @@ namespace gyronimo {
 
 metric_spherical::metric_spherical(const morphism_spherical *morph)
     : metric_nexus(morph),
-	  radius_norm_(morph->r0()),
-      radius_norm_squared_(radius_norm_*radius_norm_),
-      radius_norm_cube_(radius_norm_*radius_norm_*radius_norm_), 
-	  iradius_norm_squared_(1/radius_norm_squared_) {
+	  Lref_(morph->Lref()),
+      Lref_squared_(Lref_*Lref_),
+      Lref_cube_(Lref_*Lref_*Lref_), 
+	  iLref_squared_(1/Lref_squared_) {
 }
 SM3 metric_spherical::operator()(const IR3& r) const {
-  double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {radius_norm_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
+  return {Lref_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
 }
 SM3 metric_spherical::inverse(const IR3& r) const {
-  double ifactor = iradius_norm_squared_/(r[IR3::u]*r[IR3::u]);
+  double ifactor = iLref_squared_/(r[IR3::u]*r[IR3::u]);
   double isinv = 1/std::sin(r[IR3::v]);
-  return {iradius_norm_squared_, 0.0, 0.0, ifactor, 0.0, ifactor*isinv*isinv};
+  return {iLref_squared_, 0.0, 0.0, ifactor, 0.0, ifactor*isinv*isinv};
 }
 dSM3 metric_spherical::del(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double factor = 2.0*radius_norm_squared_*r[IR3::u];
+  double factor = 2.0*Lref_squared_*r[IR3::u];
   return {
       0.0, 0.0, 0.0, // d_i g_uu (i=u,v,w)
       0.0, 0.0, 0.0, // d_i g_uv
@@ -51,27 +51,27 @@ dSM3 metric_spherical::del(const IR3& r) const {
       factor*sinv*sinv, factor*r[IR3::u]*sinv*cosv, 0.0}; // d_i g_ww
 }
 double metric_spherical::jacobian(const IR3& r) const {
-  return radius_norm_cube_*r[IR3::u]*r[IR3::u]*std::sin(r[IR3::v]);
+  return Lref_cube_*r[IR3::u]*r[IR3::u]*std::sin(r[IR3::v]);
 }
 IR3 metric_spherical::del_jacobian(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double factor = radius_norm_cube_*r[IR3::u];
+  double factor = Lref_cube_*r[IR3::u];
   return {2.0*factor*sinv, factor*r[IR3::u]*cosv, 0.0};
 }
 IR3 metric_spherical::to_covariant(const IR3& B, const IR3& r) const {
-  double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {radius_norm_squared_*B[IR3::u],
+  return {Lref_squared_*B[IR3::u],
       factor*B[IR3::v], factor*sinv*sinv*B[IR3::w]};
 }
 IR3 metric_spherical::to_contravariant(const IR3& B, const IR3& r) const {
-  double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {B[IR3::u]/radius_norm_squared_,
+  return {B[IR3::u]/Lref_squared_,
       B[IR3::v]/factor, B[IR3::w]/(factor*sinv*sinv)};
 }
 ddIR3 metric_spherical::christoffel_first_kind(const IR3& q) const {
-	double r = radius_norm_squared_*q[IR3::u];
+	double r = Lref_squared_*q[IR3::u];
 	double s = std::sin(q[IR3::v]);
 	double c = std::cos(q[IR3::v]);
 	double rss = r*s*s;

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -88,11 +88,9 @@ double metric_spherical::jacobian(const IR3& r) const {
 	L_{ref}\,r\,\sin\theta\,\cos\theta \right) @f$
 */
 IR3 metric_spherical::del_jacobian(const IR3& r) const {
-  double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double cosw = std::cos(r[IR3::w]), sinw = std::sin(r[IR3::w]);
-  double r0 = Lref_squared_*r[IR3::u];
-  double factor = (1+sinv*sinv);
-  return {r0*cosw*factor, r0*sinw*factor, r0*sinv*cosv};
+  double cos = std::cos(r[IR3::v]), sin = std::sin(r[IR3::v]);
+  double radius = r[IR3::u];
+  return {Lref_cube_*2*radius*sin, Lref_cube_*radius*radius*cos, 0.0};
 }
 IR3 metric_spherical::to_covariant(const IR3& B, const IR3& r) const {
   double factor = Lref_squared_*r[IR3::u]*r[IR3::u];

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -23,24 +23,24 @@
 namespace gyronimo {
 
 metric_spherical::metric_spherical(double radius_norm)
-    : radius_norm_(radius_norm),
-      radius_norm_squared_(radius_norm*radius_norm),
-      radius_norm_cube_(radius_norm*radius_norm*radius_norm), 
-	  iradius_norm_squared_(1/radius_norm_squared_) {
+    : Lref_(radius_norm),
+      Lref_squared_(radius_norm*radius_norm),
+      Lref_cube_(radius_norm*radius_norm*radius_norm), 
+	  iLref_squared_(1/Lref_squared_) {
 }
 SM3 metric_spherical::operator()(const IR3& r) const {
-  double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {radius_norm_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
+  return {Lref_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
 }
 SM3 metric_spherical::inverse(const IR3& r) const {
-  double ifactor = iradius_norm_squared_/(r[IR3::u]*r[IR3::u]);
+  double ifactor = iLref_squared_/(r[IR3::u]*r[IR3::u]);
   double isinv = 1/std::sin(r[IR3::v]);
-  return {iradius_norm_squared_, 0.0, 0.0, ifactor, 0.0, ifactor*isinv*isinv};
+  return {iLref_squared_, 0.0, 0.0, ifactor, 0.0, ifactor*isinv*isinv};
 }
 dSM3 metric_spherical::del(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double factor = 2.0*radius_norm_squared_*r[IR3::u];
+  double factor = 2.0*Lref_squared_*r[IR3::u];
   return {
       0.0, 0.0, 0.0, // d_i g_uu (i=u,v,w)
       0.0, 0.0, 0.0, // d_i g_uv
@@ -50,23 +50,23 @@ dSM3 metric_spherical::del(const IR3& r) const {
       factor*sinv*sinv, factor*r[IR3::u]*sinv*cosv, 0.0}; // d_i g_ww
 }
 double metric_spherical::jacobian(const IR3& r) const {
-  return radius_norm_cube_*r[IR3::u]*r[IR3::u]*std::sin(r[IR3::v]);
+  return Lref_cube_*r[IR3::u]*r[IR3::u]*std::sin(r[IR3::v]);
 }
 IR3 metric_spherical::del_jacobian(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double factor = radius_norm_cube_*r[IR3::u];
+  double factor = Lref_cube_*r[IR3::u];
   return {2.0*factor*sinv, factor*r[IR3::u]*cosv, 0.0};
 }
 IR3 metric_spherical::to_covariant(const IR3& B, const IR3& r) const {
-  double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {radius_norm_squared_*B[IR3::u],
+  return {Lref_squared_*B[IR3::u],
       factor*B[IR3::v], factor*sinv*sinv*B[IR3::w]};
 }
 IR3 metric_spherical::to_contravariant(const IR3& B, const IR3& r) const {
-  double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
+  double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
-  return {B[IR3::u]/radius_norm_squared_,
+  return {B[IR3::u]/Lref_squared_,
       B[IR3::v]/factor, B[IR3::w]/(factor*sinv*sinv)};
 }
 

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -29,11 +29,31 @@ metric_spherical::metric_spherical(const morphism_spherical *morph)
       Lref_cube_(Lref_*Lref_*Lref_), 
 	  iLref_squared_(1/Lref_squared_) {
 }
+
+//! General-purpose implementation of the covariant metric.
+/*!
+	Implements the covariant metric in spherical coordinates: 
+	@f$ g_{\alpha\beta} = \left(\begin{matrix}
+		L_{ref}^2 && 0 && 0 \\
+		0 && L_{ref}^2 \, R^2 && 0 \\
+		0 && 0 && L_{ref}^2 \, R^2 \, \sin^2 \theta
+	\end{matrix}\right) @f$
+*/
 SM3 metric_spherical::operator()(const IR3& r) const {
   double factor = Lref_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
   return {Lref_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
 }
+
+//! General-purpose implementation of the inverse (i.e., contravariant metric).
+/*!
+	Implements the contravariant metric in spherical coordinates: 
+	@f$ g^{\alpha\beta} = \left(\begin{matrix}
+		\frac{1}{L_{ref}^2} && 0 && 0 \\
+		0 && \frac{1}{L_{ref}^2 \, R^2} && 0 \\
+		0 && 0 && \frac{1}{L_{ref}^2 \, R^2 \, \sin^2 \theta}
+	\end{matrix}\right) @f$
+*/
 SM3 metric_spherical::inverse(const IR3& r) const {
   double ifactor = iLref_squared_/(r[IR3::u]*r[IR3::u]);
   double isinv = 1/std::sin(r[IR3::v]);
@@ -50,9 +70,23 @@ dSM3 metric_spherical::del(const IR3& r) const {
       0.0, 0.0, 0.0, // d_i g_vw
       factor*sinv*sinv, factor*r[IR3::u]*sinv*cosv, 0.0}; // d_i g_ww
 }
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian in spherical coordinates: 
+	@f$ J = L_{ref}^3 \, R^2 \, \sin \theta @f$
+*/
 double metric_spherical::jacobian(const IR3& r) const {
   return Lref_cube_*r[IR3::u]*r[IR3::u]*std::sin(r[IR3::v]);
 }
+
+//! General-purpose implementation of the Jacobian gradient in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian gradient in spherical coordinates: 
+	@f$ \nabla J = \left( L_{ref}\,r\,\cos\phi\,(1+\sin^2\theta), 
+	L_{ref}\,r\,\sin\phi\,(1+\sin^2\theta), 
+	L_{ref}\,r\,\sin\theta\,\cos\theta \right) @f$
+*/
 IR3 metric_spherical::del_jacobian(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
   double cosw = std::cos(r[IR3::w]), sinw = std::sin(r[IR3::w]);

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -25,12 +25,18 @@ namespace gyronimo {
 metric_spherical::metric_spherical(double radius_norm)
     : radius_norm_(radius_norm),
       radius_norm_squared_(radius_norm*radius_norm),
-      radius_norm_cube_(radius_norm*radius_norm*radius_norm) {
+      radius_norm_cube_(radius_norm*radius_norm*radius_norm), 
+	  iradius_norm_squared_(1/radius_norm_squared_) {
 }
 SM3 metric_spherical::operator()(const IR3& r) const {
   double factor = radius_norm_squared_*r[IR3::u]*r[IR3::u];
   double sinv = std::sin(r[IR3::v]);
   return {radius_norm_squared_, 0.0, 0.0, factor, 0.0, factor*sinv*sinv};
+}
+SM3 metric_spherical::inverse(const IR3& r) const {
+  double ifactor = iradius_norm_squared_/(r[IR3::u]*r[IR3::u]);
+  double isinv = 1/std::sin(r[IR3::v]);
+  return {iradius_norm_squared_, 0.0, 0.0, ifactor, 0.0, ifactor*isinv*isinv};
 }
 dSM3 metric_spherical::del(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -55,8 +55,10 @@ double metric_spherical::jacobian(const IR3& r) const {
 }
 IR3 metric_spherical::del_jacobian(const IR3& r) const {
   double cosv = std::cos(r[IR3::v]), sinv = std::sin(r[IR3::v]);
-  double factor = Lref_cube_*r[IR3::u];
-  return {2.0*factor*sinv, factor*r[IR3::u]*cosv, 0.0};
+  double cosw = std::cos(r[IR3::w]), sinw = std::sin(r[IR3::w]);
+  double r0 = Lref_squared_*r[IR3::u];
+  double factor = (1+sinv*sinv);
+  return {r0*cosw*factor, r0*sinw*factor, r0*sinv*cosv};
 }
 IR3 metric_spherical::to_covariant(const IR3& B, const IR3& r) const {
   double factor = Lref_squared_*r[IR3::u]*r[IR3::u];

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -23,7 +23,7 @@
 namespace gyronimo {
 
 metric_spherical::metric_spherical(const morphism_spherical *morph)
-    : metric_nexus(morph),
+    : metric_connected(morph),
 	  Lref_(morph->Lref()),
       Lref_squared_(Lref_*Lref_),
       Lref_cube_(Lref_*Lref_*Lref_), 

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -35,7 +35,7 @@ namespace gyronimo {
 */
 class metric_spherical : public metric_connected {
  public:
-  metric_spherical(const morphism_spherical *morph);
+  metric_spherical(const morphism_spherical* morph);
   virtual ~metric_spherical() override {};
 
   virtual SM3 operator()(const IR3& r) const override;
@@ -49,18 +49,18 @@ class metric_spherical : public metric_connected {
 
   virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
-  
-  double Lref() const {return Lref_;};
 
-  virtual const morphism_spherical* morph() const override {
-    return static_cast<const morphism_spherical*>(morph_);
+  double Lref() const { return Lref_; };
+
+  virtual const morphism_spherical* my_morphism() const override {
+    return static_cast<const morphism_spherical*>(
+        metric_connected::my_morphism());
   };
-
  private:
   const double Lref_, Lref_squared_;
   const double Lref_cube_, iLref_squared_;
 };
 
-} // end namespace gyronimo.
+}  // end namespace gyronimo.
 
-#endif // GYRONIMO_METRIC_SPHERICAL
+#endif  // GYRONIMO_METRIC_SPHERICAL

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -49,8 +49,12 @@ class metric_spherical : public metric_connected {
 
   virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
-
+  
   double Lref() const {return Lref_;};
+
+  virtual const morphism_spherical* morph() const override {
+    return static_cast<const morphism_spherical*>(this->metric_connected::morph());
+  };
 
  private:
   const double Lref_, Lref_squared_;

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -53,7 +53,7 @@ class metric_spherical : public metric_connected {
   double Lref() const {return Lref_;};
 
   virtual const morphism_spherical* morph() const override {
-    return static_cast<const morphism_spherical*>(this->metric_connected::morph());
+    return static_cast<const morphism_spherical*>(morph_);
   };
 
  private:

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -27,14 +27,14 @@ namespace gyronimo {
 //! Covariant metric for spherical coordinates.
 /*!
     The three contravariant coordinates are the distance to the origin
-    normalized to `radius_norm` (`u`, with `radius_norm` in SI), the polar angle
+    normalized to `Lref` (`u`, with `Lref` in SI), the polar angle
     measured from the z-axis (co-latitude `v`, in rads), and the azimuthal angle
     (`w`, also in rads) measured clockwise when looking from the origin along
     the z-axis. Some inherited methods are overriden for efficiency.
 */
 class metric_spherical : public metric_covariant {
  public:
-  metric_spherical(double radius_norm);
+  metric_spherical(double Lref);
   virtual ~metric_spherical() override {};
 
   virtual SM3 operator()(const IR3& r) const override;
@@ -46,11 +46,11 @@ class metric_spherical : public metric_covariant {
   virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
   virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
 
-  double radius_norm() const {return radius_norm_;};
+  double Lref() const {return Lref_;};
 
  private:
-  const double radius_norm_, radius_norm_squared_;
-  const double radius_norm_cube_, iradius_norm_squared_;
+  const double Lref_, Lref_squared_;
+  const double Lref_cube_, iLref_squared_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -37,16 +37,20 @@ class metric_spherical : public metric_covariant {
   metric_spherical(double radius_norm);
   virtual ~metric_spherical() override {};
 
-  virtual SM3 operator()(const IR3& r) const override ;
+  virtual SM3 operator()(const IR3& r) const override;
+  virtual SM3 inverse(const IR3& r) const override;
   virtual dSM3 del(const IR3& r) const override;
 
   virtual double jacobian(const IR3& r) const override;
   virtual IR3 del_jacobian(const IR3& r) const override;
-  virtual IR3 to_covariant(const IR3& B, const IR3& r) const override ;
+  virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
   virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
+
+  double radius_norm() const {return radius_norm_;};
+
  private:
-  const double radius_norm_;
-  const double radius_norm_squared_, radius_norm_cube_;
+  const double radius_norm_, radius_norm_squared_;
+  const double radius_norm_cube_, iradius_norm_squared_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,7 +20,8 @@
 #ifndef GYRONIMO_METRIC_SPHERICAL
 #define GYRONIMO_METRIC_SPHERICAL
 
-#include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/morphism_spherical.hh>
 
 namespace gyronimo {
 
@@ -32,9 +33,9 @@ namespace gyronimo {
     (`w`, also in rads) measured clockwise when looking from the origin along
     the z-axis. Some inherited methods are overriden for efficiency.
 */
-class metric_spherical : public metric_covariant {
+class metric_spherical : public metric_nexus {
  public:
-  metric_spherical(double radius_norm);
+  metric_spherical(const morphism_spherical *morph);
   virtual ~metric_spherical() override {};
 
   virtual SM3 operator()(const IR3& r) const override;
@@ -45,6 +46,9 @@ class metric_spherical : public metric_covariant {
   virtual IR3 del_jacobian(const IR3& r) const override;
   virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
   virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;
+
+  virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
+  virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
 
   double radius_norm() const {return radius_norm_;};
 

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -20,7 +20,7 @@
 #ifndef GYRONIMO_METRIC_SPHERICAL
 #define GYRONIMO_METRIC_SPHERICAL
 
-#include <gyronimo/metrics/metric_nexus.hh>
+#include <gyronimo/metrics/metric_connected.hh>
 #include <gyronimo/metrics/morphism_spherical.hh>
 
 namespace gyronimo {
@@ -33,7 +33,7 @@ namespace gyronimo {
     (`w`, also in rads) measured clockwise when looking from the origin along
     the z-axis. Some inherited methods are overriden for efficiency.
 */
-class metric_spherical : public metric_nexus {
+class metric_spherical : public metric_connected {
  public:
   metric_spherical(const morphism_spherical *morph);
   virtual ~metric_spherical() override {};

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -28,7 +28,7 @@ namespace gyronimo {
 //! Covariant metric for spherical coordinates.
 /*!
     The three contravariant coordinates are the distance to the origin
-    normalized to `radius_norm` (`u`, with `radius_norm` in SI), the polar angle
+    normalized to `Lref` (`u`, with `Lref` in SI), the polar angle
     measured from the z-axis (co-latitude `v`, in rads), and the azimuthal angle
     (`w`, also in rads) measured clockwise when looking from the origin along
     the z-axis. Some inherited methods are overriden for efficiency.
@@ -50,11 +50,11 @@ class metric_spherical : public metric_nexus {
   virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
 
-  double radius_norm() const {return radius_norm_;};
+  double Lref() const {return Lref_;};
 
  private:
-  const double radius_norm_, radius_norm_squared_;
-  const double radius_norm_cube_, iradius_norm_squared_;
+  const double Lref_, Lref_squared_;
+  const double Lref_cube_, iLref_squared_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_vmec.cc
+++ b/gyronimo/metrics/metric_vmec.cc
@@ -21,17 +21,18 @@
 
 namespace gyronimo{
 
-metric_vmec::metric_vmec(
-    const parser_vmec *p, const interpolator1d_factory *ifactory) 
-    : parser_(p), b0_(p->B_0()), mnmax_(p->mnmax()), mnmax_nyq_(p->mnmax_nyq()),
-      ns_(p->ns()), mpol_(p->mpol()), ntor_(p->ntor()), 
-      signsgs_(p->signgs()), nfp_(p->nfp()),
-      xm_(p->xm()), xn_(p->xn()), xm_nyq_(p->xm_nyq()), xn_nyq_(p->xn_nyq()),
+metric_vmec::metric_vmec(const morphism_vmec* morph, 
+        const interpolator1d_factory *ifactory) 
+    : metric_connected(morph), parser_(morph->parser()),
+      mnmax_(parser_->mnmax()), mnmax_nyq_(parser_->mnmax_nyq()),
+      ns_(parser_->ns()), mpol_(parser_->mpol()), ntor_(parser_->ntor()), 
+      signsgs_(parser_->signgs()), nfp_(parser_->nfp()),
+      xm_(parser_->xm()), xn_(parser_->xn()), xm_nyq_(parser_->xm_nyq()), xn_nyq_(parser_->xn_nyq()),
       Rmnc_(nullptr), Zmns_(nullptr), gmnc_(nullptr)
       {
     // set radial grid block
-    dblock_adapter s_range(p->radius());
-    dblock_adapter s_half_range(p->radius_half());
+    dblock_adapter s_range(parser_->radius());
+    dblock_adapter s_half_range(parser_->radius_half());
     // set spectral components 
     Rmnc_ = new interpolator1d* [xm_.size()];
     Zmns_ = new interpolator1d* [xm_.size()];
@@ -40,13 +41,13 @@ metric_vmec::metric_vmec(
     #pragma omp parallel for
     for(size_t i=0; i<xm_.size(); i++) {
       std::slice s_cut (i, s_range.size(), xm_.size());
-      std::valarray<double> rmnc_i = (p->rmnc())[s_cut];
+      std::valarray<double> rmnc_i = (parser_->rmnc())[s_cut];
       Rmnc_[i] = ifactory->interpolate_data( s_range, dblock_adapter(rmnc_i));
-      std::valarray<double> zmnc_i = (p->zmns())[s_cut];
+      std::valarray<double> zmnc_i = (parser_->zmns())[s_cut];
       Zmns_[i] = ifactory->interpolate_data( s_range, dblock_adapter(zmnc_i));
       // note that gmnc is defined at half mesh
       std::slice s_h_cut (i+xm_nyq_.size(), s_half_range.size(), xm_nyq_.size());
-      std::valarray<double> gmnc_i = (p->gmnc())[s_h_cut];
+      std::valarray<double> gmnc_i = (parser_->gmnc())[s_h_cut];
       gmnc_[i] = ifactory->interpolate_data( s_half_range, dblock_adapter(gmnc_i));
     };
 }
@@ -157,34 +158,4 @@ dSM3 metric_vmec::del(const IR3& position) const {
   };
 }
 
-IR3 metric_vmec::transform2cylindrical(const IR3& position) const {
-    double u = position[gyronimo::IR3::u];
-    double v = position[gyronimo::IR3::v];
-    double w = position[gyronimo::IR3::w];
-    double R = 0.0, Z = 0.0;
-  
-    #pragma omp parallel for reduction(+: R, Z)
-    for (size_t i = 0; i<xm_.size(); i++) {
-      double m = xm_[i]; double n = xn_[i];
-      R+= (*Rmnc_[i])(u) * std::cos( m*w - n*v ); 
-      Z+= (*Zmns_[i])(u) * std::sin( m*w - n*v );
-    }
-    return  {R, v, Z};
-}
- 
-//@todo move this to jacobian and think about testing this by calling the parent
-double metric_vmec::jacobian_vmec(const IR3& position) const {
-  double s = position[IR3::u];
-  double zeta = position[IR3::v];
-  double theta = position[IR3::w];
-  double J = 0.0;
-  #pragma omp parallel for reduction(+: J)
-  for (size_t i = 0; i < xm_nyq_.size(); i++) {  
-    J += (*gmnc_[i])(s) * std::cos( xm_nyq_[i]*theta - xn_nyq_[i]*zeta );
-  };
-  // left-handed VMEC coordinate system is re-oriented 
-  // to u = Phi/Phi_bnd, v = zeta, w = theta for J>0
-  // should we check/assume that signgs is always negative?
-  return -J;
-}
 } // end namespace gyronimo

--- a/gyronimo/metrics/metric_vmec.cc
+++ b/gyronimo/metrics/metric_vmec.cc
@@ -142,7 +142,7 @@ dSM3 metric_vmec::del(const IR3& position) const {
       2 * (dR_ds * d2R_dsdtheta + dZ_ds * d2Z_dsdtheta), 
       dR_ds * d2R_dsdzeta       + dR_dzeta * d2R_ds2      + dZ_ds * d2Z_dsdzeta      + dZ_dzeta * d2Z_ds2,
       dR_ds * d2R_dzeta2        + dR_dzeta * d2R_dsdzeta  + dZ_ds * d2Z_dzeta2       + dZ_dzeta * d2Z_dsdzeta,// d_i g_uv
-      dR_ds * d2R_dthetadzeta   + dR_dzeta * d2R_dsdzeta  + dZ_ds * d2Z_dthetadzeta  + dZ_dzeta * d2Z_dsdtheta, 
+      dR_ds * d2R_dthetadzeta   + dR_dzeta * d2R_dsdtheta  + dZ_ds * d2Z_dthetadzeta  + dZ_dzeta * d2Z_dsdtheta, 
       dR_ds * d2R_dsdtheta      + dR_dtheta * d2R_ds2      + dZ_ds * d2Z_dsdtheta     + dZ_dtheta * d2Z_ds2,
       dR_ds * d2R_dthetadzeta   + dR_dtheta * d2R_dsdzeta  + dZ_ds * d2Z_dthetadzeta  + dZ_dtheta * d2Z_dsdzeta, // d_i g_uw
       dR_ds * d2R_dtheta2       + dR_dtheta * d2R_dsdtheta + dZ_ds * d2Z_dtheta2      + dZ_dtheta * d2Z_dsdtheta, 
@@ -154,7 +154,7 @@ dSM3 metric_vmec::del(const IR3& position) const {
       dR_dtheta * d2R_dthetadzeta + dR_dzeta * d2R_dtheta2      + dZ_dtheta * d2Z_dthetadzeta  + dZ_dzeta * d2Z_dtheta2,  
       2 * (dR_dtheta * d2R_dsdtheta     + dZ_dtheta * d2Z_dsdtheta), 
       2 * (dR_dtheta * d2R_dthetadzeta  + dZ_dtheta * d2Z_dthetadzeta), // d_i g_ww
-      2 * (dR_dtheta * d2R_dtheta2      + dZ_dtheta * d2Z_dtheta2),  
+      2 * (dR_dtheta * d2R_dtheta2      + dZ_dtheta * d2Z_dtheta2)
   };
 }
 

--- a/gyronimo/metrics/metric_vmec.hh
+++ b/gyronimo/metrics/metric_vmec.hh
@@ -21,30 +21,33 @@
 #define GYRONIMO_METRIC_VMEC
 
 #include <gyronimo/parsers/parser_vmec.hh>
-#include <gyronimo/metrics/metric_covariant.hh>
+#include <gyronimo/metrics/morphism_vmec.hh>
+#include <gyronimo/metrics/metric_connected.hh>
 #include <gyronimo/interpolators/interpolator1d.hh>
 
 namespace gyronimo{
 
 //! Covariant metric in `VMEC` curvilinear coordinates.
-class metric_vmec : public metric_covariant {
+class metric_vmec : public metric_connected {
  public:
   typedef std::valarray<double> narray_type;
   typedef std::vector<interpolator1d> spectralarray_type;
 
-  metric_vmec(
-    const parser_vmec *parser, const interpolator1d_factory *ifactory);
+  metric_vmec(const morphism_vmec* morph, 
+    const interpolator1d_factory *ifactory);
   virtual ~metric_vmec() override;
   virtual SM3 operator()(const IR3& position) const override;
   virtual dSM3 del(const IR3& position) const override;
-  virtual IR3 transform2cylindrical(const IR3& position) const;
-  double jacobian_vmec(const IR3& position) const;
   const parser_vmec* parser() const {return parser_;};
   const double signgs() const {return signsgs_;};
 
+  virtual const morphism_vmec* morph() const override {
+    return static_cast<const morphism_vmec*>(morph_);
+  };
+
  private:
   const parser_vmec* parser_;
-  double b0_;
+  const interpolator1d_factory *ifactory_;
   int mnmax_, mnmax_nyq_, ns_, mpol_, ntor_, nfp_, signsgs_; 
   narray_type xm_, xn_, xm_nyq_, xn_nyq_; 
   interpolator1d **Rmnc_;

--- a/gyronimo/metrics/metric_vmec.hh
+++ b/gyronimo/metrics/metric_vmec.hh
@@ -41,8 +41,8 @@ class metric_vmec : public metric_connected {
   const parser_vmec* parser() const {return parser_;};
   const double signgs() const {return signsgs_;};
 
-  virtual const morphism_vmec* morph() const override {
-    return static_cast<const morphism_vmec*>(morph_);
+  virtual const morphism_vmec* my_morphism() const override {
+    return static_cast<const morphism_vmec*>(metric_connected::my_morphism());
   };
 
  private:

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
+// Copyright (C) 2022-2023 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -21,82 +21,47 @@
 
 namespace gyronimo {
 
-//! Translates the curvilinear position `q` by the cartesian vector `delta`
-/*!
-	Implements the rule:
-	@f$ q^\alpha = Q^\alpha \left( \textbf{X}\left(\right) + \Delta \right) @f$
-*/
-IR3 morphism::translation(const IR3 &q, const IR3 &delta) const {
-	return this->inverse((*this)(q) + delta);
+dIR3 morphism::del_inverse(const IR3& q) const {
+  return gyronimo::inverse(del(q));
 }
 
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-/*!
-	Implements the rule:
-	@f$ J = \textbf{e}_1 \cdot \left( \textbf{e}_2 \times \textbf{e}_3 \right) @f$
-*/
-double morphism::jacobian(const IR3 &q) const {
-	dIR3 e = del(q);
-	return (
-		e[dIR3::uu] * (e[dIR3::vv] * e[dIR3::ww] - e[dIR3::vw] * e[dIR3::wv]) +
-		e[dIR3::uv] * (e[dIR3::vw] * e[dIR3::wu] - e[dIR3::vu] * e[dIR3::ww]) +
-		e[dIR3::uw] * (e[dIR3::vu] * e[dIR3::wv] - e[dIR3::vv] * e[dIR3::wu])
-	);
+//! Tangent basis @f$ \textbf{e}_\alpha = \partial_\alpha \mathbf{x} @f$.
+dIR3 morphism::tan_basis(const IR3& q) const { return del(q); }
+
+//! Dual basis @f$ \textbf{e}^\alpha = \nabla q^\alpha(\mathbf{x}) @f$.
+dIR3 morphism::dual_basis(const IR3& q) const { return del_inverse(q); }
+
+//! Covariant components of *cartesian* `A` at curvilinear @f$q^\alpha@f$.
+IR3 morphism::to_covariant(const IR3& A, const IR3& q) const {
+  return contraction<first>(del(q), A);
 }
 
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the covariant basis vectors:
-	@f$ \textbf{e}^\alpha = \nabla q^\alpha @f$
-*/
-dIR3 morphism::del_inverse(const IR3 &q) const {
-	return gyronimo::inverse(del(q));
+//! Contravariant components of *cartesian* `A` at curvilinear @f$q^\alpha@f$.
+IR3 morphism::to_contravariant(const IR3& A, const IR3& q) const {
+  return contraction<second>(del_inverse(q), A);
 }
 
-//! Returns the tangent basis @f$ \textbf{e}_\alpha @f$
-dIR3 morphism::tan_basis(const IR3& q) const {
-	return del(q);
+//! Cartesian vector from covariant components.
+IR3 morphism::from_covariant(const IR3& A, const IR3& q) const {
+  return contraction<first>(del_inverse(q), A);
 }
 
-//! Returns the dual basis @f$ \textbf{e}^\alpha @f$
-dIR3 morphism::dual_basis(const IR3& q) const {
-	return del_inverse(q);
+//! Cartesian vector from contravariant components.
+IR3 morphism::from_contravariant(const IR3& A, const IR3& q) const {
+  return contraction<second>(del(q), A);
 }
 
-//! Returns the covariant components of @f$ \textbf{A} @f$ in position @f$ q^\alpha @f$.
-/*!
-	Implements the rule:
-	@f$ A_\alpha = \textbf{A} \cdot \textbf{e}_\alpha @f$
-*/
-IR3 morphism::to_covariant(const IR3 &A, const IR3 &q) const {
-	return contraction<first>(del(q), A);
+//! Jacobian @f$ \mathbf{e}_u \cdot (\mathbf{e}_v \times \mathbf{e}_w) @f$.
+double morphism::jacobian(const IR3& q) const {
+  dIR3 e = del(q);
+  return e[dIR3::uu] * (e[dIR3::vv] * e[dIR3::ww] - e[dIR3::vw] * e[dIR3::wv]) +
+      e[dIR3::uv] * (e[dIR3::vw] * e[dIR3::wu] - e[dIR3::vu] * e[dIR3::ww]) +
+      e[dIR3::uw] * (e[dIR3::vu] * e[dIR3::wv] - e[dIR3::vv] * e[dIR3::wu]);
 }
 
-//! Returns the contravariant components of @f$ \textbf{A} @f$ in the position @f$ q^\alpha @f$.
-/*!
-	Implements the rule:
-	@f$ A^\alpha = \textbf{A} \cdot \textbf{e}^\alpha @f$
-*/
-IR3 morphism::to_contravariant(const IR3 &A, const IR3 &q) const {
-	return contraction<second>(del_inverse(q), A);
+//! Curvilinear position of *cartesian* @f$ \mathbf{x}(q^\alpha) + \Delta @f$.
+IR3 morphism::translation(const IR3& q, const IR3& delta) const {
+  return this->inverse((*this)(q) + delta);
 }
 
-//! Returns the cartesian vector from its covariant components @f$ A_\alpha @f$ in position @f$ q^\alpha @f$.
-/*!
-	Implements the rule:
-	@f$ \textbf{A} = A_\alpha \, \textbf{e}^\alpha @f$
-*/
-IR3 morphism::from_covariant(const IR3 &A, const IR3 &q) const {
-	return contraction<first>(del_inverse(q), A);
-}
-
-//! Returns the cartesian vector from its contravariant components @f$ A^\alpha @f$ in position @f$ q^\alpha @f$.
-/*!
-	Implements the rule:
-	@f$ \textbf{A} = A^\alpha \, \textbf{e}_\alpha @f$
-*/
-IR3 morphism::from_contravariant(const IR3 &A, const IR3 &q) const {
-	return contraction<second>(del(q), A);
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -21,7 +21,11 @@
 
 namespace gyronimo {
 
-//! General-purpose implementation of the Jacobian of the transformation in point `q`.
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+/*!
+	Implements the rule:
+	@f$ J = \textbf{e}_1 \cdot \left( \textbf{e}_2 \times \textbf{e}_3 \right) @f$
+*/
 double morphism::jacobian(const IR3 &q) const {
 	dIR3 e = del(q);
 	return (
@@ -31,27 +35,57 @@ double morphism::jacobian(const IR3 &q) const {
 	);
 }
 
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the covariant basis vectors:
+	@f$ \textbf{e}^\alpha = \nabla q^\alpha @f$
+*/
 dIR3 morphism::del_inverse(const IR3 &q) const {
 	return gyronimo::inverse(del(q));
 }
 
-//! Returns the covariant components of `A` in position `q`.
+//! Returns the tangent basis @f$ \textbf{e}_\alpha @f$
+dIR3 morphism::tan_basis(const IR3& q) const {
+	return del(q);
+}
+
+//! Returns the dual basis @f$ \textbf{e}^\alpha @f$
+dIR3 morphism::dual_basis(const IR3& q) const {
+	return del_inverse(q);
+}
+
+//! Returns the covariant components of @f$ \textbf{A} @f$ in position @f$ q^\alpha @f$.
+/*!
+	Implements the rule:
+	@f$ A_\alpha = \textbf{A} \cdot \textbf{e}_\alpha @f$
+*/
 IR3 morphism::to_covariant(const IR3 &q, const IR3 &A) const {
 	return contraction<first>(del(q), A);
 }
 
-//! Returns the contravariant components of `A` in the position `q`.
+//! Returns the contravariant components of @f$ \textbf{A} @f$ in the position @f$ q^\alpha @f$.
+/*!
+	Implements the rule:
+	@f$ A^\alpha = \textbf{A} \cdot \textbf{e}^\alpha @f$
+*/
 IR3 morphism::to_contravariant(const IR3 &q, const IR3 &A) const {
 	return contraction<second>(del_inverse(q), A);
 }
 
-//! Returns the cartesian vector from its covariant components `A` in position `q`.
+//! Returns the cartesian vector from its covariant components @f$ A_\alpha @f$ in position @f$ q^\alpha @f$.
+/*!
+	Implements the rule:
+	@f$ \textbf{A} = A_\alpha \, \textbf{e}^\alpha @f$
+*/
 IR3 morphism::from_covariant(const IR3 &q, const IR3 &A) const {
 	return contraction<first>(del_inverse(q), A);
 }
 
-//! Returns the cartesian vector from its contravariant components `A` in position `q`.
+//! Returns the cartesian vector from its contravariant components @f$ A^\alpha @f$ in position @f$ q^\alpha @f$.
+/*!
+	Implements the rule:
+	@f$ \textbf{A} = A^\alpha \, \textbf{e}_\alpha @f$
+*/
 IR3 morphism::from_contravariant(const IR3 &q, const IR3 &A) const {
 	return contraction<second>(del(q), A);
 }

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -1,5 +1,4 @@
-// ::gyronimo:: - gyromotion for the people, by the people -
-// An object-oriented library for gyromotion applications in plasma physics.
+// ::gyronimo:: - gyromotion for the people, by the people -, // An object-oriented library for gyromotion applications in plasma physics.
 // Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
@@ -59,7 +58,7 @@ dIR3 morphism::dual_basis(const IR3& q) const {
 	Implements the rule:
 	@f$ A_\alpha = \textbf{A} \cdot \textbf{e}_\alpha @f$
 */
-IR3 morphism::to_covariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism::to_covariant(const IR3 &A, const IR3 &q) const {
 	return contraction<first>(del(q), A);
 }
 
@@ -68,7 +67,7 @@ IR3 morphism::to_covariant(const IR3 &q, const IR3 &A) const {
 	Implements the rule:
 	@f$ A^\alpha = \textbf{A} \cdot \textbf{e}^\alpha @f$
 */
-IR3 morphism::to_contravariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism::to_contravariant(const IR3 &A, const IR3 &q) const {
 	return contraction<second>(del_inverse(q), A);
 }
 
@@ -77,7 +76,7 @@ IR3 morphism::to_contravariant(const IR3 &q, const IR3 &A) const {
 	Implements the rule:
 	@f$ \textbf{A} = A_\alpha \, \textbf{e}^\alpha @f$
 */
-IR3 morphism::from_covariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism::from_covariant(const IR3 &A, const IR3 &q) const {
 	return contraction<first>(del_inverse(q), A);
 }
 
@@ -86,7 +85,7 @@ IR3 morphism::from_covariant(const IR3 &q, const IR3 &A) const {
 	Implements the rule:
 	@f$ \textbf{A} = A^\alpha \, \textbf{e}_\alpha @f$
 */
-IR3 morphism::from_contravariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism::from_contravariant(const IR3 &A, const IR3 &q) const {
 	return contraction<second>(del(q), A);
 }
 

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -21,6 +21,15 @@
 
 namespace gyronimo {
 
+//! Translates the curvilinear position `q` by the cartesian vector `delta`
+/*!
+	Implements the rule:
+	@f$ q^\alpha = Q^\alpha \left( \textbf{X}\left(\right) + \Delta \right) @f$
+*/
+IR3 morphism::translation(const IR3 &q, const IR3 &delta) const {
+	return this->inverse((*this)(q) + delta);
+}
+
 //! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
 /*!
 	Implements the rule:

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -1,8 +1,27 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2021 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism.cc, this file is part of ::gyronimo::
+
 #include <gyronimo/metrics/morphism.hh>
 
 namespace gyronimo {
 
-// Returns the jacobian of the transformation in point `q`.
+//! General-purpose implementation of the Jacobian of the transformation in point `q`.
 double morphism::jacobian(const IR3 &q) const {
 	dIR3 e = del(q);
 	return (
@@ -12,27 +31,27 @@ double morphism::jacobian(const IR3 &q) const {
 	);
 }
 
-// Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
 dIR3 morphism::del_inverse(const IR3 &q) const {
 	return gyronimo::inverse(del(q));
 }
 
-// Returns the covariant components of `A` in position `q`.
+//! Returns the covariant components of `A` in position `q`.
 IR3 morphism::to_covariant(const IR3 &q, const IR3 &A) const {
 	return contraction<first>(del(q), A);
 }
 
-// Returns the contravariant components of `A` in the position `q`.
+//! Returns the contravariant components of `A` in the position `q`.
 IR3 morphism::to_contravariant(const IR3 &q, const IR3 &A) const {
 	return contraction<second>(del_inverse(q), A);
 }
 
-// Returns the cartesian vector from its covariant components `A` in position `q`.
+//! Returns the cartesian vector from its covariant components `A` in position `q`.
 IR3 morphism::from_covariant(const IR3 &q, const IR3 &A) const {
 	return contraction<first>(del_inverse(q), A);
 }
 
-// Returns the cartesian vector from its contravariant components `A` in position `q`.
+//! Returns the cartesian vector from its contravariant components `A` in position `q`.
 IR3 morphism::from_contravariant(const IR3 &q, const IR3 &A) const {
 	return contraction<second>(del(q), A);
 }

--- a/gyronimo/metrics/morphism.cc
+++ b/gyronimo/metrics/morphism.cc
@@ -1,0 +1,40 @@
+#include <gyronimo/metrics/morphism.hh>
+
+namespace gyronimo {
+
+// Returns the jacobian of the transformation in point `q`.
+double morphism::jacobian(const IR3 &q) const {
+	dIR3 e = del(q);
+	return (
+		e[dIR3::uu] * (e[dIR3::vv] * e[dIR3::ww] - e[dIR3::vw] * e[dIR3::wv]) +
+		e[dIR3::uv] * (e[dIR3::vw] * e[dIR3::wu] - e[dIR3::vu] * e[dIR3::ww]) +
+		e[dIR3::uw] * (e[dIR3::vu] * e[dIR3::wv] - e[dIR3::vv] * e[dIR3::wu])
+	);
+}
+
+// Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+dIR3 morphism::del_inverse(const IR3 &q) const {
+	return gyronimo::inverse(del(q));
+}
+
+// Returns the covariant components of `A` in position `q`.
+IR3 morphism::to_covariant(const IR3 &q, const IR3 &A) const {
+	return contraction<first>(del(q), A);
+}
+
+// Returns the contravariant components of `A` in the position `q`.
+IR3 morphism::to_contravariant(const IR3 &q, const IR3 &A) const {
+	return contraction<second>(del_inverse(q), A);
+}
+
+// Returns the cartesian vector from its covariant components `A` in position `q`.
+IR3 morphism::from_covariant(const IR3 &q, const IR3 &A) const {
+	return contraction<first>(del_inverse(q), A);
+}
+
+// Returns the cartesian vector from its contravariant components `A` in position `q`.
+IR3 morphism::from_contravariant(const IR3 &q, const IR3 &A) const {
+	return contraction<second>(del(q), A);
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -25,7 +25,7 @@
 
 namespace gyronimo {
 
-//! Abstract morphism from curvilinear (q) into cartesian (x) coordinates.
+//! Abstract morphism class from curvilinear @f$ q^\alpha @f$ into cartesian @f$ \textbf{x} @f$ coordinates.
 class morphism {
 
 public:
@@ -33,17 +33,27 @@ public:
 	morphism() {};
 	virtual ~morphism() {};
 
-	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+	//! Maps curvilinear coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
 	virtual IR3 operator()(const IR3 &q) const = 0;
-	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+	//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into curvilinear coordinates @f$ q^\alpha @f$.
 	virtual IR3 inverse(const IR3 &x) const = 0;
-	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
+	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
+	/*!
+		Implements the covariant basis vectors:
+		@f$ \textbf{e}_\alpha = \frac{\partial \textbf{x}}{\partial q^\alpha} @f$
+	*/
 	virtual dIR3 del(const IR3 &q) const = 0;
+	//! Returns the morphism's second derivatives, calculated in point `q`.
+	/*!
+		Implements the derivatives of the covariant basis vectors:
+		@f$ \partial_\beta \, \textbf{e}_\alpha = \frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\alpha} @f$
+	*/
+	virtual ddIR3 del2(const IR3 &q) const = 0;
 
 	virtual double jacobian(const IR3 &q) const;
 	virtual dIR3 del_inverse(const IR3 &q) const;
-	virtual dIR3 tan_basis(const IR3& q) const {return del(q);};
-	virtual dIR3 dual_basis(const IR3& q) const {return del_inverse(q);};
+	virtual dIR3 tan_basis(const IR3& q) const;
+	virtual dIR3 dual_basis(const IR3& q) const;
 
 	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const;
 	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const;

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
+// Copyright (C) 2022-2023 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,46 +25,38 @@
 
 namespace gyronimo {
 
-//! Abstract morphism class from curvilinear @f$ q^\alpha @f$ into cartesian @f$ \textbf{x} @f$ coordinates.
+//! Abstract morphism from curvilinear `q` into *cartesian* `x` coordinates.
+/*!
+    Derived classes must implement the map @f$ \mathbf{x}(q^\alpha) @f$ from the
+    curvilinear coordinates @f$ q^\alpha @f$ into the cartesian space and its
+    inverse, along with the first-order and second-order partial derivatives of
+    the former. The default implementation provides the inverse derivative and
+    the transformation jacobian, dual and tangent-space basis, and conversion
+    between covariant and contravariant components. These methods are left
+    virtual to allow more efficient reimplementations in derived classes, if
+    needed.
+*/
 class morphism {
+ public:
+  morphism() {};
+  virtual ~morphism() {};
 
-public:
+  virtual IR3 operator()(const IR3& q) const = 0;
+  virtual IR3 inverse(const IR3& x) const = 0;
+  virtual dIR3 del(const IR3& q) const = 0;
+  virtual ddIR3 ddel(const IR3& q) const = 0;
 
-	morphism() {};
-	virtual ~morphism() {};
+  virtual double jacobian(const IR3& q) const;
+  virtual dIR3 del_inverse(const IR3& q) const;
+  virtual dIR3 tan_basis(const IR3& q) const;
+  virtual dIR3 dual_basis(const IR3& q) const;
+  virtual IR3 to_covariant(const IR3& A, const IR3& q) const;
+  virtual IR3 to_contravariant(const IR3& A, const IR3& q) const;
+  virtual IR3 from_covariant(const IR3& A, const IR3& q) const;
+  virtual IR3 from_contravariant(const IR3& A, const IR3& q) const;
+  virtual IR3 translation(const IR3& q, const IR3& delta) const;
+};
 
-	//! Maps curvilinear coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
-	virtual IR3 operator()(const IR3 &q) const = 0;
-	//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into curvilinear coordinates @f$ q^\alpha @f$.
-	virtual IR3 inverse(const IR3 &x) const = 0;
-	virtual IR3 translation(const IR3 &q, const IR3 &delta) const;
-	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
-	/*!
-		Implements the covariant basis vectors:
-		@f$ \textbf{e}_\alpha = \frac{\partial \textbf{x}}{\partial q^\alpha} @f$
-	*/
-	virtual dIR3 del(const IR3 &q) const = 0;
-	//! Returns the morphism's second derivatives, calculated in point `q`.
-	/*!
-		Implements the derivatives of the covariant basis vectors:
-		@f$ \partial_\beta \, \textbf{e}_\alpha = \frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\alpha} @f$
-	*/
-	virtual ddIR3 ddel(const IR3 &q) const = 0;
+}  // end namespace gyronimo
 
-	virtual double jacobian(const IR3 &q) const;
-	virtual dIR3 del_inverse(const IR3 &q) const;
-	virtual dIR3 tan_basis(const IR3& q) const;
-	virtual dIR3 dual_basis(const IR3& q) const;
-
-	virtual IR3 to_covariant(const IR3 &A, const IR3 &q) const;
-	virtual IR3 to_contravariant(const IR3 &A, const IR3 &q) const;
-	virtual IR3 from_covariant(const IR3 &A, const IR3 &q) const;
-	virtual IR3 from_contravariant(const IR3 &A, const IR3 &q) const;
-
-private:
-
-}; // end class morphism
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_MORPHISM
+#endif  // GYRONIMO_MORPHISM

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -55,10 +55,10 @@ public:
 	virtual dIR3 tan_basis(const IR3& q) const;
 	virtual dIR3 dual_basis(const IR3& q) const;
 
-	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const;
-	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const;
-	virtual IR3 from_covariant(const IR3 &q, const IR3 &A) const;
-	virtual IR3 from_contravariant(const IR3 &q, const IR3 &A) const;
+	virtual IR3 to_covariant(const IR3 &A, const IR3 &q) const;
+	virtual IR3 to_contravariant(const IR3 &A, const IR3 &q) const;
+	virtual IR3 from_covariant(const IR3 &A, const IR3 &q) const;
+	virtual IR3 from_contravariant(const IR3 &A, const IR3 &q) const;
 
 private:
 

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -25,7 +25,7 @@
 
 namespace gyronimo {
 
-//! Abstract morphism from curvilinear (q) into cartesian (x) coordinates.
+//! Abstract morphism classfrom curvilinear @f$ q^\alpha @f$ into cartesian @f$ \textbf{x} @f$ coordinates.
 class morphism {
 
 public:
@@ -33,17 +33,27 @@ public:
 	morphism() {};
 	virtual ~morphism() {};
 
-	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+	//! Maps curvilinear coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
 	virtual IR3 operator()(const IR3 &q) const = 0;
-	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+	//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into curvilinear coordinates @f$ q^\alpha @f$.
 	virtual IR3 inverse(const IR3 &x) const = 0;
-	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
+	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
+	/*!
+		Implements the covariant basis vectors:
+		@f$ \textbf{e}_\alpha = \frac{\partial \textbf{x}}{\partial q^\alpha} @f$
+	*/
 	virtual dIR3 del(const IR3 &q) const = 0;
+	//! Returns the morphism's second derivatives, calculated in point `q`.
+	/*!
+		Implements the derivatives of the covariant basis vectors:
+		@f$ \partial_\beta \, \textbf{e}_\alpha = \frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\alpha} @f$
+	*/
+	virtual ddIR3 del2(const IR3 &q) const = 0;
 
 	virtual double jacobian(const IR3 &q) const;
 	virtual dIR3 del_inverse(const IR3 &q) const;
-	virtual dIR3 tan_basis(const IR3& q) const {return del(q);};
-	virtual dIR3 dual_basis(const IR3& q) const {return del_inverse(q);};
+	virtual dIR3 tan_basis(const IR3& q) const;
+	virtual dIR3 dual_basis(const IR3& q) const;
 
 	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const;
 	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const;

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -30,45 +30,24 @@ class morphism {
 
 public:
 
-	//! Class Constructor
 	morphism() {};
-
-	//! Class Destructor
 	virtual ~morphism() {};
 
 	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
 	virtual IR3 operator()(const IR3 &q) const = 0;
-
 	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
 	virtual IR3 inverse(const IR3 &x) const = 0;
-
-	//! Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
 	virtual dIR3 del(const IR3 &q) const = 0;
 
-	//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+	virtual double jacobian(const IR3 &q) const;
 	virtual dIR3 del_inverse(const IR3 &q) const;
-
 	virtual dIR3 tan_basis(const IR3& q) const {return del(q);};
 	virtual dIR3 dual_basis(const IR3& q) const {return del_inverse(q);};
 
-	// //! Returns the morphism's second derivatives, calculated in point `q`.
-	// virtual dSM3 del2(const IR3& q) const = 0;
-	virtual dSM3 g_del(const IR3& q) const = 0; // to evade the problem of not getting a metric through the morphism (yet)
-
-	//! Returns the jacobian of the transformation in point `q`.
-	virtual double jacobian(const IR3 &q) const;
-
-
-	//! Returns the covariant components of cartesian `A` in position `q`.
 	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const;
-
-	//! Returns the contravariant components of `A` in position `q`.
 	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const;
-
-	//! Returns the cartesian vector from its covariant components `A` in position `q`.
 	virtual IR3 from_covariant(const IR3 &q, const IR3 &A) const;
-
-	//! Returns the cartesian vector from its contravariant components `A` in position `q`.
 	virtual IR3 from_contravariant(const IR3 &q, const IR3 &A) const;
 
 private:

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@ public:
 		Implements the derivatives of the covariant basis vectors:
 		@f$ \partial_\beta \, \textbf{e}_\alpha = \frac{\partial^2 \textbf{x}}{\partial q^\beta \, \partial q^\alpha} @f$
 	*/
-	virtual ddIR3 del2(const IR3 &q) const = 0;
+	virtual ddIR3 ddel(const IR3 &q) const = 0;
 
 	virtual double jacobian(const IR3 &q) const;
 	virtual dIR3 del_inverse(const IR3 &q) const;

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -21,22 +21,60 @@
 #define GYRONIMO_MORPHISM
 
 #include <gyronimo/core/IR3algebra.hh>
+#include <gyronimo/core/contraction.hh>
 
 namespace gyronimo {
 
 //! Abstract morphism from curvilinear (q) into cartesian (x) coordinates.
 class morphism {
- public:
-  virtual ~morphism() {};
-  virtual IR3 operator()(const IR3& q) const = 0;
-  virtual IR3 inverse(const IR3& x) const = 0;
-  virtual dIR3 del(const IR3& q) const = 0;
-  virtual dIR3 del_inverse(
-      const IR3& q) const {return gyronimo::inverse(del(q));};
-  virtual dIR3 tan_basis(const IR3& q) const {return del(q);};
-  virtual dIR3 dual_basis(const IR3& q) const {return del_inverse(q);};
-};
 
-}
+public:
+
+	//! Class Constructor
+	morphism() {};
+
+	//! Class Destructor
+	virtual ~morphism() {};
+
+	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+	virtual IR3 operator()(const IR3 &q) const = 0;
+
+	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+	virtual IR3 inverse(const IR3 &x) const = 0;
+
+	//! Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+	virtual dIR3 del(const IR3 &q) const = 0;
+
+	//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+	virtual dIR3 del_inverse(const IR3 &q) const;
+
+	virtual dIR3 tan_basis(const IR3& q) const {return del(q);};
+	virtual dIR3 dual_basis(const IR3& q) const {return del_inverse(q);};
+
+	// //! Returns the morphism's second derivatives, calculated in point `q`.
+	// virtual dSM3 del2(const IR3& q) const = 0;
+	virtual dSM3 g_del(const IR3& q) const = 0; // to evade the problem of not getting a metric through the morphism (yet)
+
+	//! Returns the jacobian of the transformation in point `q`.
+	virtual double jacobian(const IR3 &q) const;
+
+
+	//! Returns the covariant components of cartesian `A` in position `q`.
+	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const;
+
+	//! Returns the contravariant components of `A` in position `q`.
+	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const;
+
+	//! Returns the cartesian vector from its covariant components `A` in position `q`.
+	virtual IR3 from_covariant(const IR3 &q, const IR3 &A) const;
+
+	//! Returns the cartesian vector from its contravariant components `A` in position `q`.
+	virtual IR3 from_contravariant(const IR3 &q, const IR3 &A) const;
+
+private:
+
+}; // end class morphism
+
+} // end namespace gyronimo
 
 #endif // GYRONIMO_MORPHISM

--- a/gyronimo/metrics/morphism.hh
+++ b/gyronimo/metrics/morphism.hh
@@ -37,6 +37,7 @@ public:
 	virtual IR3 operator()(const IR3 &q) const = 0;
 	//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into curvilinear coordinates @f$ q^\alpha @f$.
 	virtual IR3 inverse(const IR3 &x) const = 0;
+	virtual IR3 translation(const IR3 &q, const IR3 &delta) const;
 	//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
 	/*!
 		Implements the covariant basis vectors:

--- a/gyronimo/metrics/morphism_cartesian.cc
+++ b/gyronimo/metrics/morphism_cartesian.cc
@@ -21,96 +21,33 @@
 
 namespace gyronimo {
 
-morphism_cartesian::morphism_cartesian() 
-	: morphism() {
+IR3 morphism_cartesian::operator()(const IR3& q) const { return q; }
+IR3 morphism_cartesian::inverse(const IR3& x) const { return x; }
+IR3 morphism_cartesian::translation(const IR3& q, const IR3& delta) const {
+  return q + delta;
+}
+dIR3 morphism_cartesian::del(const IR3& q) const {
+  return {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+}
+ddIR3 morphism_cartesian::ddel(const IR3& q) const {
+  return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+}
+double morphism_cartesian::jacobian(const IR3& q) const { return 1.0; }
+dIR3 morphism_cartesian::del_inverse(const IR3& q) const {
+  return {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
+}
+IR3 morphism_cartesian::to_covariant(const IR3& A, const IR3& q) const {
+  return A;
+}
+IR3 morphism_cartesian::to_contravariant(const IR3& A, const IR3& q) const {
+  return A;
+}
+IR3 morphism_cartesian::from_covariant(const IR3& A, const IR3& q) const {
+  return A;
+}
+IR3 morphism_cartesian::from_contravariant(const IR3& A, const IR3& q) const {
+  return A;
 }
 
-//! Cartesian coordinates map identity transformation @f$ \left( q^1, q^2, q^3 \right) = \left( x, y, z \right) @f$.
-IR3 morphism_cartesian::operator()(const IR3 &q) const {
-	return q;
-}
-
-//! Inverse map is identity transformation.
-IR3 morphism_cartesian::inverse(const IR3 &x) const {
-	return x;
-}
-
-//! Translates the curvilinear position `q` by the cartesian vector `delta`
-/*!
-	Implements the rule:
-	@f$ q^\alpha = Q^\alpha \left( \textbf{X}\left(\right) + \Delta \right) @f$
-*/
-IR3 morphism_cartesian::translation(const IR3 &q, const IR3 &delta) const {
-	return q+delta;
-}
-
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ \textbf{x} @f$.
-/*!
-	Implements the coordinate transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}_x &= \left( 1,0,0 \right) \\
-			\textbf{e}_y &= \left( 0,1,0 \right) \\
-			\textbf{e}_Z &= \left( 0,0,1 \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_cartesian::del(const IR3 &q) const {
-	return {
-		1.0, 0.0, 0.0,
-		0.0, 1.0, 0.0,
-		0.0, 0.0, 1.0
-	};
-}
-
-//! Returns the morphism's second derivatives, calculated in point @f$ \textbf{x} @f$.
-ddIR3 morphism_cartesian::ddel(const IR3 &q) const {
-	return {
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-	};
-}
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ \textbf{x} @f$.
-/*!
-	Implements the Jacobian in cartesian coordinates: 
-	@f$ J = 1 @f$
-*/
-double morphism_cartesian::jacobian(const IR3 &q) const {
-	return 1.0;
-}
-
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ \textbf{x} @f$.
-/*!
-	Implements the inverse transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}^x &= \left( 1,0,0 \right) \\
-			\textbf{e}^y &= \left( 0,1,0 \right) \\
-			\textbf{e}^Z &= \left( 0,0,1 \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_cartesian::del_inverse(const IR3 &q) const {
-	return {
-		1.0, 0.0, 0.0,
-		0.0, 1.0, 0.0,
-		0.0, 0.0, 1.0
-	};
-}
-
-IR3 morphism_cartesian::to_covariant(const IR3 &A, const IR3 &q) const {
-	return A;
-}
-IR3 morphism_cartesian::to_contravariant(const IR3 &A, const IR3 &q) const {
-	return A;
-}
-IR3 morphism_cartesian::from_covariant(const IR3 &A, const IR3 &q) const {
-	return A;
-}
-IR3 morphism_cartesian::from_contravariant(const IR3 &A, const IR3 &q) const {
-	return A;
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism_cartesian.cc
+++ b/gyronimo/metrics/morphism_cartesian.cc
@@ -35,6 +35,15 @@ IR3 morphism_cartesian::inverse(const IR3 &x) const {
 	return x;
 }
 
+//! Translates the curvilinear position `q` by the cartesian vector `delta`
+/*!
+	Implements the rule:
+	@f$ q^\alpha = Q^\alpha \left( \textbf{X}\left(\right) + \Delta \right) @f$
+*/
+IR3 morphism_cartesian::translation(const IR3 &q, const IR3 &delta) const {
+	return q+delta;
+}
+
 //! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ \textbf{x} @f$.
 /*!
 	Implements the coordinate transformation's first derivatives:

--- a/gyronimo/metrics/morphism_cartesian.cc
+++ b/gyronimo/metrics/morphism_cartesian.cc
@@ -21,21 +21,20 @@
 
 namespace gyronimo {
 
-morphism_cartesian::morphism_cartesian(double Lref) 
-	: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {
-	
+morphism_cartesian::morphism_cartesian() 
+	: morphism() {
 }
 IR3 morphism_cartesian::operator()(const IR3 &q) const {
-	return {Lref_*q[IR3::u], Lref_*q[IR3::v], Lref_*q[IR3::w]};
+	return {q[IR3::u], q[IR3::v], q[IR3::w]};
 }
 IR3 morphism_cartesian::inverse(const IR3 &x) const {
-	return {iLref_*x[IR3::u], iLref_*x[IR3::v], iLref_*x[IR3::w]};
+	return {x[IR3::u], x[IR3::v], x[IR3::w]};
 }
 dIR3 morphism_cartesian::del(const IR3 &q) const {
 	return {
-		Lref_, 0.0, 0.0,
-		0.0, Lref_, 0.0,
-		0.0, 0.0, Lref_
+		1.0, 0.0, 0.0,
+		0.0, 1.0, 0.0,
+		0.0, 0.0, 1.0
 	};
 }
 ddIR3 morphism_cartesian::ddel(const IR3 &q) const {
@@ -46,25 +45,25 @@ ddIR3 morphism_cartesian::ddel(const IR3 &q) const {
 	};
 }
 double morphism_cartesian::jacobian(const IR3 &q) const {
-	return Lref_3_;
+	return 1.0;
 }
 dIR3 morphism_cartesian::del_inverse(const IR3 &q) const {
 	return {
-		iLref_, 0.0, 0.0,
-		0.0, iLref_, 0.0,
-		0.0, 0.0, iLref_
+		1.0, 0.0, 0.0,
+		0.0, 1.0, 0.0,
+		0.0, 0.0, 1.0
 	};
 }
-IR3 morphism_cartesian::to_covariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism_cartesian::to_covariant(const IR3 &A, const IR3 &q) const {
 	return A;
 }
-IR3 morphism_cartesian::to_contravariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism_cartesian::to_contravariant(const IR3 &A, const IR3 &q) const {
 	return A;
 }
-IR3 morphism_cartesian::from_covariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism_cartesian::from_covariant(const IR3 &A, const IR3 &q) const {
 	return A;
 }
-IR3 morphism_cartesian::from_contravariant(const IR3 &q, const IR3 &A) const {
+IR3 morphism_cartesian::from_contravariant(const IR3 &A, const IR3 &q) const {
 	return A;
 }
 

--- a/gyronimo/metrics/morphism_cartesian.cc
+++ b/gyronimo/metrics/morphism_cartesian.cc
@@ -1,0 +1,71 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_cartesian.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/metrics/morphism_cartesian.hh>
+
+namespace gyronimo {
+
+morphism_cartesian::morphism_cartesian(double Lref) 
+	: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {
+	
+}
+IR3 morphism_cartesian::operator()(const IR3 &q) const {
+	return {Lref_*q[IR3::u], Lref_*q[IR3::v], Lref_*q[IR3::w]};
+}
+IR3 morphism_cartesian::inverse(const IR3 &x) const {
+	return {iLref_*x[IR3::u], iLref_*x[IR3::v], iLref_*x[IR3::w]};
+}
+dIR3 morphism_cartesian::del(const IR3 &q) const {
+	return {
+		Lref_, 0.0, 0.0,
+		0.0, Lref_, 0.0,
+		0.0, 0.0, Lref_
+	};
+}
+ddIR3 morphism_cartesian::ddel(const IR3 &q) const {
+	return {
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+	};
+}
+double morphism_cartesian::jacobian(const IR3 &q) const {
+	return Lref_3_;
+}
+dIR3 morphism_cartesian::del_inverse(const IR3 &q) const {
+	return {
+		iLref_, 0.0, 0.0,
+		0.0, iLref_, 0.0,
+		0.0, 0.0, iLref_
+	};
+}
+IR3 morphism_cartesian::to_covariant(const IR3 &q, const IR3 &A) const {
+	return A;
+}
+IR3 morphism_cartesian::to_contravariant(const IR3 &q, const IR3 &A) const {
+	return A;
+}
+IR3 morphism_cartesian::from_covariant(const IR3 &q, const IR3 &A) const {
+	return A;
+}
+IR3 morphism_cartesian::from_contravariant(const IR3 &q, const IR3 &A) const {
+	return A;
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/morphism_cartesian.cc
+++ b/gyronimo/metrics/morphism_cartesian.cc
@@ -24,12 +24,28 @@ namespace gyronimo {
 morphism_cartesian::morphism_cartesian() 
 	: morphism() {
 }
+
+//! Cartesian coordinates map identity transformation @f$ \left( q^1, q^2, q^3 \right) = \left( x, y, z \right) @f$.
 IR3 morphism_cartesian::operator()(const IR3 &q) const {
-	return {q[IR3::u], q[IR3::v], q[IR3::w]};
+	return q;
 }
+
+//! Inverse map is identity transformation.
 IR3 morphism_cartesian::inverse(const IR3 &x) const {
-	return {x[IR3::u], x[IR3::v], x[IR3::w]};
+	return x;
 }
+
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ \textbf{x} @f$.
+/*!
+	Implements the coordinate transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}_x &= \left( 1,0,0 \right) \\
+			\textbf{e}_y &= \left( 0,1,0 \right) \\
+			\textbf{e}_Z &= \left( 0,0,1 \right)
+		\end{aligned}
+    @f}
+*/
 dIR3 morphism_cartesian::del(const IR3 &q) const {
 	return {
 		1.0, 0.0, 0.0,
@@ -37,6 +53,8 @@ dIR3 morphism_cartesian::del(const IR3 &q) const {
 		0.0, 0.0, 1.0
 	};
 }
+
+//! Returns the morphism's second derivatives, calculated in point @f$ \textbf{x} @f$.
 ddIR3 morphism_cartesian::ddel(const IR3 &q) const {
 	return {
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -44,9 +62,27 @@ ddIR3 morphism_cartesian::ddel(const IR3 &q) const {
 		0.0, 0.0, 0.0, 0.0, 0.0, 0.0
 	};
 }
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ \textbf{x} @f$.
+/*!
+	Implements the Jacobian in cartesian coordinates: 
+	@f$ J = 1 @f$
+*/
 double morphism_cartesian::jacobian(const IR3 &q) const {
 	return 1.0;
 }
+
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ \textbf{x} @f$.
+/*!
+	Implements the inverse transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}^x &= \left( 1,0,0 \right) \\
+			\textbf{e}^y &= \left( 0,1,0 \right) \\
+			\textbf{e}^Z &= \left( 0,0,1 \right)
+		\end{aligned}
+    @f}
+*/
 dIR3 morphism_cartesian::del_inverse(const IR3 &q) const {
 	return {
 		1.0, 0.0, 0.0,
@@ -54,6 +90,7 @@ dIR3 morphism_cartesian::del_inverse(const IR3 &q) const {
 		0.0, 0.0, 1.0
 	};
 }
+
 IR3 morphism_cartesian::to_covariant(const IR3 &A, const IR3 &q) const {
 	return A;
 }

--- a/gyronimo/metrics/morphism_cartesian.hh
+++ b/gyronimo/metrics/morphism_cartesian.hh
@@ -1,0 +1,53 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_cartesian.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_MORPHISM_CARTESIAN
+#define GYRONIMO_MORPHISM_CARTESIAN
+
+#include <gyronimo/metrics/morphism.hh>
+
+namespace gyronimo {
+
+class morphism_cartesian : public morphism {
+public:
+	morphism_cartesian(double Lref);
+	virtual ~morphism_cartesian() override {};
+
+	virtual IR3 operator()(const IR3 &q) const override;
+	virtual IR3 inverse(const IR3 &x) const override;
+	virtual dIR3 del(const IR3 &q) const override;
+	virtual ddIR3 ddel(const IR3 &q) const override;
+
+	virtual double jacobian(const IR3 &q) const override;
+	virtual dIR3 del_inverse(const IR3 &q) const override;
+
+	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const override;
+	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const override;
+	virtual IR3 from_covariant(const IR3 &q, const IR3 &A) const override;
+	virtual IR3 from_contravariant(const IR3 &q, const IR3 &A) const override;
+
+	double Lref() const {return Lref_;};
+
+private:
+	double Lref_, iLref_, Lref_3_;
+};
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_MORPHISM_CARTESIAN

--- a/gyronimo/metrics/morphism_cartesian.hh
+++ b/gyronimo/metrics/morphism_cartesian.hh
@@ -31,6 +31,7 @@ public:
 
 	virtual IR3 operator()(const IR3 &q) const override;
 	virtual IR3 inverse(const IR3 &x) const override;
+	virtual IR3 translation(const IR3 &q, const IR3 &delta) const override;
 	virtual dIR3 del(const IR3 &q) const override;
 	virtual ddIR3 ddel(const IR3 &q) const override;
 

--- a/gyronimo/metrics/morphism_cartesian.hh
+++ b/gyronimo/metrics/morphism_cartesian.hh
@@ -26,7 +26,7 @@ namespace gyronimo {
 
 class morphism_cartesian : public morphism {
 public:
-	morphism_cartesian(double Lref);
+	morphism_cartesian();
 	virtual ~morphism_cartesian() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
@@ -37,15 +37,12 @@ public:
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
-	virtual IR3 to_covariant(const IR3 &q, const IR3 &A) const override;
-	virtual IR3 to_contravariant(const IR3 &q, const IR3 &A) const override;
-	virtual IR3 from_covariant(const IR3 &q, const IR3 &A) const override;
-	virtual IR3 from_contravariant(const IR3 &q, const IR3 &A) const override;
-
-	double Lref() const {return Lref_;};
+	virtual IR3 to_covariant(const IR3 &A, const IR3 &q) const override;
+	virtual IR3 to_contravariant(const IR3 &A, const IR3 &q) const override;
+	virtual IR3 from_covariant(const IR3 &A, const IR3 &q) const override;
+	virtual IR3 from_contravariant(const IR3 &A, const IR3 &q) const override;
 
 private:
-	double Lref_, iLref_, Lref_3_;
 };
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/morphism_cartesian.hh
+++ b/gyronimo/metrics/morphism_cartesian.hh
@@ -25,27 +25,24 @@
 namespace gyronimo {
 
 class morphism_cartesian : public morphism {
-public:
-	morphism_cartesian();
-	virtual ~morphism_cartesian() override {};
+ public:
+  morphism_cartesian() : morphism() {};
+  virtual ~morphism_cartesian() override {};
 
-	virtual IR3 operator()(const IR3 &q) const override;
-	virtual IR3 inverse(const IR3 &x) const override;
-	virtual IR3 translation(const IR3 &q, const IR3 &delta) const override;
-	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 ddel(const IR3 &q) const override;
+  virtual IR3 operator()(const IR3& q) const override;
+  virtual IR3 inverse(const IR3& x) const override;
+  virtual dIR3 del(const IR3& q) const override;
+  virtual ddIR3 ddel(const IR3& q) const override;
 
-	virtual double jacobian(const IR3 &q) const override;
-	virtual dIR3 del_inverse(const IR3 &q) const override;
-
-	virtual IR3 to_covariant(const IR3 &A, const IR3 &q) const override;
-	virtual IR3 to_contravariant(const IR3 &A, const IR3 &q) const override;
-	virtual IR3 from_covariant(const IR3 &A, const IR3 &q) const override;
-	virtual IR3 from_contravariant(const IR3 &A, const IR3 &q) const override;
-
-private:
+  virtual double jacobian(const IR3& q) const override;
+  virtual dIR3 del_inverse(const IR3& q) const override;
+  virtual IR3 to_covariant(const IR3& A, const IR3& q) const override;
+  virtual IR3 to_contravariant(const IR3& A, const IR3& q) const override;
+  virtual IR3 from_covariant(const IR3& A, const IR3& q) const override;
+  virtual IR3 from_contravariant(const IR3& A, const IR3& q) const override;
+  virtual IR3 translation(const IR3& q, const IR3& delta) const override;
 };
 
-} // end namespace gyronimo
+}  // end namespace gyronimo
 
-#endif // GYRONIMO_MORPHISM_CARTESIAN
+#endif  // GYRONIMO_MORPHISM_CARTESIAN

--- a/gyronimo/metrics/morphism_cylindrical.cc
+++ b/gyronimo/metrics/morphism_cylindrical.cc
@@ -21,18 +21,49 @@
 
 namespace gyronimo {
 
-//! Maps the curvilinear coordinates `q = (r, \phi, z)` into cartesian coordinates `x`.
+//! Maps cylindrical coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
+/*!
+	In cylindrical coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( r, \phi, z \right) @f$.
+	Implements the coordinate transformation:
+	@f{gather*}{
+		\begin{aligned}
+			x &= r \, \cos \phi \\
+			y &= r \, \sin \phi \\
+			z &= z
+		\end{aligned}
+    @f}
+*/
 IR3 morphism_cylindrical::operator()(const IR3 &q) const {
 	return {q[IR3::u] * std::cos(q[IR3::v]), q[IR3::u] * std::sin(q[IR3::v]), q[IR3::w]};
 }
 
-//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into cylindrical coordinates @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation:
+	@f{gather*}{
+		\begin{aligned}
+			r &= \sqrt{x^2 + y^2} \\
+			\phi &= \arctan \left( \frac{y}{x} \right) \\
+			z &= z
+		\end{aligned}
+    @f}
+*/
 IR3 morphism_cylindrical::inverse(const IR3 &x) const {
 	return {sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
 			atan2(x[IR3::v], x[IR3::u]), x[IR3::w]};
 }
 
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the coordinate transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}_r &= \left( \cos \phi, \sin \phi, 0 \right) \\
+			\textbf{e}_\phi &= \left( -r \, \sin \phi, r \, \cos \phi, 0 \right) \\
+			\textbf{e}_z &= \left( 0, 0, 1 \right)
+		\end{aligned}
+    @f}
+*/
 dIR3 morphism_cylindrical::del(const IR3 &q) const {
 	double sn = sin(q[IR3::v]);
 	double cn = cos(q[IR3::v]);
@@ -44,12 +75,39 @@ dIR3 morphism_cylindrical::del(const IR3 &q) const {
 	};
 }
 
-//! General-purpose implementation of the Jacobian of the transformation in point `q`.
+//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
+ddIR3 morphism_cylindrical::del2(const IR3 &q) const {
+	double r = q[IR3::u];
+	double sn = sin(q[IR3::v]);
+	double cn = cos(q[IR3::v]);
+	return {
+	// iuu iuv iuw   ivv  ivw  iww
+		0, -sn, 0, -r * cn, 0, 0,
+		0,  cn, 0, -r * sn, 0, 0,
+		0,   0, 0,		 0, 0, 0
+	};
+}
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian in spherical coordinates: 
+	@f$ J = r @f$
+*/
 double morphism_cylindrical::jacobian(const IR3 &q) const {
 	return q[IR3::u];
 }
 
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}^r &= \left( \cos \phi, \sin \phi, 0 \right) \\
+			\textbf{e}^\phi &= \left( -\frac{1}{r} \, \sin \phi, \frac{1}{r} \, \cos \phi, 0 \right) \\
+			\textbf{e}^z &= \left( 0, 0, 1 \right)
+		\end{aligned}
+    @f}
+*/
 dIR3 morphism_cylindrical::del_inverse(const IR3 &q) const {
 	double sn = sin(q[IR3::v]);
 	double cn = cos(q[IR3::v]);

--- a/gyronimo/metrics/morphism_cylindrical.cc
+++ b/gyronimo/metrics/morphism_cylindrical.cc
@@ -1,0 +1,57 @@
+#include <gyronimo/metrics/morphism_cylindrical.hh>
+
+namespace gyronimo {
+
+// Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+IR3 morphism_cylindrical::operator()(const IR3 &q) const {
+	return {q[IR3::u] * cos(q[IR3::v]), q[IR3::u] * sin(q[IR3::v]), q[IR3::w]};
+}
+
+// Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+IR3 morphism_cylindrical::inverse(const IR3 &x) const {
+	return {sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
+			atan2(x[IR3::v], x[IR3::u]), x[IR3::w]};
+}
+
+// Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+dIR3 morphism_cylindrical::del(const IR3 &q) const {
+	double sn = sin(q[IR3::v]);
+	double cn = cos(q[IR3::v]);
+	double r  = q[IR3::u];
+	return {
+		cn, - r * sn, 0,
+		sn,   r * cn, 0,
+		0, 		0, 	  1
+	};
+}
+
+dSM3 morphism_cylindrical::g_del(const IR3 &q) const {
+	double r  = q[IR3::u];
+	return {
+		0, 0, 0, // g_uu
+		0, 0, 0, // g_uv
+		0, 0, 0, // g_uw
+		2 * r, 0, 0, // g_vv
+		0, 0, 0, // g_vw
+		0, 0, 0  // g_ww
+	};
+}
+
+// Returns the jacobian of the transformation in point `q`.
+double morphism_cylindrical::jacobian(const IR3 &q) const {
+	return q[IR3::u];
+}
+
+// Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+dIR3 morphism_cylindrical::del_inverse(const IR3 &q) const {
+	double sn = sin(q[IR3::v]);
+	double cn = cos(q[IR3::v]);
+	double ir = 1 / q[IR3::u];
+	return {
+		cn, sn, 0,
+		-sn * ir,  cn * ir, 0,
+		0,	0   , 1
+	};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/morphism_cylindrical.cc
+++ b/gyronimo/metrics/morphism_cylindrical.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,24 +17,27 @@
 
 // @morphism_cylindrical.cc, this file is part of ::gyronimo::
 
+#include <cmath>
 #include <gyronimo/metrics/morphism_cylindrical.hh>
 
 namespace gyronimo {
 
 //! Maps cylindrical coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
 /*!
-	In cylindrical coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( r, \phi, z \right) @f$.
+	In cylindrical coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( R, \phi, Z \right) @f$.
 	Implements the coordinate transformation:
 	@f{gather*}{
 		\begin{aligned}
-			x &= r \, \cos \phi \\
-			y &= r \, \sin \phi \\
-			z &= z
+			x &= L_0 \, R \, \cos \phi \\
+			y &= L_0 \, R \, \sin \phi \\
+			z &= L_0 \, Z
 		\end{aligned}
     @f}
 */
 IR3 morphism_cylindrical::operator()(const IR3 &q) const {
-	return {q[IR3::u] * std::cos(q[IR3::v]), q[IR3::u] * std::sin(q[IR3::v]), q[IR3::w]};
+	return {L0_ * q[IR3::u] * std::cos(q[IR3::v]), 
+			L0_ * q[IR3::u] * std::sin(q[IR3::v]), 
+			L0_ * q[IR3::w]};
 }
 
 //! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into cylindrical coordinates @f$ q^\alpha @f$.
@@ -42,15 +45,16 @@ IR3 morphism_cylindrical::operator()(const IR3 &q) const {
 	Implements the inverse transformation:
 	@f{gather*}{
 		\begin{aligned}
-			r &= \sqrt{x^2 + y^2} \\
+			R &= \frac{1}{L_0} \sqrt{x^2 + y^2} \\
 			\phi &= \arctan \left( \frac{y}{x} \right) \\
-			z &= z
+			Z &= \frac{z}{L_0}
 		\end{aligned}
     @f}
 */
 IR3 morphism_cylindrical::inverse(const IR3 &x) const {
-	return {sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
-			atan2(x[IR3::v], x[IR3::u]), x[IR3::w]};
+	return {iL0_ * std::sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
+			std::atan2(x[IR3::v], x[IR3::u]), 
+			iL0_ * x[IR3::w]};
 }
 
 //! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
@@ -58,28 +62,28 @@ IR3 morphism_cylindrical::inverse(const IR3 &x) const {
 	Implements the coordinate transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}_r &= \left( \cos \phi, \sin \phi, 0 \right) \\
-			\textbf{e}_\phi &= \left( -r \, \sin \phi, r \, \cos \phi, 0 \right) \\
-			\textbf{e}_z &= \left( 0, 0, 1 \right)
+			\textbf{e}_R &= \left( L_0 \, \cos \phi, L_0 \, \sin \phi, 0 \right) \\
+			\textbf{e}_\phi &= \left( -L_0 \, R \, \sin \phi, L_0 \, R \, \cos \phi, 0 \right) \\
+			\textbf{e}_Z &= \left( 0, 0, L_0 \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_cylindrical::del(const IR3 &q) const {
-	double sn = sin(q[IR3::v]);
-	double cn = cos(q[IR3::v]);
+	double sn = L0_ * std::sin(q[IR3::v]);
+	double cn = L0_ * std::cos(q[IR3::v]);
 	double r  = q[IR3::u];
 	return {
 		cn, - r * sn, 0,
 		sn,   r * cn, 0,
-		0, 		0, 	  1
+		0, 		0, 	 L0_
 	};
 }
 
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_cylindrical::del2(const IR3 &q) const {
+ddIR3 morphism_cylindrical::ddel(const IR3 &q) const {
 	double r = q[IR3::u];
-	double sn = sin(q[IR3::v]);
-	double cn = cos(q[IR3::v]);
+	double sn = L0_ * std::sin(q[IR3::v]);
+	double cn = L0_ * std::cos(q[IR3::v]);
 	return {
 	// iuu iuv iuw   ivv  ivw  iww
 		0, -sn, 0, -r * cn, 0, 0,
@@ -91,10 +95,10 @@ ddIR3 morphism_cylindrical::del2(const IR3 &q) const {
 //! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
 /*!
 	Implements the Jacobian in spherical coordinates: 
-	@f$ J = r @f$
+	@f$ J = {L_0}^3 \, R @f$
 */
 double morphism_cylindrical::jacobian(const IR3 &q) const {
-	return q[IR3::u];
+	return L0_3_ * q[IR3::u];
 }
 
 //! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
@@ -102,20 +106,20 @@ double morphism_cylindrical::jacobian(const IR3 &q) const {
 	Implements the inverse transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}^r &= \left( \cos \phi, \sin \phi, 0 \right) \\
-			\textbf{e}^\phi &= \left( -\frac{1}{r} \, \sin \phi, \frac{1}{r} \, \cos \phi, 0 \right) \\
-			\textbf{e}^z &= \left( 0, 0, 1 \right)
+			\textbf{e}^R &= \left( \frac{1}{L_0} \, \cos \phi, \frac{1}{L_0} \, \sin \phi, 0 \right) \\
+			\textbf{e}^\phi &= \left( -\frac{1}{L_0 \, r} \, \sin \phi, \frac{1}{L_0 \, r} \, \cos \phi, 0 \right) \\
+			\textbf{e}^Z &= \left( 0, 0, \frac{1}{L_0} \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_cylindrical::del_inverse(const IR3 &q) const {
-	double sn = sin(q[IR3::v]);
-	double cn = cos(q[IR3::v]);
+	double sn = iL0_ * std::sin(q[IR3::v]);
+	double cn = iL0_ * std::cos(q[IR3::v]);
 	double ir = 1 / q[IR3::u];
 	return {
 		cn, sn, 0,
 		-sn * ir,  cn * ir, 0,
-		0,	0   , 1
+		0,	0, iL0_
 	};
 }
 

--- a/gyronimo/metrics/morphism_cylindrical.cc
+++ b/gyronimo/metrics/morphism_cylindrical.cc
@@ -28,16 +28,16 @@ namespace gyronimo {
 	Implements the coordinate transformation:
 	@f{gather*}{
 		\begin{aligned}
-			x &= L_0 \, R \, \cos \phi \\
-			y &= L_0 \, R \, \sin \phi \\
-			z &= L_0 \, Z
+			x &= L_{ref} \, R \, \cos \phi \\
+			y &= L_{ref} \, R \, \sin \phi \\
+			z &= L_{ref} \, Z
 		\end{aligned}
     @f}
 */
 IR3 morphism_cylindrical::operator()(const IR3 &q) const {
-	return {L0_ * q[IR3::u] * std::cos(q[IR3::v]), 
-			L0_ * q[IR3::u] * std::sin(q[IR3::v]), 
-			L0_ * q[IR3::w]};
+	return {Lref_ * q[IR3::u] * std::cos(q[IR3::v]), 
+			Lref_ * q[IR3::u] * std::sin(q[IR3::v]), 
+			Lref_ * q[IR3::w]};
 }
 
 //! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into cylindrical coordinates @f$ q^\alpha @f$.
@@ -45,16 +45,16 @@ IR3 morphism_cylindrical::operator()(const IR3 &q) const {
 	Implements the inverse transformation:
 	@f{gather*}{
 		\begin{aligned}
-			R &= \frac{1}{L_0} \sqrt{x^2 + y^2} \\
+			R &= \frac{1}{L_{ref}} \sqrt{x^2 + y^2} \\
 			\phi &= \arctan \left( \frac{y}{x} \right) \\
-			Z &= \frac{z}{L_0}
+			Z &= \frac{z}{L_{ref}}
 		\end{aligned}
     @f}
 */
 IR3 morphism_cylindrical::inverse(const IR3 &x) const {
-	return {iL0_ * std::sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
+	return {iLref_ * std::sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
 			std::atan2(x[IR3::v], x[IR3::u]), 
-			iL0_ * x[IR3::w]};
+			iLref_ * x[IR3::w]};
 }
 
 //! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
@@ -62,28 +62,28 @@ IR3 morphism_cylindrical::inverse(const IR3 &x) const {
 	Implements the coordinate transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}_R &= \left( L_0 \, \cos \phi, L_0 \, \sin \phi, 0 \right) \\
-			\textbf{e}_\phi &= \left( -L_0 \, R \, \sin \phi, L_0 \, R \, \cos \phi, 0 \right) \\
-			\textbf{e}_Z &= \left( 0, 0, L_0 \right)
+			\textbf{e}_R &= \left( L_{ref} \, \cos \phi, L_{ref} \, \sin \phi, 0 \right) \\
+			\textbf{e}_\phi &= \left( -L_{ref} \, R \, \sin \phi, L_{ref} \, R \, \cos \phi, 0 \right) \\
+			\textbf{e}_Z &= \left( 0, 0, L_{ref} \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_cylindrical::del(const IR3 &q) const {
-	double sn = L0_ * std::sin(q[IR3::v]);
-	double cn = L0_ * std::cos(q[IR3::v]);
+	double sn = Lref_ * std::sin(q[IR3::v]);
+	double cn = Lref_ * std::cos(q[IR3::v]);
 	double r  = q[IR3::u];
 	return {
 		cn, - r * sn, 0,
 		sn,   r * cn, 0,
-		0, 		0, 	 L0_
+		0, 		0, 	 Lref_
 	};
 }
 
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
 ddIR3 morphism_cylindrical::ddel(const IR3 &q) const {
 	double r = q[IR3::u];
-	double sn = L0_ * std::sin(q[IR3::v]);
-	double cn = L0_ * std::cos(q[IR3::v]);
+	double sn = Lref_ * std::sin(q[IR3::v]);
+	double cn = Lref_ * std::cos(q[IR3::v]);
 	return {
 	// iuu iuv iuw   ivv  ivw  iww
 		0, -sn, 0, -r * cn, 0, 0,
@@ -95,10 +95,10 @@ ddIR3 morphism_cylindrical::ddel(const IR3 &q) const {
 //! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
 /*!
 	Implements the Jacobian in spherical coordinates: 
-	@f$ J = {L_0}^3 \, R @f$
+	@f$ J = {L_{ref}}^3 \, R @f$
 */
 double morphism_cylindrical::jacobian(const IR3 &q) const {
-	return L0_3_ * q[IR3::u];
+	return Lref_3_ * q[IR3::u];
 }
 
 //! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
@@ -106,20 +106,20 @@ double morphism_cylindrical::jacobian(const IR3 &q) const {
 	Implements the inverse transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}^R &= \left( \frac{1}{L_0} \, \cos \phi, \frac{1}{L_0} \, \sin \phi, 0 \right) \\
-			\textbf{e}^\phi &= \left( -\frac{1}{L_0 \, r} \, \sin \phi, \frac{1}{L_0 \, r} \, \cos \phi, 0 \right) \\
-			\textbf{e}^Z &= \left( 0, 0, \frac{1}{L_0} \right)
+			\textbf{e}^R &= \left( \frac{1}{L_{ref}} \, \cos \phi, \frac{1}{L_{ref}} \, \sin \phi, 0 \right) \\
+			\textbf{e}^\phi &= \left( -\frac{1}{L_{ref} \, r} \, \sin \phi, \frac{1}{L_{ref} \, r} \, \cos \phi, 0 \right) \\
+			\textbf{e}^Z &= \left( 0, 0, \frac{1}{L_{ref}} \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_cylindrical::del_inverse(const IR3 &q) const {
-	double sn = iL0_ * std::sin(q[IR3::v]);
-	double cn = iL0_ * std::cos(q[IR3::v]);
+	double sn = iLref_ * std::sin(q[IR3::v]);
+	double cn = iLref_ * std::cos(q[IR3::v]);
 	double ir = 1 / q[IR3::u];
 	return {
 		cn, sn, 0,
 		-sn * ir,  cn * ir, 0,
-		0,	0, iL0_
+		0,	0, iLref_
 	};
 }
 

--- a/gyronimo/metrics/morphism_cylindrical.cc
+++ b/gyronimo/metrics/morphism_cylindrical.cc
@@ -17,110 +17,44 @@
 
 // @morphism_cylindrical.cc, this file is part of ::gyronimo::
 
-#include <cmath>
 #include <gyronimo/metrics/morphism_cylindrical.hh>
+
+#include <cmath>
 
 namespace gyronimo {
 
-//! Maps cylindrical coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
-/*!
-	In cylindrical coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( R, \phi, Z \right) @f$.
-	Implements the coordinate transformation:
-	@f{gather*}{
-		\begin{aligned}
-			x &= L_{ref} \, R \, \cos \phi \\
-			y &= L_{ref} \, R \, \sin \phi \\
-			z &= L_{ref} \, Z
-		\end{aligned}
-    @f}
-*/
-IR3 morphism_cylindrical::operator()(const IR3 &q) const {
-	return {Lref_ * q[IR3::u] * std::cos(q[IR3::v]), 
-			Lref_ * q[IR3::u] * std::sin(q[IR3::v]), 
-			Lref_ * q[IR3::w]};
+IR3 morphism_cylindrical::operator()(const IR3& q) const {
+  return {
+      Lref_ * q[IR3::u] * std::cos(q[IR3::v]),
+      Lref_ * q[IR3::u] * std::sin(q[IR3::v]), Lref_ * q[IR3::w]};
+}
+IR3 morphism_cylindrical::inverse(const IR3& x) const {
+  return {
+      iLref_ * std::sqrt(x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v]),
+      std::atan2(x[IR3::v], x[IR3::u]), iLref_ * x[IR3::w]};
+}
+dIR3 morphism_cylindrical::del(const IR3& q) const {
+  double Lref_sn = Lref_ * std::sin(q[IR3::v]);
+  double Lref_cn = Lref_ * std::cos(q[IR3::v]);
+  double r = q[IR3::u];
+  return {Lref_cn, -r * Lref_sn, 0, Lref_sn, r * Lref_cn, 0, 0, 0, Lref_};
+}
+ddIR3 morphism_cylindrical::ddel(const IR3& q) const {
+  double r = q[IR3::u];
+  double Lref_sn = Lref_ * std::sin(q[IR3::v]);
+  double Lref_cn = Lref_ * std::cos(q[IR3::v]);
+  return {0, -Lref_sn, 0, -r * Lref_cn, 0, 0,
+          0, Lref_cn, 0, -r * Lref_sn, 0, 0, 0, 0, 0, 0, 0, 0};
+}
+double morphism_cylindrical::jacobian(const IR3& q) const {
+  return Lref3_ * q[IR3::u];
+}
+dIR3 morphism_cylindrical::del_inverse(const IR3& q) const {
+  double iLref_sn = iLref_ * std::sin(q[IR3::v]);
+  double iLref_cn = iLref_ * std::cos(q[IR3::v]);
+  double ir = 1 / q[IR3::u];
+  return {
+      iLref_cn, iLref_sn, 0, -iLref_sn * ir, iLref_cn * ir, 0, 0, 0, iLref_};
 }
 
-//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into cylindrical coordinates @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation:
-	@f{gather*}{
-		\begin{aligned}
-			R &= \frac{1}{L_{ref}} \sqrt{x^2 + y^2} \\
-			\phi &= \arctan \left( \frac{y}{x} \right) \\
-			Z &= \frac{z}{L_{ref}}
-		\end{aligned}
-    @f}
-*/
-IR3 morphism_cylindrical::inverse(const IR3 &x) const {
-	return {iLref_ * std::sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
-			std::atan2(x[IR3::v], x[IR3::u]), 
-			iLref_ * x[IR3::w]};
-}
-
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the coordinate transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}_R &= \left( L_{ref} \, \cos \phi, L_{ref} \, \sin \phi, 0 \right) \\
-			\textbf{e}_\phi &= \left( -L_{ref} \, R \, \sin \phi, L_{ref} \, R \, \cos \phi, 0 \right) \\
-			\textbf{e}_Z &= \left( 0, 0, L_{ref} \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_cylindrical::del(const IR3 &q) const {
-	double sn = Lref_ * std::sin(q[IR3::v]);
-	double cn = Lref_ * std::cos(q[IR3::v]);
-	double r  = q[IR3::u];
-	return {
-		cn, - r * sn, 0,
-		sn,   r * cn, 0,
-		0, 		0, 	 Lref_
-	};
-}
-
-//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_cylindrical::ddel(const IR3 &q) const {
-	double r = q[IR3::u];
-	double sn = Lref_ * std::sin(q[IR3::v]);
-	double cn = Lref_ * std::cos(q[IR3::v]);
-	return {
-	// iuu iuv iuw   ivv  ivw  iww
-		0, -sn, 0, -r * cn, 0, 0,
-		0,  cn, 0, -r * sn, 0, 0,
-		0,   0, 0,		 0, 0, 0
-	};
-}
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian in cylindrical coordinates: 
-	@f$ J = {L_{ref}}^3 \, R @f$
-*/
-double morphism_cylindrical::jacobian(const IR3 &q) const {
-	return Lref_3_ * q[IR3::u];
-}
-
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}^R &= \left( \frac{1}{L_{ref}} \, \cos \phi, \frac{1}{L_{ref}} \, \sin \phi, 0 \right) \\
-			\textbf{e}^\phi &= \left( -\frac{1}{L_{ref} \, r} \, \sin \phi, \frac{1}{L_{ref} \, r} \, \cos \phi, 0 \right) \\
-			\textbf{e}^Z &= \left( 0, 0, \frac{1}{L_{ref}} \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_cylindrical::del_inverse(const IR3 &q) const {
-	double sn = iLref_ * std::sin(q[IR3::v]);
-	double cn = iLref_ * std::cos(q[IR3::v]);
-	double ir = 1 / q[IR3::u];
-	return {
-		cn, sn, 0,
-		-sn * ir,  cn * ir, 0,
-		0,	0, iLref_
-	};
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism_cylindrical.cc
+++ b/gyronimo/metrics/morphism_cylindrical.cc
@@ -1,19 +1,38 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_cylindrical.cc, this file is part of ::gyronimo::
+
 #include <gyronimo/metrics/morphism_cylindrical.hh>
 
 namespace gyronimo {
 
-// Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+//! Maps the curvilinear coordinates `q = (r, \phi, z)` into cartesian coordinates `x`.
 IR3 morphism_cylindrical::operator()(const IR3 &q) const {
-	return {q[IR3::u] * cos(q[IR3::v]), q[IR3::u] * sin(q[IR3::v]), q[IR3::w]};
+	return {q[IR3::u] * std::cos(q[IR3::v]), q[IR3::u] * std::sin(q[IR3::v]), q[IR3::w]};
 }
 
-// Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
 IR3 morphism_cylindrical::inverse(const IR3 &x) const {
 	return {sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]),
 			atan2(x[IR3::v], x[IR3::u]), x[IR3::w]};
 }
 
-// Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
 dIR3 morphism_cylindrical::del(const IR3 &q) const {
 	double sn = sin(q[IR3::v]);
 	double cn = cos(q[IR3::v]);
@@ -25,24 +44,12 @@ dIR3 morphism_cylindrical::del(const IR3 &q) const {
 	};
 }
 
-dSM3 morphism_cylindrical::g_del(const IR3 &q) const {
-	double r  = q[IR3::u];
-	return {
-		0, 0, 0, // g_uu
-		0, 0, 0, // g_uv
-		0, 0, 0, // g_uw
-		2 * r, 0, 0, // g_vv
-		0, 0, 0, // g_vw
-		0, 0, 0  // g_ww
-	};
-}
-
-// Returns the jacobian of the transformation in point `q`.
+//! General-purpose implementation of the Jacobian of the transformation in point `q`.
 double morphism_cylindrical::jacobian(const IR3 &q) const {
 	return q[IR3::u];
 }
 
-// Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
 dIR3 morphism_cylindrical::del_inverse(const IR3 &q) const {
 	double sn = sin(q[IR3::v]);
 	double cn = cos(q[IR3::v]);

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -28,8 +28,8 @@ class morphism_cylindrical : public morphism {
 
 public:
 
-	morphism_cylindrical(const double &L0) 
-		: morphism(), L0_(L0), iL0_(1/L0), L0_3_(L0*L0*L0) {};
+	morphism_cylindrical(const double &Lref) 
+		: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {};
 	virtual ~morphism_cylindrical() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
@@ -41,7 +41,7 @@ public:
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
 private:
-	const double L0_, iL0_, L0_3_;
+	const double Lref_, iLref_, Lref_3_;
 
 }; // end class morphism_cylindrical
 

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -1,0 +1,42 @@
+#ifndef GYRONIMO_MORPHISM_CYLINDRICAL
+#define GYRONIMO_MORPHISM_CYLINDRICAL
+
+#include <cmath>
+
+#include <gyronimo/metrics/morphism.hh>
+
+namespace gyronimo {
+
+class morphism_cylindrical : public morphism {
+
+public:
+
+	//! Class Constructor
+	morphism_cylindrical() : morphism() {};
+
+	//! Class Destructor
+	~morphism_cylindrical() {};
+
+	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+	IR3 operator()(const IR3 &q) const override;
+
+	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+	IR3 inverse(const IR3 &x) const override;
+
+	//! Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+	dIR3 del(const IR3 &q) const override;
+	dSM3 g_del(const IR3 &q) const override;
+
+	//! Returns the jacobian of the transformation in point `q`.
+	double jacobian(const IR3 &q) const override;
+
+	//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+	dIR3 del_inverse(const IR3 &q) const override;
+
+private:
+
+}; // end class morphism_cylindrical
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_MORPHISM_CYLINDRICAL

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -1,3 +1,22 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_cylindrical.hh, this file is part of ::gyronimo::
+
 #ifndef GYRONIMO_MORPHISM_CYLINDRICAL
 #define GYRONIMO_MORPHISM_CYLINDRICAL
 
@@ -11,27 +30,15 @@ class morphism_cylindrical : public morphism {
 
 public:
 
-	//! Class Constructor
 	morphism_cylindrical() : morphism() {};
+	virtual ~morphism_cylindrical() override {};
 
-	//! Class Destructor
-	~morphism_cylindrical() {};
+	virtual IR3 operator()(const IR3 &q) const override;
+	virtual IR3 inverse(const IR3 &x) const override;
+	virtual dIR3 del(const IR3 &q) const override;
 
-	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
-	IR3 operator()(const IR3 &q) const override;
-
-	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
-	IR3 inverse(const IR3 &x) const override;
-
-	//! Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
-	dIR3 del(const IR3 &q) const override;
-	dSM3 g_del(const IR3 &q) const override;
-
-	//! Returns the jacobian of the transformation in point `q`.
-	double jacobian(const IR3 &q) const override;
-
-	//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
-	dIR3 del_inverse(const IR3 &q) const override;
+	virtual double jacobian(const IR3 &q) const override;
+	virtual dIR3 del_inverse(const IR3 &q) const override;
 
 private:
 

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,8 +20,6 @@
 #ifndef GYRONIMO_MORPHISM_CYLINDRICAL
 #define GYRONIMO_MORPHISM_CYLINDRICAL
 
-#include <cmath>
-
 #include <gyronimo/metrics/morphism.hh>
 
 namespace gyronimo {
@@ -30,18 +28,20 @@ class morphism_cylindrical : public morphism {
 
 public:
 
-	morphism_cylindrical() : morphism() {};
+	morphism_cylindrical(const double &L0) 
+		: morphism(), L0_(L0), iL0_(1/L0), L0_3_(L0*L0*L0) {};
 	virtual ~morphism_cylindrical() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
 	virtual IR3 inverse(const IR3 &x) const override;
 	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 del2(const IR3 &q) const override;
+	virtual ddIR3 ddel(const IR3 &q) const override;
 
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
 private:
+	const double L0_, iL0_, L0_3_;
 
 }; // end class morphism_cylindrical
 

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -40,6 +40,8 @@ public:
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
+	double L0() const {return L0_;};
+
 private:
 	const double L0_, iL0_, L0_3_;
 

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -36,6 +36,7 @@ public:
 	virtual IR3 operator()(const IR3 &q) const override;
 	virtual IR3 inverse(const IR3 &x) const override;
 	virtual dIR3 del(const IR3 &q) const override;
+	virtual ddIR3 del2(const IR3 &q) const override;
 
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -28,8 +28,8 @@ class morphism_cylindrical : public morphism {
 
 public:
 
-	morphism_cylindrical(const double &L0) 
-		: morphism(), L0_(L0), iL0_(1/L0), L0_3_(L0*L0*L0) {};
+	morphism_cylindrical(const double &Lref) 
+		: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {};
 	virtual ~morphism_cylindrical() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
@@ -40,10 +40,10 @@ public:
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
-	double L0() const {return L0_;};
+	double Lref() const {return Lref_;};
 
 private:
-	const double L0_, iL0_, L0_3_;
+	const double Lref_, iLref_, Lref_3_;
 
 }; // end class morphism_cylindrical
 

--- a/gyronimo/metrics/morphism_cylindrical.hh
+++ b/gyronimo/metrics/morphism_cylindrical.hh
@@ -24,29 +24,33 @@
 
 namespace gyronimo {
 
+//! Morphism for cylindrical coordinates.
+/*!
+    The three contravariant coordinates are the distance to the axis (`u`,
+    normalised to `Lref` in SI units), the angle measured counterclockwise when
+    seen from the top of the axis (`v`), and the length measured along the
+    latter (`w`, normalised also to `Lref`).
+*/
 class morphism_cylindrical : public morphism {
+ public:
+  morphism_cylindrical(const double& Lref)
+      : morphism(), Lref_(Lref), iLref_(1 / Lref),
+        Lref3_(Lref * Lref * Lref) {};
+  virtual ~morphism_cylindrical() override {};
 
-public:
+  virtual IR3 operator()(const IR3& q) const override;
+  virtual IR3 inverse(const IR3& x) const override;
+  virtual dIR3 del(const IR3& q) const override;
+  virtual ddIR3 ddel(const IR3& q) const override;
 
-	morphism_cylindrical(const double &Lref) 
-		: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {};
-	virtual ~morphism_cylindrical() override {};
+  virtual double jacobian(const IR3& q) const override;
+  virtual dIR3 del_inverse(const IR3& q) const override;
 
-	virtual IR3 operator()(const IR3 &q) const override;
-	virtual IR3 inverse(const IR3 &x) const override;
-	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 ddel(const IR3 &q) const override;
+  double Lref() const { return Lref_; };
+ private:
+  const double Lref_, iLref_, Lref3_;
+};
 
-	virtual double jacobian(const IR3 &q) const override;
-	virtual dIR3 del_inverse(const IR3 &q) const override;
+}  // end namespace gyronimo
 
-	double Lref() const {return Lref_;};
-
-private:
-	const double Lref_, iLref_, Lref_3_;
-
-}; // end class morphism_cylindrical
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_MORPHISM_CYLINDRICAL
+#endif  // GYRONIMO_MORPHISM_CYLINDRICAL

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -26,8 +26,7 @@ namespace gyronimo{
 
 morphism_helena::morphism_helena(
 		const parser_helena *p, const interpolator2d_factory *ifactory)
-		: parser_(p), R_(nullptr), z_(nullptr), 
-		R0_(p->rmag()), squaredR0_(p->rmag()*p->rmag()) {
+		: parser_(p), R_(nullptr), z_(nullptr) {
 	double Rgeo = p->rgeo();
 	double a = p->eps()*Rgeo;
 	dblock_adapter s_range(p->s()), chi_range(p->chi());
@@ -44,12 +43,25 @@ morphism_helena::~morphism_helena() {
 	if(z_) delete z_;
 }
 
+//! Maps `HELENA` coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
+/*!
+	In `HELENA` coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( s, \chi, \phi \right) @f$,
+	where @f$ s @f$ is the flux surface label, @f$ \chi @f$ is the poloidal angle 
+	and @f$ \phi @f$ is the toroidal angle.
+	Implements the coordinate transformation:
+	@f$ \left( x, y, z \right) = \textbf{R} \left( s, \chi, \phi \right) @f$
+*/
 IR3 morphism_helena::operator()(const IR3& q) const {
 	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi);
 	return {R*std::cos(phi), -R*std::sin(phi), (*z_)(s, chi)};
 }
 
+//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into `HELENA` coordinates @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation:
+	@f$ \left( s, \chi, \phi \right) = \textbf{R}^{-1} \left( x, y, z \right) @f$
+*/
 IR3 morphism_helena::inverse(const IR3& X) const {
 	typedef std::array<double, 2> IR2;
 	double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
@@ -65,6 +77,7 @@ IR3 morphism_helena::inverse(const IR3& X) const {
 	return {s, chi, std::atan2(-y, x)};
 }
 
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
 dIR3 morphism_helena::del(const IR3& q) const {
 	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi),
@@ -72,6 +85,30 @@ dIR3 morphism_helena::del(const IR3& q) const {
 	double cos = std::cos(phi), sin = std::sin(phi);
 	return {Ru*cos, Rv*cos, -R*sin, -Ru*sin, -Rv*sin, -R*cos,
 		(*z_).partial_u(s, chi), (*z_).partial_v(s, chi), 0.0};
+}
+
+//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
+ddIR3 morphism_helena::del2(const IR3 &q) const {
+	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
+	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
+	double Ruu = R_->partial2_uu(s, chi), Ruv = R_->partial2_uv(s, chi), Rvv = R_->partial2_vv(s, chi);
+	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
+	double Zuu = z_->partial2_uu(s, chi), Zuv = z_->partial2_uv(s, chi), Zvv = z_->partial2_vv(s, chi);
+	double sn = std::sin(phi), cn = std::cos(phi);
+	return {
+	// 		iuu		iuv			iuw		ivv			ivw		iww
+		Ruu * cn, Ruv * cn, -Ru * sn, Rvv * cn, -Rv * sn, -R * cn,
+		Ruu * sn, Ruv * sn,  Ru * cn, Rvv * sn,  Rv * cn,  R * sn,
+			 Zuu, 	   Zuv, 	   0, 	   Zvv, 	   0,    	0
+	};
+}
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+double morphism_helena::jacobian(const IR3 &q) const {
+	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]);
+	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
+	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
+	return R * (Rv * Zu - Ru * Zv);
 }
 
 std::tuple<double, double> morphism_helena::reflection_past_axis(

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -51,7 +51,7 @@ morphism_helena::~morphism_helena() {
 	@f$ \left( x, y, z \right) = \textbf{R} \left( s, \chi, \phi \right) @f$
 */
 IR3 morphism_helena::operator()(const IR3& q) const {
-	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
+	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi);
 	return {R*std::cos(phi), -R*std::sin(phi), (*z_)(s, chi)};
 }
@@ -78,7 +78,7 @@ IR3 morphism_helena::inverse(const IR3& X) const {
 
 //! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
 dIR3 morphism_helena::del(const IR3& q) const {
-	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
+	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi),
 		Ru = (*R_).partial_u(s, chi), Rv = (*R_).partial_v(s, chi);
 	double cos = std::cos(phi), sin = std::sin(phi);
@@ -88,7 +88,7 @@ dIR3 morphism_helena::del(const IR3& q) const {
 
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
 ddIR3 morphism_helena::ddel(const IR3 &q) const {
-	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
+	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
 	double Ruu = R_->partial2_uu(s, chi), Ruv = R_->partial2_uv(s, chi), Rvv = R_->partial2_vv(s, chi);
 	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
@@ -104,23 +104,18 @@ ddIR3 morphism_helena::ddel(const IR3 &q) const {
 
 //! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
 double morphism_helena::jacobian(const IR3 &q) const {
-	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]);
+	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]);
 	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
 	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
 	return R * (Rv * Zu - Ru * Zv);
 }
 
 std::tuple<double, double> morphism_helena::reflection_past_axis(
-		double s, double chi) {
+		double s, double chi) const {
 	if(s < 0)
-		return {-s, reduce_2pi(chi + std::numbers::pi)};
+		return {-s, parser_->reduce_chi(chi + std::numbers::pi)};
 	else
 		return {s, chi};
-}
-
-double morphism_helena::reduce_2pi(double x) {
-	double l = 2*std::numbers::pi;
-	return (x -= l*std::floor(x/l));
 }
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -25,7 +25,7 @@ namespace gyronimo{
 
 morphism_helena::morphism_helena(
 		const parser_helena *p, const interpolator2d_factory *ifactory)
-		: parser_(p), ifactory_(ifactory), R_(nullptr), z_(nullptr) {
+		: parser_(p), R_(nullptr), z_(nullptr) {
 	double Rgeo = p->rgeo();
 	double a = p->eps()*Rgeo;
 	dblock_adapter s_range(p->s()), chi_range(p->chi());

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -25,117 +25,66 @@
 namespace gyronimo{
 
 morphism_helena::morphism_helena(
-    const parser_helena *p, const interpolator2d_factory *ifactory)
-    : parser_(p), R_(nullptr), z_(nullptr), 
-	R0_(p->rmag()), squaredR0_(p->rmag()*p->rmag()) {
-  double Rgeo = p->rgeo();
-  double a = p->eps()*Rgeo;
-  dblock_adapter s_range(p->s()), chi_range(p->chi());
-  R_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(
-          parser_helena::narray_type(a*p->x() + Rgeo)));
-  z_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(
-          parser_helena::narray_type(a*p->y() + 0.0)));
-
-  guu_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g11()));
-  guv_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g12()));
-  gvv_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g22()));
-  gww_ = ifactory->interpolate_data(
-      s_range, chi_range, dblock_adapter(p->covariant_g33()));
+		const parser_helena *p, const interpolator2d_factory *ifactory)
+		: parser_(p), R_(nullptr), z_(nullptr), 
+		R0_(p->rmag()), squaredR0_(p->rmag()*p->rmag()) {
+	double Rgeo = p->rgeo();
+	double a = p->eps()*Rgeo;
+	dblock_adapter s_range(p->s()), chi_range(p->chi());
+	R_ = ifactory->interpolate_data(
+		s_range, chi_range, dblock_adapter(
+			parser_helena::narray_type(a*p->x() + Rgeo)));
+	z_ = ifactory->interpolate_data(
+		s_range, chi_range, dblock_adapter(
+			parser_helena::narray_type(a*p->y() + 0.0)));
 }
+
 morphism_helena::~morphism_helena() {
-  if(R_) delete R_;
-  if(z_) delete z_;
-  if(guu_) delete guu_;
-  if(guv_) delete guv_;
-  if(gvv_) delete gvv_;
-  if(gww_) delete gww_;
-}
-IR3 morphism_helena::operator()(const IR3& q) const {
-  double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
-  double R = (*R_)(s, chi);
-  return {R*std::cos(phi), -R*std::sin(phi), (*z_)(s, chi)};
-}
-// int morphism_helena::root_f(const gsl_vector *q, void *target, gsl_vector *f) {
-// //   double u = reduce(gsl_vector_get(q, 0), 1);
-//   reduce2(q->data[0], q->data[1]);
-//   double u = q->data[0];
-//   double v = reduce(gsl_vector_get(q, 1), 2*std::numbers::pi);
-//   double target_R = ((struct root_target*) target)->R;
-//   double target_z = ((struct root_target*) target)->z;
-//   interpolator2d* interpolator_R = ((struct root_target*) target)->i_R;
-//   interpolator2d* interpolator_z = ((struct root_target*) target)->i_z;
-//   gsl_vector_set(f, 0, target_R - (*interpolator_R)(u, v));
-//   gsl_vector_set(f, 1, target_z - (*interpolator_z)(u, v));
-//   return GSL_SUCCESS;
-// }
-IR3 morphism_helena::inverse(const IR3& X) const {
-  typedef std::array<double, 2> IR2;
-  double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
-  double R = std::sqrt(x*x + y*y);
-  std::function<IR2(const IR2&)> zero_function =
-      [&](const IR2& args) {
-        auto [s, chi] = reflection_past_axis(args[0], args[1]);
-        return IR2({(*R_)(s, chi) - R, (*z_)(s, chi) - z});
-      };
-  IR2 guess = {0.5, std::atan2(z, R - parser_->rmag())};
-  IR2 roots = multiroot(1.0e-15, 100)(zero_function, guess);
-  auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
-  return {s, chi, std::atan2(-y, x)};
-}
-dIR3 morphism_helena::del(const IR3& q) const {
-  double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
-  double R = (*R_)(s, chi),
-      Ru = (*R_).partial_u(s, chi), Rv = (*R_).partial_v(s, chi);
-  double cos = std::cos(phi), sin = std::sin(phi);
-  return {Ru*cos, Rv*cos, -R*sin, -Ru*sin, -Rv*sin, -R*cos,
-      (*z_).partial_u(s, chi), (*z_).partial_v(s, chi), 0.0};
-}
-double morphism_helena::jacobian(const IR3 &q) const {
-	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]);
-	double guu = squaredR0_ * (*guu_)(s, chi);
-	double guv = squaredR0_ * (*guv_)(s, chi);
-	double gvv = squaredR0_ * (*gvv_)(s, chi);
-	double gww = squaredR0_ * (*gww_)(s, chi);
-	return std::sqrt((guu*gvv - guv*guv)*gww);
-}
-dSM3 morphism_helena::g_del(const IR3& q) const {
-	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]);
-	return {
-		squaredR0_*(*guu_).partial_u(s, chi),
-		squaredR0_*(*guu_).partial_v(s, chi), 0.0, // d_i g_uu
-		squaredR0_*(*guv_).partial_u(s, chi),
-		squaredR0_*(*guv_).partial_v(s, chi), 0.0, // d_i g_uv
-		0.0, 0.0, 0.0, // d_i g_uw
-		squaredR0_*(*gvv_).partial_u(s, chi),
-		squaredR0_*(*gvv_).partial_v(s, chi), 0.0, //d_i g_vv
-		0.0, 0.0, 0.0, // d_i g_vw
-		squaredR0_*(*gww_).partial_u(s, chi),
-		squaredR0_*(*gww_).partial_v(s, chi), 0.0}; // d_i g_ww
+	if(R_) delete R_;
+	if(z_) delete z_;
 }
 
-// //! Reduces an arbitrary angle chi to the interval [0:pi].
-// double morphism_helena::reduce_chi(double chi) const {
-//   double rchi = reduce(chi, 2*std::numbers::pi);
-//   if(parser_->is_symmetric() && rchi > std::numbers::pi)
-//       rchi = 2*std::numbers::pi - rchi;
-//   return rchi;
-// }
+IR3 morphism_helena::operator()(const IR3& q) const {
+	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
+	double R = (*R_)(s, chi);
+	return {R*std::cos(phi), -R*std::sin(phi), (*z_)(s, chi)};
+}
+
+IR3 morphism_helena::inverse(const IR3& X) const {
+	typedef std::array<double, 2> IR2;
+	double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
+	double R = std::sqrt(x*x + y*y);
+	std::function<IR2(const IR2&)> zero_function =
+		[&](const IR2& args) {
+			auto [s, chi] = reflection_past_axis(args[0], args[1]);
+			return IR2({(*R_)(s, chi) - R, (*z_)(s, chi) - z});
+		};
+	IR2 guess = {0.5, std::atan2(z, R - parser_->rmag())};
+	IR2 roots = multiroot(1.0e-15, 100)(zero_function, guess);
+	auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
+	return {s, chi, std::atan2(-y, x)};
+}
+
+dIR3 morphism_helena::del(const IR3& q) const {
+	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
+	double R = (*R_)(s, chi),
+		Ru = (*R_).partial_u(s, chi), Rv = (*R_).partial_v(s, chi);
+	double cos = std::cos(phi), sin = std::sin(phi);
+	return {Ru*cos, Rv*cos, -R*sin, -Ru*sin, -Rv*sin, -R*cos,
+		(*z_).partial_u(s, chi), (*z_).partial_v(s, chi), 0.0};
+}
 
 std::tuple<double, double> morphism_helena::reflection_past_axis(
-    double s, double chi) {
-  if(s < 0)
-    return {-s, reduce_2pi(chi + std::numbers::pi)};
-  else
-    return {s, chi};
+		double s, double chi) {
+	if(s < 0)
+		return {-s, reduce_2pi(chi + std::numbers::pi)};
+	else
+		return {s, chi};
 }
+
 double morphism_helena::reduce_2pi(double x) {
-  double l = 2*std::numbers::pi;
-  return (x -= l*std::floor(x/l));
+	double l = 2*std::numbers::pi;
+	return (x -= l*std::floor(x/l));
 }
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -115,7 +115,7 @@ std::tuple<double, double> morphism_helena::reflection_past_axis(
 	if(s < 0)
 		return {-s, parser_->reduce_chi(chi + std::numbers::pi)};
 	else
-		return {s, chi};
+		return {s, parser_->reduce_chi(chi)};
 }
 
 } // end namespace gyronimo

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -25,7 +25,7 @@ namespace gyronimo{
 
 morphism_helena::morphism_helena(
 		const parser_helena *p, const interpolator2d_factory *ifactory)
-		: parser_(p), R_(nullptr), z_(nullptr) {
+		: parser_(p), ifactory_(ifactory), R_(nullptr), z_(nullptr) {
 	double Rgeo = p->rgeo();
 	double a = p->eps()*Rgeo;
 	dblock_adapter s_range(p->s()), chi_range(p->chi());

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,8 +18,7 @@
 // @morphism_helena.cc, this file is part of ::gyronimo::
 
 #include <gyronimo/metrics/morphism_helena.hh>
-#include <gsl/gsl_vector.h>
-#include <gsl/gsl_multiroots.h>
+#include <numbers>
 #include <gyronimo/core/multiroot.hh>
 
 namespace gyronimo{
@@ -88,7 +87,7 @@ dIR3 morphism_helena::del(const IR3& q) const {
 }
 
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_helena::del2(const IR3 &q) const {
+ddIR3 morphism_helena::ddel(const IR3 &q) const {
 	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
 	double Ruu = R_->partial2_uu(s, chi), Ruv = R_->partial2_uv(s, chi), Rvv = R_->partial2_vv(s, chi);

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -17,16 +17,17 @@
 
 // @morphism_helena.cc, this file is part of ::gyronimo::
 
-#include <numbers>
-#include <gyronimo/core/error.hh>
-#include <gyronimo/core/multiroot.hh>
 #include <gyronimo/metrics/morphism_helena.hh>
+#include <gsl/gsl_vector.h>
+#include <gsl/gsl_multiroots.h>
+#include <gyronimo/core/multiroot.hh>
 
 namespace gyronimo{
 
 morphism_helena::morphism_helena(
     const parser_helena *p, const interpolator2d_factory *ifactory)
-    : parser_(p), R_(nullptr), z_(nullptr) {
+    : parser_(p), R_(nullptr), z_(nullptr), 
+	R0_(p->rmag()), squaredR0_(p->rmag()*p->rmag()) {
   double Rgeo = p->rgeo();
   double a = p->eps()*Rgeo;
   dblock_adapter s_range(p->s()), chi_range(p->chi());
@@ -36,16 +37,42 @@ morphism_helena::morphism_helena(
   z_ = ifactory->interpolate_data(
       s_range, chi_range, dblock_adapter(
           parser_helena::narray_type(a*p->y() + 0.0)));
+
+  guu_ = ifactory->interpolate_data(
+      s_range, chi_range, dblock_adapter(p->covariant_g11()));
+  guv_ = ifactory->interpolate_data(
+      s_range, chi_range, dblock_adapter(p->covariant_g12()));
+  gvv_ = ifactory->interpolate_data(
+      s_range, chi_range, dblock_adapter(p->covariant_g22()));
+  gww_ = ifactory->interpolate_data(
+      s_range, chi_range, dblock_adapter(p->covariant_g33()));
 }
 morphism_helena::~morphism_helena() {
   if(R_) delete R_;
   if(z_) delete z_;
+  if(guu_) delete guu_;
+  if(guv_) delete guv_;
+  if(gvv_) delete gvv_;
+  if(gww_) delete gww_;
 }
 IR3 morphism_helena::operator()(const IR3& q) const {
   double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]), phi = q[IR3::w];
   double R = (*R_)(s, chi);
   return {R*std::cos(phi), -R*std::sin(phi), (*z_)(s, chi)};
 }
+// int morphism_helena::root_f(const gsl_vector *q, void *target, gsl_vector *f) {
+// //   double u = reduce(gsl_vector_get(q, 0), 1);
+//   reduce2(q->data[0], q->data[1]);
+//   double u = q->data[0];
+//   double v = reduce(gsl_vector_get(q, 1), 2*std::numbers::pi);
+//   double target_R = ((struct root_target*) target)->R;
+//   double target_z = ((struct root_target*) target)->z;
+//   interpolator2d* interpolator_R = ((struct root_target*) target)->i_R;
+//   interpolator2d* interpolator_z = ((struct root_target*) target)->i_z;
+//   gsl_vector_set(f, 0, target_R - (*interpolator_R)(u, v));
+//   gsl_vector_set(f, 1, target_z - (*interpolator_z)(u, v));
+//   return GSL_SUCCESS;
+// }
 IR3 morphism_helena::inverse(const IR3& X) const {
   typedef std::array<double, 2> IR2;
   double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
@@ -68,6 +95,37 @@ dIR3 morphism_helena::del(const IR3& q) const {
   return {Ru*cos, Rv*cos, -R*sin, -Ru*sin, -Rv*sin, -R*cos,
       (*z_).partial_u(s, chi), (*z_).partial_v(s, chi), 0.0};
 }
+double morphism_helena::jacobian(const IR3 &q) const {
+	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]);
+	double guu = squaredR0_ * (*guu_)(s, chi);
+	double guv = squaredR0_ * (*guv_)(s, chi);
+	double gvv = squaredR0_ * (*gvv_)(s, chi);
+	double gww = squaredR0_ * (*gww_)(s, chi);
+	return std::sqrt((guu*gvv - guv*guv)*gww);
+}
+dSM3 morphism_helena::g_del(const IR3& q) const {
+	double s = q[IR3::u], chi = reduce_2pi(q[IR3::v]);
+	return {
+		squaredR0_*(*guu_).partial_u(s, chi),
+		squaredR0_*(*guu_).partial_v(s, chi), 0.0, // d_i g_uu
+		squaredR0_*(*guv_).partial_u(s, chi),
+		squaredR0_*(*guv_).partial_v(s, chi), 0.0, // d_i g_uv
+		0.0, 0.0, 0.0, // d_i g_uw
+		squaredR0_*(*gvv_).partial_u(s, chi),
+		squaredR0_*(*gvv_).partial_v(s, chi), 0.0, //d_i g_vv
+		0.0, 0.0, 0.0, // d_i g_vw
+		squaredR0_*(*gww_).partial_u(s, chi),
+		squaredR0_*(*gww_).partial_v(s, chi), 0.0}; // d_i g_ww
+}
+
+// //! Reduces an arbitrary angle chi to the interval [0:pi].
+// double morphism_helena::reduce_chi(double chi) const {
+//   double rchi = reduce(chi, 2*std::numbers::pi);
+//   if(parser_->is_symmetric() && rchi > std::numbers::pi)
+//       rchi = 2*std::numbers::pi - rchi;
+//   return rchi;
+// }
+
 std::tuple<double, double> morphism_helena::reflection_past_axis(
     double s, double chi) {
   if(s < 0)

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -95,10 +95,10 @@ ddIR3 morphism_helena::ddel(const IR3 &q) const {
 	double Zuu = z_->partial2_uu(s, chi), Zuv = z_->partial2_uv(s, chi), Zvv = z_->partial2_vv(s, chi);
 	double sn = std::sin(phi), cn = std::cos(phi);
 	return {
-	// 		iuu		iuv			iuw		ivv			ivw		iww
-		Ruu * cn, Ruv * cn, -Ru * sn, Rvv * cn, -Rv * sn, -R * cn,
-		Ruu * sn, Ruv * sn,  Ru * cn, Rvv * sn,  Rv * cn,  R * sn,
-			 Zuu, 	   Zuv, 	   0, 	   Zvv, 	   0,    	0
+	//	   iuu      iuv     iuw      ivv     ivw    iww
+		 Ruu*cn,  Ruv*cn, -Ru*sn,  Rvv*cn, -Rv*sn, -R*cn,
+		-Ruu*sn, -Ruv*sn, -Ru*cn, -Rvv*sn, -Rv*cn,  R*sn,
+		    Zuu,  Zuv   ,    0  ,  Zvv   ,    0  ,   0
 	};
 }
 
@@ -107,7 +107,7 @@ double morphism_helena::jacobian(const IR3 &q) const {
 	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]);
 	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
 	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
-	return R * (Rv * Zu - Ru * Zv);
+	return R * (Ru * Zv - Rv * Zu);
 }
 
 std::tuple<double, double> morphism_helena::reflection_past_axis(

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -17,128 +17,97 @@
 
 // @morphism_helena.cc, this file is part of ::gyronimo::
 
-#include <gyronimo/metrics/morphism_helena.hh>
-#include <numbers>
 #include <gyronimo/core/multiroot.hh>
+#include <gyronimo/metrics/morphism_helena.hh>
 
-namespace gyronimo{
+#include <numbers>
+
+namespace gyronimo {
 
 morphism_helena::morphism_helena(
-		const parser_helena *p, const interpolator2d_factory *ifactory)
-		: parser_(p), R_(nullptr), z_(nullptr) {
-	double Rgeo = p->rgeo();
-	double a = p->eps()*Rgeo;
-	dblock_adapter s_range(p->s()), chi_range(p->chi());
-	R_ = ifactory->interpolate_data(
-		s_range, chi_range, dblock_adapter(
-			parser_helena::narray_type(a*p->x() + Rgeo)));
-	z_ = ifactory->interpolate_data(
-		s_range, chi_range, dblock_adapter(
-			parser_helena::narray_type(a*p->y() + 0.0)));
+    const parser_helena* p, const interpolator2d_factory* ifactory)
+    : parser_(p), R_(nullptr), z_(nullptr) {
+  double Rgeo = p->rgeo();
+  double a = p->eps() * Rgeo;
+  dblock_adapter s_range(p->s()), chi_range(p->chi());
+  R_ = ifactory->interpolate_data(
+      s_range, chi_range,
+      dblock_adapter(parser_helena::narray_type(a * p->x() + Rgeo)));
+  z_ = ifactory->interpolate_data(
+      s_range, chi_range,
+      dblock_adapter(parser_helena::narray_type(a * p->y() + 0.0)));
 }
-
 morphism_helena::~morphism_helena() {
-	if(R_) delete R_;
-	if(z_) delete z_;
+  if (R_) delete R_;
+  if (z_) delete z_;
 }
-
-//! Maps `HELENA` coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
-/*!
-	In `HELENA` coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( s, \chi, \phi \right) @f$,
-	where @f$ s @f$ is the flux surface label, @f$ \chi @f$ is the poloidal angle 
-	and @f$ \phi @f$ is the toroidal angle.
-	Implements the coordinate transformation:
-	@f$ \left( x, y, z \right) = \textbf{R} \left( s, \chi, \phi \right) @f$
-*/
 IR3 morphism_helena::operator()(const IR3& q) const {
-	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
-	double R = (*R_)(s, chi);
-	return {R*std::cos(phi), -R*std::sin(phi), (*z_)(s, chi)};
+  double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
+  double R = (*R_)(s, chi);
+  return {R * std::cos(phi), -R * std::sin(phi), (*z_)(s, chi)};
 }
-
-//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into `HELENA` coordinates @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation:
-	@f$ \left( s, \chi, \phi \right) = \textbf{R}^{-1} \left( x, y, z \right) @f$
-*/
 IR3 morphism_helena::inverse(const IR3& X) const {
-	typedef std::array<double, 2> IR2;
-	double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
-	double R = std::sqrt(x*x + y*y);
-	std::function<IR2(const IR2&)> zero_function =
-		[&](const IR2& args) {
-			auto [s, chi] = reflection_past_axis(args[0], args[1]);
-			return IR2({(*R_)(s, chi) - R, (*z_)(s, chi) - z});
-		};
-	IR2 guess = {0.5, std::atan2(z, R - parser_->rmag())};
-	IR2 roots = multiroot(1.0e-13, 100)(zero_function, guess);
-	auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
-	return {s, chi, std::atan2(-y, x)};
+  typedef std::array<double, 2> IR2;
+  double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
+  double R = std::sqrt(x * x + y * y);
+  std::function<IR2(const IR2&)> zero_function = [&](const IR2& args) {
+    auto [s, chi] = reflection_past_axis(args[0], args[1]);
+    return IR2({(*R_)(s, chi) - R, (*z_)(s, chi) - z});
+  };
+  IR2 guess = {0.5, std::atan2(z, R - parser_->rmag())};
+  IR2 roots = multiroot(1.0e-13, 100)(zero_function, guess);
+  auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
+  return {s, chi, std::atan2(-y, x)};
 }
-
-//! Translates the curvilinear position `q` by the cartesian vector `delta`
-/*!
-	Implements the rule:
-	@f$ q^\alpha = Q^\alpha \left( \textbf{X}\left(\right) + \Delta \right) @f$
-*/
-IR3 morphism_helena::translation(const IR3 &q, const IR3 &delta) const {
-	typedef std::array<double, 2> IR2;
-	IR3 X = (*this)(q);
-	double Xt = X[IR3::u] + delta[IR3::u];
-	double Yt = X[IR3::v] + delta[IR3::v];
-	double Zt = X[IR3::w] + delta[IR3::w];
-	double Rt = std::sqrt(Xt*Xt + Yt*Yt);
-	std::function<IR2(const IR2&)> zero_function =
-		[&](const IR2& args) {
-			auto [s, chi] = reflection_past_axis(args[0], args[1]);
-			return IR2({(*R_)(s, chi) - Rt, (*z_)(s, chi) - Zt});
-		};
-	IR2 guess = {q[IR3::u], q[IR3::v]};
-	IR2 roots = multiroot(1.0e-12, 100)(zero_function, guess);
-	auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
-	return {s, chi, std::atan2(-Yt, Xt)};
+IR3 morphism_helena::translation(const IR3& q, const IR3& delta) const {
+  typedef std::array<double, 2> IR2;
+  IR3 X = (*this)(q);
+  double Xt = X[IR3::u] + delta[IR3::u];
+  double Yt = X[IR3::v] + delta[IR3::v];
+  double Zt = X[IR3::w] + delta[IR3::w];
+  double Rt = std::sqrt(Xt * Xt + Yt * Yt);
+  std::function<IR2(const IR2&)> zero_function = [&](const IR2& args) {
+    auto [s, chi] = reflection_past_axis(args[0], args[1]);
+    return IR2({(*R_)(s, chi) - Rt, (*z_)(s, chi) - Zt});
+  };
+  IR2 guess = {q[IR3::u], q[IR3::v]};
+  IR2 roots = multiroot(1.0e-12, 100)(zero_function, guess);
+  auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
+  return {s, chi, std::atan2(-Yt, Xt)};
 }
-
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
 dIR3 morphism_helena::del(const IR3& q) const {
-	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
-	double R = (*R_)(s, chi),
-		Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
-	double cos = std::cos(phi), sin = std::sin(phi);
-	return {Ru*cos, Rv*cos, -R*sin, -Ru*sin, -Rv*sin, -R*cos,
-		z_->partial_u(s, chi), z_->partial_v(s, chi), 0.0};
+  double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
+  double R = (*R_)(s, chi);
+  double Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
+  double cos = std::cos(phi), sin = std::sin(phi);
+  return {Ru * cos, Rv * cos, -R * sin, -Ru * sin, -Rv * sin,
+      -R * cos, z_->partial_u(s, chi), z_->partial_v(s, chi), 0.0};
+}
+ddIR3 morphism_helena::ddel(const IR3& q) const {
+  double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
+  double R = (*R_)(s, chi);
+  double Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
+  double Ruu = R_->partial2_uu(s, chi), Ruv = R_->partial2_uv(s, chi),
+      Rvv = R_->partial2_vv(s, chi);
+  double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
+  double Zuu = z_->partial2_uu(s, chi), Zuv = z_->partial2_uv(s, chi),
+      Zvv = z_->partial2_vv(s, chi);
+  double sn = std::sin(phi), cn = std::cos(phi);
+  return {Ruu * cn, Ruv * cn, -Ru * sn, Rvv * cn,
+      -Rv * sn, -R * cn, -Ruu * sn, -Ruv * sn, -Ru * cn,
+      -Rvv * sn, -Rv * cn, R * sn, Zuu, Zuv, 0, Zvv, 0, 0};
+}
+double morphism_helena::jacobian(const IR3& q) const {
+  double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]);
+  double R = (*R_)(s, chi);
+  double Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
+  double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
+  return R * (Ru * Zv - Rv * Zu);
+}
+std::pair<double, double> morphism_helena::reflection_past_axis(
+    double s, double chi) const {
+  if (s < 0) return {-s, parser_->reduce_chi(chi + std::numbers::pi)};
+  else return {s, parser_->reduce_chi(chi)};
 }
 
-//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_helena::ddel(const IR3 &q) const {
-	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
-	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
-	double Ruu = R_->partial2_uu(s, chi), Ruv = R_->partial2_uv(s, chi), Rvv = R_->partial2_vv(s, chi);
-	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
-	double Zuu = z_->partial2_uu(s, chi), Zuv = z_->partial2_uv(s, chi), Zvv = z_->partial2_vv(s, chi);
-	double sn = std::sin(phi), cn = std::cos(phi);
-	return {
-	//	   iuu      iuv     iuw      ivv     ivw    iww
-		 Ruu*cn,  Ruv*cn, -Ru*sn,  Rvv*cn, -Rv*sn, -R*cn,
-		-Ruu*sn, -Ruv*sn, -Ru*cn, -Rvv*sn, -Rv*cn,  R*sn,
-		    Zuu,  Zuv   ,    0  ,  Zvv   ,    0  ,   0
-	};
-}
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-double morphism_helena::jacobian(const IR3 &q) const {
-	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]);
-	double R = (*R_)(s, chi), Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
-	double Zu = z_->partial_u(s, chi), Zv = z_->partial_v(s, chi);
-	return R * (Ru * Zv - Rv * Zu);
-}
-
-std::tuple<double, double> morphism_helena::reflection_past_axis(
-		double s, double chi) const {
-	if(s < 0)
-		return {-s, parser_->reduce_chi(chi + std::numbers::pi)};
-	else
-		return {s, parser_->reduce_chi(chi)};
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism_helena.cc
+++ b/gyronimo/metrics/morphism_helena.cc
@@ -71,7 +71,7 @@ IR3 morphism_helena::inverse(const IR3& X) const {
 			return IR2({(*R_)(s, chi) - R, (*z_)(s, chi) - z});
 		};
 	IR2 guess = {0.5, std::atan2(z, R - parser_->rmag())};
-	IR2 roots = multiroot(1.0e-15, 100)(zero_function, guess);
+	IR2 roots = multiroot(1.0e-13, 100)(zero_function, guess);
 	auto [s, chi] = reflection_past_axis(roots[0], roots[1]);
 	return {s, chi, std::atan2(-y, x)};
 }
@@ -80,10 +80,10 @@ IR3 morphism_helena::inverse(const IR3& X) const {
 dIR3 morphism_helena::del(const IR3& q) const {
 	double s = q[IR3::u], chi = parser_->reduce_chi(q[IR3::v]), phi = q[IR3::w];
 	double R = (*R_)(s, chi),
-		Ru = (*R_).partial_u(s, chi), Rv = (*R_).partial_v(s, chi);
+		Ru = R_->partial_u(s, chi), Rv = R_->partial_v(s, chi);
 	double cos = std::cos(phi), sin = std::sin(phi);
 	return {Ru*cos, Rv*cos, -R*sin, -Ru*sin, -Rv*sin, -R*cos,
-		(*z_).partial_u(s, chi), (*z_).partial_v(s, chi), 0.0};
+		z_->partial_u(s, chi), z_->partial_v(s, chi), 0.0};
 }
 
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -34,20 +34,22 @@ namespace gyronimo {
 
 //! Morphism from `HELENA` curvilinear coordinates.
 class morphism_helena : public morphism {
- public:
-  morphism_helena(
-      const parser_helena *parser, const interpolator2d_factory *ifactory);
-  virtual ~morphism_helena() override;
-  virtual IR3 operator()(const IR3& q) const override;
-  virtual IR3 inverse(const IR3& x) const override;
-  virtual dIR3 del(const IR3& q) const override;
-  const parser_helena* parser() const {return parser_;};
- private:
-  const parser_helena *parser_;
-  interpolator2d *R_, *z_;
-  double R0_, squaredR0_;
-  static double reduce_2pi(double x);
-  static std::tuple<double, double> reflection_past_axis(double s, double chi);
+public:
+	morphism_helena(
+		const parser_helena *parser, const interpolator2d_factory *ifactory);
+	virtual ~morphism_helena() override;
+	virtual IR3 operator()(const IR3& q) const override;
+	virtual IR3 inverse(const IR3& x) const override;
+	virtual dIR3 del(const IR3& q) const override;
+	virtual ddIR3 del2(const IR3& q) const override;
+
+	virtual double jacobian(const IR3 &q) const override;
+	const parser_helena* parser() const {return parser_;};
+private:
+	const parser_helena *parser_;
+	interpolator2d *R_, *z_;
+	static double reduce_2pi(double x);
+	static std::tuple<double, double> reflection_past_axis(double s, double chi);
 };
 
 }

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -45,8 +45,7 @@ private:
 	const parser_helena *parser_;
 	const interpolator2d_factory *ifactory_;
 	interpolator2d *R_, *z_;
-	static double reduce_2pi(double x);
-	static std::tuple<double, double> reflection_past_axis(double s, double chi);
+	std::tuple<double, double> reflection_past_axis(double s, double chi) const;
 };
 
 }

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -41,23 +41,11 @@ class morphism_helena : public morphism {
   virtual IR3 operator()(const IR3& q) const override;
   virtual IR3 inverse(const IR3& x) const override;
   virtual dIR3 del(const IR3& q) const override;
-  double jacobian(const IR3 &q) const override;
-  virtual dSM3 g_del(const IR3& q) const override;
-//   virtual dSM3 del2(const IR3& q) const override;
   const parser_helena* parser() const {return parser_;};
-//   double reduce_chi(double chi) const;
  private:
-//   static double reduce(double x, double l) {return (x -= l*std::floor(x/l));};
-//   static void reduce2(double &u, double &v) {
-// 	v = u < 0 ? v + std::numbers::pi : v;
-// 	u = u < 0 ? -u : u > 1 ? 1 : u;
-//   };
   const parser_helena *parser_;
   interpolator2d *R_, *z_;
   double R0_, squaredR0_;
-  interpolator2d *guu_, *guv_, *gvv_, *gww_;
-//   static int root_f(const gsl_vector *q, void *target, gsl_vector *f);
-//   struct root_target {double R, z;interpolator2d *i_R, *i_z;};
   static double reduce_2pi(double x);
   static std::tuple<double, double> reflection_past_axis(double s, double chi);
 };

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -20,9 +20,15 @@
 #ifndef GYRONIMO_MORPHISM_HELENA
 #define GYRONIMO_MORPHISM_HELENA
 
+#include <gsl/gsl_vector.h>
+#include <gsl/gsl_multiroots.h>
+#include <numbers>
+#include <gyronimo/core/error.hh>
+#include <gyronimo/core/multiroot.hh>
 #include <gyronimo/metrics/morphism.hh>
 #include <gyronimo/parsers/parser_helena.hh>
 #include <gyronimo/interpolators/interpolator2d.hh>
+
 
 namespace gyronimo {
 
@@ -35,10 +41,23 @@ class morphism_helena : public morphism {
   virtual IR3 operator()(const IR3& q) const override;
   virtual IR3 inverse(const IR3& x) const override;
   virtual dIR3 del(const IR3& q) const override;
+  double jacobian(const IR3 &q) const override;
+  virtual dSM3 g_del(const IR3& q) const override;
+//   virtual dSM3 del2(const IR3& q) const override;
   const parser_helena* parser() const {return parser_;};
+//   double reduce_chi(double chi) const;
  private:
+//   static double reduce(double x, double l) {return (x -= l*std::floor(x/l));};
+//   static void reduce2(double &u, double &v) {
+// 	v = u < 0 ? v + std::numbers::pi : v;
+// 	u = u < 0 ? -u : u > 1 ? 1 : u;
+//   };
   const parser_helena *parser_;
   interpolator2d *R_, *z_;
+  double R0_, squaredR0_;
+  interpolator2d *guu_, *guv_, *gvv_, *gww_;
+//   static int root_f(const gsl_vector *q, void *target, gsl_vector *f);
+//   struct root_target {double R, z;interpolator2d *i_R, *i_z;};
   static double reduce_2pi(double x);
   static std::tuple<double, double> reflection_past_axis(double s, double chi);
 };

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -20,33 +20,45 @@
 #ifndef GYRONIMO_MORPHISM_HELENA
 #define GYRONIMO_MORPHISM_HELENA
 
+#include <gyronimo/interpolators/interpolator2d.hh>
 #include <gyronimo/metrics/morphism.hh>
 #include <gyronimo/parsers/parser_helena.hh>
-#include <gyronimo/interpolators/interpolator2d.hh>
-
 
 namespace gyronimo {
 
-//! Morphism from `HELENA` curvilinear coordinates.
-class morphism_helena : public morphism {
-public:
-	morphism_helena(const parser_helena *parser, 
-		const interpolator2d_factory *ifactory);
-	virtual ~morphism_helena() override;
-	virtual IR3 operator()(const IR3& q) const override;
-	virtual IR3 inverse(const IR3& x) const override;
-	virtual IR3 translation(const IR3 &q, const IR3 &delta) const override;
-	virtual dIR3 del(const IR3& q) const override;
-	virtual ddIR3 ddel(const IR3& q) const override;
+//! Morphism for `HELENA` curvilinear coordinates.
+/*!
+    Builds the morphism from the information provided by a `parser_helena`
+    object. The actual type of 2d interpolators to use is set by the specific
+    `interpolator2d_factory` object pointer provided to the constructor.
 
-	virtual double jacobian(const IR3 &q) const override;
-	const parser_helena* parser() const {return parser_;};
-private:
-	const parser_helena *parser_;
-	interpolator2d *R_, *z_;
-	std::tuple<double, double> reflection_past_axis(double s, double chi) const;
+    The right-handed curvilinear coordinates are the square root of the poloidal
+    flux per radian normalised to its value at the boundary (`u`, or `HELENA`
+    @f$s=\sqrt{\Psi/\Psi_b}@f$), an angle on the poloidal cross section (`v`, or
+    `HELENA` @f$\chi : B^\phi=q B^\chi@f$, in rads) measured *counterclockwise*
+    from the left-hand side midplane (the `x` axis), and the toroidal angle
+    (`w`, or `HELENA` @f$\phi@f$, in rads) measured *clockwise* when looking
+    from the torus top.
+*/
+class morphism_helena : public morphism {
+ public:
+  morphism_helena(
+      const parser_helena* parser, const interpolator2d_factory* ifactory);
+  virtual ~morphism_helena() override;
+  virtual IR3 operator()(const IR3& q) const override;
+  virtual IR3 inverse(const IR3& x) const override;
+  virtual dIR3 del(const IR3& q) const override;
+  virtual ddIR3 ddel(const IR3& q) const override;
+
+  virtual double jacobian(const IR3& q) const override;
+  virtual IR3 translation(const IR3& q, const IR3& delta) const override;
+  const parser_helena* parser() const { return parser_; };
+ private:
+  const parser_helena* parser_;
+  interpolator2d *R_, *z_;
+  std::pair<double, double> reflection_past_axis(double s, double chi) const;
 };
 
-}
+}  // namespace gyronimo
 
-#endif // GYRONIMO_MORPHISM_HELENA
+#endif  // GYRONIMO_MORPHISM_HELENA

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -40,8 +40,10 @@ public:
 
 	virtual double jacobian(const IR3 &q) const override;
 	const parser_helena* parser() const {return parser_;};
+	const interpolator2d_factory* ifactory() const {return ifactory_;};
 private:
 	const parser_helena *parser_;
+	const interpolator2d_factory *ifactory_;
 	interpolator2d *R_, *z_;
 	static double reduce_2pi(double x);
 	static std::tuple<double, double> reflection_past_axis(double s, double chi);

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -35,6 +35,7 @@ public:
 	virtual ~morphism_helena() override;
 	virtual IR3 operator()(const IR3& q) const override;
 	virtual IR3 inverse(const IR3& x) const override;
+	virtual IR3 translation(const IR3 &q, const IR3 &delta) const override;
 	virtual dIR3 del(const IR3& q) const override;
 	virtual ddIR3 ddel(const IR3& q) const override;
 

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -30,8 +30,8 @@ namespace gyronimo {
 //! Morphism from `HELENA` curvilinear coordinates.
 class morphism_helena : public morphism {
 public:
-	morphism_helena(
-		const parser_helena *parser, const interpolator2d_factory *ifactory);
+	morphism_helena(const parser_helena *parser, 
+		const interpolator2d_factory *ifactory);
 	virtual ~morphism_helena() override;
 	virtual IR3 operator()(const IR3& q) const override;
 	virtual IR3 inverse(const IR3& x) const override;
@@ -40,10 +40,8 @@ public:
 
 	virtual double jacobian(const IR3 &q) const override;
 	const parser_helena* parser() const {return parser_;};
-	const interpolator2d_factory* ifactory() const {return ifactory_;};
 private:
 	const parser_helena *parser_;
-	const interpolator2d_factory *ifactory_;
 	interpolator2d *R_, *z_;
 	std::tuple<double, double> reflection_past_axis(double s, double chi) const;
 };

--- a/gyronimo/metrics/morphism_helena.hh
+++ b/gyronimo/metrics/morphism_helena.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,11 +20,6 @@
 #ifndef GYRONIMO_MORPHISM_HELENA
 #define GYRONIMO_MORPHISM_HELENA
 
-#include <gsl/gsl_vector.h>
-#include <gsl/gsl_multiroots.h>
-#include <numbers>
-#include <gyronimo/core/error.hh>
-#include <gyronimo/core/multiroot.hh>
 #include <gyronimo/metrics/morphism.hh>
 #include <gyronimo/parsers/parser_helena.hh>
 #include <gyronimo/interpolators/interpolator2d.hh>
@@ -41,7 +36,7 @@ public:
 	virtual IR3 operator()(const IR3& q) const override;
 	virtual IR3 inverse(const IR3& x) const override;
 	virtual dIR3 del(const IR3& q) const override;
-	virtual ddIR3 del2(const IR3& q) const override;
+	virtual ddIR3 ddel(const IR3& q) const override;
 
 	virtual double jacobian(const IR3 &q) const override;
 	const parser_helena* parser() const {return parser_;};

--- a/gyronimo/metrics/morphism_polar_torus.cc
+++ b/gyronimo/metrics/morphism_polar_torus.cc
@@ -1,0 +1,165 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_polar_torus.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/metrics/morphism_polar_torus.hh>
+#include <cmath>
+
+namespace gyronimo {
+
+morphism_polar_torus::morphism_polar_torus(const double minor_radius, double major_radius)
+    : minor_radius_(minor_radius), major_radius_(major_radius),
+      iaspect_ratio_(minor_radius_/major_radius_),
+	  volume_factor_(minor_radius*minor_radius*major_radius),
+	  iminor_radius_(1.0/minor_radius) {
+}
+
+//! Maps polar torus coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
+/*!
+	In polar torus coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( r, \theta, \phi \right) @f$.
+	Implements the coordinate transformation:
+	@f{gather*}{
+		\begin{aligned}
+			x &=  \left( R_{0} + a \, r \, \cos \theta \right) \, \cos \phi \\
+			y &= -\left( R_{0} + a \, r \, \cos \theta \right) \, \sin \phi \\
+			z &= a \, r \, \sin \theta
+		\end{aligned}
+    @f}
+*/
+IR3 morphism_polar_torus::operator()(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::v]), sn_theta = std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]), sn_phi = std::sin(q[IR3::w]);
+	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
+	return { R*cn_phi, 
+			-R*sn_phi, 
+			minor_radius_*r*sn_theta};
+}
+
+//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into spherical coordinates @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation:
+	@f{gather*}{
+		\begin{aligned}
+			r &= \frac{1}{a} \, \sqrt{z^2 + (\sqrt{x^2 + y^2} - R_{0})^2} \\
+			\theta &= \arctan \left( \frac{z}{\sqrt{x^2 + y^2} - R_{0}} \right) \\
+			\phi &= -\arctan \left( \frac{y}{x} \right)
+		\end{aligned}
+    @f}
+*/
+IR3 morphism_polar_torus::inverse(const IR3 &x) const {
+	double z = x[IR3::w];
+	double R = std::sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]);
+	double dR = R - major_radius_;
+	return {iminor_radius_*std::sqrt(z*z + dR*dR), 
+			std::atan2(z, dR), 
+			std::atan2(-x[IR3::v], x[IR3::u])};
+}
+
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the coordinate transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}_r &= \left( a \, \cos \theta \, \cos \phi, -a \, \cos \theta \, \sin \phi, a \, \sin \theta \right) \\
+			\textbf{e}_\theta &= \left( -a \, r \, \sin \theta \, \cos \phi, a \, r \, \sin \theta \, \sin \phi, a \, r \, \cos \theta \right) \\
+			\textbf{e}_\phi &= \left( -\left( R_0 + a \, r \, \cos \theta \right) \, \sin \phi, \left( R_0 + a \, r \, \cos \theta \right) \, \cos \phi, 0 \right)
+		\end{aligned}
+    @f}
+*/
+dIR3 morphism_polar_torus::del(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::v]);
+	double sn_theta = std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
+	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
+	double a_cn = minor_radius_*cn_theta;
+	double ar_cn = r * a_cn;
+	double a_sn = minor_radius_*sn_theta;
+	double ar_sn = r * a_sn;
+	return {
+		 a_cn * cn_phi, -ar_sn * cn_phi, -R * sn_phi,
+		-a_cn * sn_phi,  ar_sn * sn_phi, -R * cn_phi,
+		 a_sn         ,  ar_cn         ,  0
+	};
+}
+
+//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
+ddIR3 morphism_polar_torus::ddel(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::v]);
+	double sn_theta = std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
+	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
+	double a_cn = minor_radius_*cn_theta;
+	double ar_cn = r * a_cn;
+	double a_sn = minor_radius_*sn_theta;
+	double ar_sn = r * a_sn;
+	return {
+	// iuu      iuv             iuw              ivv             ivw          iww
+		0, -a_sn * cn_phi, -a_cn * sn_phi, -ar_cn * cn_phi, ar_sn * sn_phi, -R * cn_phi,
+		0,  a_sn * sn_phi, -a_cn * cn_phi,  ar_cn * sn_phi, ar_sn * cn_phi,  R * sn_phi,
+		0,  a_cn         ,       0       , -ar_sn         ,       0       ,  0
+	};
+}
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian in spherical coordinates: 
+	@f$ J = a^2 \, r \, \left( R_0 + a \, r \, \cos \theta \right) @f$
+*/
+double morphism_polar_torus::jacobian(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn = std::cos(q[IR3::v]);
+	double Rfactor = (1.0+iaspect_ratio_*r*cn);
+	return volume_factor_*r*Rfactor;
+}
+
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}^r &= \left( \frac{\cos \theta \, \cos \phi}{a}, -\frac{\cos \theta \, \sin \phi}{a}, \frac{\sin \theta}{a} \right) \\
+			\textbf{e}^\theta &= \left( -\frac{\sin \theta \, \cos \phi}{a \, r}, \frac{\sin \theta \, \sin \phi}{a \, r}, \frac{\cos \theta}{a \, r} \right) \\
+			\textbf{e}^\phi &= \left( - \frac{\sin \phi}{R_0 + a \, r \, \cos \theta}, \frac{\cos \phi}{R_0 + a \, r \, \cos \theta}, 0 \right)
+		\end{aligned}
+    @f}
+*/
+dIR3 morphism_polar_torus::del_inverse(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::v]);
+	double sn_theta = std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
+	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
+	double iR = 1.0 / R;
+	double ia_cn = iminor_radius_*cn_theta;
+	double iar_cn = r * ia_cn;
+	double ia_sn = iminor_radius_*sn_theta;
+	double iar_sn = r * ia_sn;
+	return {
+		  ia_cn * cn_phi, -ia_cn * sn_phi,  ia_sn,
+		-iar_sn * cn_phi, iar_sn * sn_phi, iar_cn,
+		    -iR * sn_phi,    -iR * cn_phi, 0
+	};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/morphism_polar_torus.cc
+++ b/gyronimo/metrics/morphism_polar_torus.cc
@@ -18,148 +18,69 @@
 // @morphism_polar_torus.cc, this file is part of ::gyronimo::
 
 #include <gyronimo/metrics/morphism_polar_torus.hh>
+
 #include <cmath>
 
 namespace gyronimo {
 
-morphism_polar_torus::morphism_polar_torus(const double minor_radius, double major_radius)
+morphism_polar_torus::morphism_polar_torus(
+    const double minor_radius, double major_radius)
     : minor_radius_(minor_radius), major_radius_(major_radius),
-      iaspect_ratio_(minor_radius_/major_radius_),
-	  volume_factor_(minor_radius*minor_radius*major_radius),
-	  iminor_radius_(1.0/minor_radius) {
+      iaspect_ratio_(minor_radius_ / major_radius_),
+      volume_factor_(minor_radius * minor_radius * major_radius),
+      iminor_radius_(1.0 / minor_radius) {}
+IR3 morphism_polar_torus::operator()(const IR3& q) const {
+  double r = q[IR3::u];
+  double cn_theta = std::cos(q[IR3::v]), sn_theta = std::sin(q[IR3::v]);
+  double cn_phi = std::cos(q[IR3::w]), sn_phi = std::sin(q[IR3::w]);
+  double R = major_radius_ * (1.0 + iaspect_ratio_ * r * cn_theta);
+  return {R * cn_phi, -R * sn_phi, minor_radius_ * r * sn_theta};
+}
+IR3 morphism_polar_torus::inverse(const IR3& x) const {
+  double z = x[IR3::w];
+  double R = std::sqrt(x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v]);
+  double dR = R - major_radius_;
+  return {
+      iminor_radius_ * std::sqrt(z * z + dR * dR), std::atan2(z, dR),
+      std::atan2(-x[IR3::v], x[IR3::u])};
+}
+dIR3 morphism_polar_torus::del(const IR3& q) const {
+  double r = q[IR3::u];
+  double cn_phi = std::cos(q[IR3::w]), sn_phi = std::sin(q[IR3::w]);
+  double cn_theta = std::cos(q[IR3::v]), sn_theta = std::sin(q[IR3::v]);
+  double R = major_radius_ * (1.0 + iaspect_ratio_ * r * cn_theta);
+  double a_cn = minor_radius_ * cn_theta, ar_cn = r * a_cn;
+  double a_sn = minor_radius_ * sn_theta, ar_sn = r * a_sn;
+  return {a_cn * cn_phi, -ar_sn * cn_phi, -R * sn_phi,
+       -a_cn * sn_phi, ar_sn * sn_phi, -R * cn_phi, a_sn, ar_cn, 0};
+}
+ddIR3 morphism_polar_torus::ddel(const IR3& q) const {
+  double r = q[IR3::u];
+  double cn_phi = std::cos(q[IR3::w]), sn_phi = std::sin(q[IR3::w]);
+  double cn_theta = std::cos(q[IR3::v]), sn_theta = std::sin(q[IR3::v]);
+  double R = major_radius_ * (1.0 + iaspect_ratio_ * r * cn_theta);
+  double a_cn = minor_radius_ * cn_theta, ar_cn = r * a_cn;
+  double a_sn = minor_radius_ * sn_theta, ar_sn = r * a_sn;
+  return {0, -a_sn * cn_phi, -a_cn * sn_phi, -ar_cn * cn_phi, ar_sn * sn_phi,
+      -R * cn_phi, 0, a_sn * sn_phi, -a_cn * cn_phi, ar_cn * sn_phi,
+      ar_sn * cn_phi, R * sn_phi, 0, a_cn, 0, -ar_sn, 0, 0};
+}
+double morphism_polar_torus::jacobian(const IR3& q) const {
+  double r = q[IR3::u];
+  double cn = std::cos(q[IR3::v]);
+  double Rfactor = (1.0 + iaspect_ratio_ * r * cn);
+  return volume_factor_ * r * Rfactor;
+}
+dIR3 morphism_polar_torus::del_inverse(const IR3& q) const {
+  double r = q[IR3::u], ir = 1.0 / r;
+  double cn_phi = std::cos(q[IR3::w]), sn_phi = std::sin(q[IR3::w]);
+  double cn_theta = std::cos(q[IR3::v]), sn_theta = std::sin(q[IR3::v]);
+  double iR = 1.0 / (major_radius_ * (1.0 + iaspect_ratio_ * r * cn_theta));
+  double ia_cn = iminor_radius_ * cn_theta, iar_cn = ir * ia_cn;
+  double ia_sn = iminor_radius_ * sn_theta, iar_sn = ir * ia_sn;
+  return {ia_cn * cn_phi,   -ia_cn * sn_phi, ia_sn,
+          -iar_sn * cn_phi, iar_sn * sn_phi, iar_cn,
+          -iR * sn_phi,     -iR * cn_phi,    0};
 }
 
-//! Maps polar torus coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
-/*!
-	In polar torus coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( r, \theta, \phi \right) @f$.
-	Implements the coordinate transformation:
-	@f{gather*}{
-		\begin{aligned}
-			x &=  \left( R_{0} + a \, r \, \cos \theta \right) \, \cos \phi \\
-			y &= -\left( R_{0} + a \, r \, \cos \theta \right) \, \sin \phi \\
-			z &= a \, r \, \sin \theta
-		\end{aligned}
-    @f}
-*/
-IR3 morphism_polar_torus::operator()(const IR3 &q) const {
-	double r = q[IR3::u];
-	double cn_theta = std::cos(q[IR3::v]), sn_theta = std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]), sn_phi = std::sin(q[IR3::w]);
-	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
-	return { R*cn_phi, 
-			-R*sn_phi, 
-			minor_radius_*r*sn_theta};
-}
-
-//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into spherical coordinates @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation:
-	@f{gather*}{
-		\begin{aligned}
-			r &= \frac{1}{a} \, \sqrt{z^2 + (\sqrt{x^2 + y^2} - R_{0})^2} \\
-			\theta &= \arctan \left( \frac{z}{\sqrt{x^2 + y^2} - R_{0}} \right) \\
-			\phi &= -\arctan \left( \frac{y}{x} \right)
-		\end{aligned}
-    @f}
-*/
-IR3 morphism_polar_torus::inverse(const IR3 &x) const {
-	double z = x[IR3::w];
-	double R = std::sqrt(x[IR3::u]*x[IR3::u] + x[IR3::v]*x[IR3::v]);
-	double dR = R - major_radius_;
-	return {iminor_radius_*std::sqrt(z*z + dR*dR), 
-			std::atan2(z, dR), 
-			std::atan2(-x[IR3::v], x[IR3::u])};
-}
-
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the coordinate transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}_r &= \left( a \, \cos \theta \, \cos \phi, -a \, \cos \theta \, \sin \phi, a \, \sin \theta \right) \\
-			\textbf{e}_\theta &= \left( -a \, r \, \sin \theta \, \cos \phi, a \, r \, \sin \theta \, \sin \phi, a \, r \, \cos \theta \right) \\
-			\textbf{e}_\phi &= \left( -\left( R_0 + a \, r \, \cos \theta \right) \, \sin \phi, \left( R_0 + a \, r \, \cos \theta \right) \, \cos \phi, 0 \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_polar_torus::del(const IR3 &q) const {
-	double r = q[IR3::u];
-	double cn_theta = std::cos(q[IR3::v]);
-	double sn_theta = std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
-	double a_cn = minor_radius_*cn_theta;
-	double ar_cn = r * a_cn;
-	double a_sn = minor_radius_*sn_theta;
-	double ar_sn = r * a_sn;
-	return {
-		 a_cn * cn_phi, -ar_sn * cn_phi, -R * sn_phi,
-		-a_cn * sn_phi,  ar_sn * sn_phi, -R * cn_phi,
-		 a_sn         ,  ar_cn         ,  0
-	};
-}
-
-//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_polar_torus::ddel(const IR3 &q) const {
-	double r = q[IR3::u];
-	double cn_theta = std::cos(q[IR3::v]);
-	double sn_theta = std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
-	double a_cn = minor_radius_*cn_theta;
-	double ar_cn = r * a_cn;
-	double a_sn = minor_radius_*sn_theta;
-	double ar_sn = r * a_sn;
-	return {
-	// iuu      iuv             iuw              ivv             ivw          iww
-		0, -a_sn * cn_phi, -a_cn * sn_phi, -ar_cn * cn_phi, ar_sn * sn_phi, -R * cn_phi,
-		0,  a_sn * sn_phi, -a_cn * cn_phi,  ar_cn * sn_phi, ar_sn * cn_phi,  R * sn_phi,
-		0,  a_cn         ,       0       , -ar_sn         ,       0       ,  0
-	};
-}
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian in spherical coordinates: 
-	@f$ J = a^2 \, r \, \left( R_0 + a \, r \, \cos \theta \right) @f$
-*/
-double morphism_polar_torus::jacobian(const IR3 &q) const {
-	double r = q[IR3::u];
-	double cn = std::cos(q[IR3::v]);
-	double Rfactor = (1.0+iaspect_ratio_*r*cn);
-	return volume_factor_*r*Rfactor;
-}
-
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}^r &= \left( \frac{\cos \theta \, \cos \phi}{a}, -\frac{\cos \theta \, \sin \phi}{a}, \frac{\sin \theta}{a} \right) \\
-			\textbf{e}^\theta &= \left( -\frac{\sin \theta \, \cos \phi}{a \, r}, \frac{\sin \theta \, \sin \phi}{a \, r}, \frac{\cos \theta}{a \, r} \right) \\
-			\textbf{e}^\phi &= \left( - \frac{\sin \phi}{R_0 + a \, r \, \cos \theta}, \frac{\cos \phi}{R_0 + a \, r \, \cos \theta}, 0 \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_polar_torus::del_inverse(const IR3 &q) const {
-	double r = q[IR3::u], ir = 1.0/q[IR3::u];
-	double cn_theta = std::cos(q[IR3::v]);
-	double sn_theta = std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
-	double iR = 1.0 / R;
-	double ia_cn = iminor_radius_*cn_theta;
-	double iar_cn = ir * ia_cn;
-	double ia_sn = iminor_radius_*sn_theta;
-	double iar_sn = ir * ia_sn;
-	return {
-		  ia_cn * cn_phi, -ia_cn * sn_phi,  ia_sn,
-		-iar_sn * cn_phi, iar_sn * sn_phi, iar_cn,
-		    -iR * sn_phi,    -iR * cn_phi, 0
-	};
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism_polar_torus.cc
+++ b/gyronimo/metrics/morphism_polar_torus.cc
@@ -144,7 +144,7 @@ double morphism_polar_torus::jacobian(const IR3 &q) const {
     @f}
 */
 dIR3 morphism_polar_torus::del_inverse(const IR3 &q) const {
-	double r = q[IR3::u];
+	double r = q[IR3::u], ir = 1.0/q[IR3::u];
 	double cn_theta = std::cos(q[IR3::v]);
 	double sn_theta = std::sin(q[IR3::v]);
 	double cn_phi = std::cos(q[IR3::w]);
@@ -152,9 +152,9 @@ dIR3 morphism_polar_torus::del_inverse(const IR3 &q) const {
 	double R = major_radius_*(1.0 + iaspect_ratio_*r*cn_theta);
 	double iR = 1.0 / R;
 	double ia_cn = iminor_radius_*cn_theta;
-	double iar_cn = r * ia_cn;
+	double iar_cn = ir * ia_cn;
 	double ia_sn = iminor_radius_*sn_theta;
-	double iar_sn = r * ia_sn;
+	double iar_sn = ir * ia_sn;
 	return {
 		  ia_cn * cn_phi, -ia_cn * sn_phi,  ia_sn,
 		-iar_sn * cn_phi, iar_sn * sn_phi, iar_cn,

--- a/gyronimo/metrics/morphism_polar_torus.hh
+++ b/gyronimo/metrics/morphism_polar_torus.hh
@@ -24,32 +24,38 @@
 
 namespace gyronimo {
 
+//! Morphism for toroidal coordinates with polar cross section.
+/*!
+    The three contravariant coordinates are the distance to the magnetic axis
+    normalized to the `minor_radius` (`u`), the angle measured counterclockwise
+    on the poloidal cross section from the low-field side midplane (`v`, in
+    rads), and the toroidal angle (`w`, in rads) measured clockwise when looking
+    from the torus' top. The lengths `minor_radius` and `major_radius` are in SI
+    units.
+*/
 class morphism_polar_torus : public morphism {
+ public:
+  morphism_polar_torus(const double minor_radius, double major_radius);
+  virtual ~morphism_polar_torus() override {};
 
-public:
+  virtual IR3 operator()(const IR3& q) const override;
+  virtual IR3 inverse(const IR3& x) const override;
+  virtual dIR3 del(const IR3& q) const override;
+  virtual ddIR3 ddel(const IR3& q) const override;
 
-	morphism_polar_torus(const double minor_radius, double major_radius);
-	virtual ~morphism_polar_torus() override {};
+  virtual double jacobian(const IR3& q) const override;
+  virtual dIR3 del_inverse(const IR3& q) const override;
 
-	virtual IR3 operator()(const IR3 &q) const override;
-	virtual IR3 inverse(const IR3 &x) const override;
-	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 ddel(const IR3 &q) const override;
+  double minor_radius() const { return minor_radius_; };
+  double major_radius() const { return major_radius_; };
+  double iaspect_ratio() const { return iaspect_ratio_; };
 
-	virtual double jacobian(const IR3 &q) const override;
-	virtual dIR3 del_inverse(const IR3 &q) const override;
+ private:
+  const double minor_radius_, major_radius_;
+  const double iaspect_ratio_, volume_factor_;
+  const double iminor_radius_;
+};
 
-	double minor_radius() const {return minor_radius_;};
-	double major_radius() const {return major_radius_;};
-	double iaspect_ratio() const {return iaspect_ratio_;};
+}  // end namespace gyronimo
 
-private:
-	const double minor_radius_, major_radius_;
-	const double iaspect_ratio_, volume_factor_;
-	const double iminor_radius_;
-
-}; // end class morphism_polar_torus
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_MORPHISM_POLAR_TORUS
+#endif  // GYRONIMO_MORPHISM_POLAR_TORUS

--- a/gyronimo/metrics/morphism_polar_torus.hh
+++ b/gyronimo/metrics/morphism_polar_torus.hh
@@ -1,0 +1,55 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_polar_torus.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_MORPHISM_POLAR_TORUS
+#define GYRONIMO_MORPHISM_POLAR_TORUS
+
+#include <gyronimo/metrics/morphism.hh>
+
+namespace gyronimo {
+
+class morphism_polar_torus : public morphism {
+
+public:
+
+	morphism_polar_torus(const double minor_radius, double major_radius);
+	virtual ~morphism_polar_torus() override {};
+
+	virtual IR3 operator()(const IR3 &q) const override;
+	virtual IR3 inverse(const IR3 &x) const override;
+	virtual dIR3 del(const IR3 &q) const override;
+	virtual ddIR3 ddel(const IR3 &q) const override;
+
+	virtual double jacobian(const IR3 &q) const override;
+	virtual dIR3 del_inverse(const IR3 &q) const override;
+
+	double minor_radius() const {return minor_radius_;};
+	double major_radius() const {return major_radius_;};
+	double iaspect_ratio() const {return iaspect_ratio_;};
+
+private:
+	const double minor_radius_, major_radius_;
+	const double iaspect_ratio_, volume_factor_;
+	const double iminor_radius_;
+
+}; // end class morphism_polar_torus
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_MORPHISM_POLAR_TORUS

--- a/gyronimo/metrics/morphism_spherical.cc
+++ b/gyronimo/metrics/morphism_spherical.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 // @morphism_spherical.cc, this file is part of ::gyronimo::
 
+#include <cmath>
 #include <gyronimo/metrics/morphism_spherical.hh>
 
 namespace gyronimo {
@@ -27,19 +28,21 @@ namespace gyronimo {
 	Implements the coordinate transformation:
 	@f{gather*}{
 		\begin{aligned}
-			x &= r \, \cos \phi \, \sin \theta \\
-			y &= r \, \sin \phi \, \sin \theta \\
-			z &= r \, \cos \theta
+			x &= r_0 \, r \, \cos \phi \, \sin \theta \\
+			y &= r_0 \, r \, \sin \phi \, \sin \theta \\
+			z &= r_0 \, r \, \cos \theta
 		\end{aligned}
     @f}
 */
 IR3 morphism_spherical::operator()(const IR3 &q) const {
-	double r = q[IR3::u];
+	double r = r0_ * q[IR3::u];
 	double cn_theta = std::cos(q[IR3::v]);
 	double sn_theta = std::sin(q[IR3::v]);
 	double cn_phi = std::cos(q[IR3::w]);
 	double sn_phi = std::sin(q[IR3::w]);
-	return {r * cn_phi * sn_theta, r * sn_phi * sn_theta, r * cn_theta};
+	return {r * cn_phi * sn_theta, 
+			r * sn_phi * sn_theta, 
+			r * cn_theta};
 }
 
 //! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into spherical coordinates @f$ q^\alpha @f$.
@@ -47,7 +50,7 @@ IR3 morphism_spherical::operator()(const IR3 &q) const {
 	Implements the inverse transformation:
 	@f{gather*}{
 		\begin{aligned}
-			r &= \sqrt{x^2 + y^2 + z^2} \\
+			r &= \frac{1}{r_0} \sqrt{x^2 + y^2 + z^2} \\
 			\theta &= \arctan \left( \frac{\sqrt{x^2 + y^2}}{z} \right) \\
 			\phi &= \arctan \left( \frac{y}{x} \right)
 		\end{aligned}
@@ -55,7 +58,9 @@ IR3 morphism_spherical::operator()(const IR3 &q) const {
 */
 IR3 morphism_spherical::inverse(const IR3 &x) const {
 	double rho = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
-	return {std::sqrt(rho + x[IR3::w] * x[IR3::w]), std::atan2(sqrt(rho), x[IR3::w]), std::atan2(x[IR3::v], x[IR3::u])};
+	return {ir0_ * std::sqrt(rho + x[IR3::w] * x[IR3::w]), 
+			std::atan2(sqrt(rho), x[IR3::w]), 
+			std::atan2(x[IR3::v], x[IR3::u])};
 }
 
 //! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
@@ -63,47 +68,47 @@ IR3 morphism_spherical::inverse(const IR3 &x) const {
 	Implements the coordinate transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}_r &= \left( \cos \phi \, \sin \theta, \sin \phi \, \sin \theta, \cos \theta \right) \\
-			\textbf{e}_\theta &= \left( r \, \cos \phi \, \cos \theta, r \, \sin \phi \, \cos \theta, -r \, \sin \theta \right) \\
-			\textbf{e}_\phi &= \left( -r \, \sin \phi \, \sin \theta, r\, \cos \phi \, \sin \theta, 0 \right)
+			\textbf{e}_r &= \left( r_0 \, \cos \phi \, \sin \theta, r_0 \, \sin \phi \, \sin \theta, r_0 \, \cos \theta \right) \\
+			\textbf{e}_\theta &= \left( r_0 \, r \, \cos \phi \, \cos \theta, r_0 \, r \, \sin \phi \, \cos \theta, - r_0 \, r \, \sin \theta \right) \\
+			\textbf{e}_\phi &= \left( - r_0 \, r \, \sin \phi \, \sin \theta, r_0 \, r\, \cos \phi \, \sin \theta, 0 \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_spherical::del(const IR3 &q) const {
 	double r = q[IR3::u];
-	double cn_theta = std::cos(q[IR3::w]);
-	double sn_theta = std::sin(q[IR3::w]);
-	double cn_phi = std::cos(q[IR3::v]);
-	double sn_phi = std::sin(q[IR3::v]);
+	double cn_theta = r0_ * std::cos(q[IR3::v]);
+	double sn_theta = r0_ * std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
 	return {
-		cn_phi * sn_theta, r * cn_phi * cn_theta, - r * sn_phi * sn_theta,
-		sn_phi * sn_theta, r * sn_phi * cn_theta,   r * cn_phi * sn_theta,
-				 cn_theta, 		  - r * sn_theta, 	0
+		cn_phi * sn_theta,  r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
+		sn_phi * sn_theta,  r * sn_phi * cn_theta,  r * cn_phi * sn_theta,
+				 cn_theta, -r * 		 sn_theta,  		0
 	};
 }
 
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_spherical::del2(const IR3 &q) const {
+ddIR3 morphism_spherical::ddel(const IR3 &q) const {
 	double r = q[IR3::u];
-	double cn_theta = std::cos(q[IR3::w]);
-	double sn_theta = std::sin(q[IR3::w]);
-	double cn_phi = std::cos(q[IR3::v]);
-	double sn_phi = std::sin(q[IR3::v]);
+	double cn_theta = r0_ * std::cos(q[IR3::v]);
+	double sn_theta = r0_ * std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
 	return {
-	// iuu		iuv					iuw						ivv						ivw						iww
+	// iuu		iuv						iuw					ivv						ivw						iww
 		0, cn_phi * cn_theta, -sn_phi * sn_theta, -r * cn_phi * sn_theta, -r * sn_phi * cn_theta, -r * cn_phi * sn_theta,
 		0, sn_phi * cn_theta,  cn_phi * sn_theta, -r * sn_phi * sn_theta,  r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
-		0, 		   -sn_theta,				   0, 		   -r * cn_theta,					   0,		0
+		0, 		   -sn_theta,				   0, 		   -r * cn_theta,					   0,			0
 	};
 }
 
 //! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
 /*!
 	Implements the Jacobian in spherical coordinates: 
-	@f$ J = r^2 \, \sin \theta @f$
+	@f$ J = r_0^3 \, r^2 \, \sin \theta @f$
 */
 double morphism_spherical::jacobian(const IR3 &q) const {
-	return q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
+	return r0_3_ * q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
 }
 
 //! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
@@ -111,23 +116,24 @@ double morphism_spherical::jacobian(const IR3 &q) const {
 	Implements the inverse transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}^r &= \left( \cos \phi \, \sin \theta, \sin \phi \, \sin \theta, \cos \theta \right) \\
-			\textbf{e}^\theta &= \left( \frac{1}{r} \, \cos \phi \, \cos \theta, \frac{1}{r} \, \sin \phi \, \cos \theta, -\frac{1}{r} \, \sin \theta \right) \\
-			\textbf{e}^\phi &= \left( -\frac{\sin \phi}{r \, \sin \theta}, \frac{\cos \phi}{r \, \sin \theta}, 0 \right)
+			\textbf{e}^r &= \left( \frac{1}{r_0} \, \cos \phi \, \sin \theta, \frac{1}{r_0} \, \sin \phi \, \sin \theta, \frac{1}{r_0} \, \cos \theta \right) \\
+			\textbf{e}^\theta &= \left( \frac{1}{r_0 \, r} \, \cos \phi \, \cos \theta, \frac{1}{r_0 \, r} \, \sin \phi \, \cos \theta, -\frac{1}{r_0 \, r} \, \sin \theta \right) \\
+			\textbf{e}^\phi &= \left( -\frac{\sin \phi}{r_0 \, r \, \sin \theta}, \frac{\cos \phi}{r_0 \, r \, \sin \theta}, 0 \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
 	double ir = 1 / q[IR3::u];
-	double cn_theta = std::cos(q[IR3::w]);
-	double sn_theta = std::sin(q[IR3::w]);
-	double csc_theta = 1 / sn_theta;
-	double cn_phi = std::cos(q[IR3::v]);
-	double sn_phi = std::sin(q[IR3::v]);
+	double cn_theta = ir0_ * std::cos(q[IR3::v]);
+	double sn_theta = std::sin(q[IR3::v]);
+	double csc_theta = ir0_ / sn_theta;
+	sn_theta *= ir0_;
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
 	return {
-			   cn_phi * sn_theta, 		sn_phi * sn_theta, 		  cn_theta,
-		  ir * cn_phi * cn_theta,  ir * sn_phi * cn_theta, - ir * sn_theta,
-		- ir * sn_phi * csc_theta, ir * cn_phi * csc_theta, 	0
+			   cn_phi * sn_theta, 		 sn_phi * sn_theta, 	   cn_theta,
+		  ir * cn_phi * cn_theta,   ir * sn_phi * cn_theta, - ir * sn_theta,
+		- ir * sn_phi * csc_theta,  ir * cn_phi * csc_theta, 	0
 	};
 }
 

--- a/gyronimo/metrics/morphism_spherical.cc
+++ b/gyronimo/metrics/morphism_spherical.cc
@@ -28,14 +28,14 @@ namespace gyronimo {
 	Implements the coordinate transformation:
 	@f{gather*}{
 		\begin{aligned}
-			x &= r_0 \, r \, \cos \phi \, \sin \theta \\
-			y &= r_0 \, r \, \sin \phi \, \sin \theta \\
-			z &= r_0 \, r \, \cos \theta
+			x &= L_{ref} \, r \, \cos \phi \, \sin \theta \\
+			y &= L_{ref} \, r \, \sin \phi \, \sin \theta \\
+			z &= L_{ref} \, r \, \cos \theta
 		\end{aligned}
     @f}
 */
 IR3 morphism_spherical::operator()(const IR3 &q) const {
-	double r = r0_ * q[IR3::u];
+	double r = Lref_ * q[IR3::u];
 	double cn_theta = std::cos(q[IR3::v]);
 	double sn_theta = std::sin(q[IR3::v]);
 	double cn_phi = std::cos(q[IR3::w]);
@@ -50,7 +50,7 @@ IR3 morphism_spherical::operator()(const IR3 &q) const {
 	Implements the inverse transformation:
 	@f{gather*}{
 		\begin{aligned}
-			r &= \frac{1}{r_0} \sqrt{x^2 + y^2 + z^2} \\
+			r &= \frac{1}{L_{ref}} \sqrt{x^2 + y^2 + z^2} \\
 			\theta &= \arctan \left( \frac{\sqrt{x^2 + y^2}}{z} \right) \\
 			\phi &= \arctan \left( \frac{y}{x} \right)
 		\end{aligned}
@@ -58,7 +58,7 @@ IR3 morphism_spherical::operator()(const IR3 &q) const {
 */
 IR3 morphism_spherical::inverse(const IR3 &x) const {
 	double rho = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
-	return {ir0_ * std::sqrt(rho + x[IR3::w] * x[IR3::w]), 
+	return {iLref_ * std::sqrt(rho + x[IR3::w] * x[IR3::w]), 
 			std::atan2(sqrt(rho), x[IR3::w]), 
 			std::atan2(x[IR3::v], x[IR3::u])};
 }
@@ -68,16 +68,16 @@ IR3 morphism_spherical::inverse(const IR3 &x) const {
 	Implements the coordinate transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}_r &= \left( r_0 \, \cos \phi \, \sin \theta, r_0 \, \sin \phi \, \sin \theta, r_0 \, \cos \theta \right) \\
-			\textbf{e}_\theta &= \left( r_0 \, r \, \cos \phi \, \cos \theta, r_0 \, r \, \sin \phi \, \cos \theta, - r_0 \, r \, \sin \theta \right) \\
-			\textbf{e}_\phi &= \left( - r_0 \, r \, \sin \phi \, \sin \theta, r_0 \, r\, \cos \phi \, \sin \theta, 0 \right)
+			\textbf{e}_r &= \left( L_{ref} \, \cos \phi \, \sin \theta, L_{ref} \, \sin \phi \, \sin \theta, L_{ref} \, \cos \theta \right) \\
+			\textbf{e}_\theta &= \left( L_{ref} \, r \, \cos \phi \, \cos \theta, L_{ref} \, r \, \sin \phi \, \cos \theta, - L_{ref} \, r \, \sin \theta \right) \\
+			\textbf{e}_\phi &= \left( - L_{ref} \, r \, \sin \phi \, \sin \theta, L_{ref} \, r\, \cos \phi \, \sin \theta, 0 \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_spherical::del(const IR3 &q) const {
 	double r = q[IR3::u];
-	double cn_theta = r0_ * std::cos(q[IR3::v]);
-	double sn_theta = r0_ * std::sin(q[IR3::v]);
+	double cn_theta = Lref_ * std::cos(q[IR3::v]);
+	double sn_theta = Lref_ * std::sin(q[IR3::v]);
 	double cn_phi = std::cos(q[IR3::w]);
 	double sn_phi = std::sin(q[IR3::w]);
 	return {
@@ -90,8 +90,8 @@ dIR3 morphism_spherical::del(const IR3 &q) const {
 //! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
 ddIR3 morphism_spherical::ddel(const IR3 &q) const {
 	double r = q[IR3::u];
-	double cn_theta = r0_ * std::cos(q[IR3::v]);
-	double sn_theta = r0_ * std::sin(q[IR3::v]);
+	double cn_theta = Lref_ * std::cos(q[IR3::v]);
+	double sn_theta = Lref_ * std::sin(q[IR3::v]);
 	double cn_phi = std::cos(q[IR3::w]);
 	double sn_phi = std::sin(q[IR3::w]);
 	return {
@@ -105,10 +105,10 @@ ddIR3 morphism_spherical::ddel(const IR3 &q) const {
 //! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
 /*!
 	Implements the Jacobian in spherical coordinates: 
-	@f$ J = r_0^3 \, r^2 \, \sin \theta @f$
+	@f$ J = L_{ref}^3 \, r^2 \, \sin \theta @f$
 */
 double morphism_spherical::jacobian(const IR3 &q) const {
-	return r0_3_ * q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
+	return Lref_3_ * q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
 }
 
 //! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
@@ -116,18 +116,18 @@ double morphism_spherical::jacobian(const IR3 &q) const {
 	Implements the inverse transformation's first derivatives:
 	@f{gather*}{
 		\begin{aligned}
-			\textbf{e}^r &= \left( \frac{1}{r_0} \, \cos \phi \, \sin \theta, \frac{1}{r_0} \, \sin \phi \, \sin \theta, \frac{1}{r_0} \, \cos \theta \right) \\
-			\textbf{e}^\theta &= \left( \frac{1}{r_0 \, r} \, \cos \phi \, \cos \theta, \frac{1}{r_0 \, r} \, \sin \phi \, \cos \theta, -\frac{1}{r_0 \, r} \, \sin \theta \right) \\
-			\textbf{e}^\phi &= \left( -\frac{\sin \phi}{r_0 \, r \, \sin \theta}, \frac{\cos \phi}{r_0 \, r \, \sin \theta}, 0 \right)
+			\textbf{e}^r &= \left( \frac{1}{L_{ref}} \, \cos \phi \, \sin \theta, \frac{1}{L_{ref}} \, \sin \phi \, \sin \theta, \frac{1}{L_{ref}} \, \cos \theta \right) \\
+			\textbf{e}^\theta &= \left( \frac{1}{L_{ref} \, r} \, \cos \phi \, \cos \theta, \frac{1}{L_{ref} \, r} \, \sin \phi \, \cos \theta, -\frac{1}{L_{ref} \, r} \, \sin \theta \right) \\
+			\textbf{e}^\phi &= \left( -\frac{\sin \phi}{L_{ref} \, r \, \sin \theta}, \frac{\cos \phi}{L_{ref} \, r \, \sin \theta}, 0 \right)
 		\end{aligned}
     @f}
 */
 dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
 	double ir = 1 / q[IR3::u];
-	double cn_theta = ir0_ * std::cos(q[IR3::v]);
+	double cn_theta = iLref_ * std::cos(q[IR3::v]);
 	double sn_theta = std::sin(q[IR3::v]);
-	double csc_theta = ir0_ / sn_theta;
-	sn_theta *= ir0_;
+	double csc_theta = iLref_ / sn_theta;
+	sn_theta *= iLref_;
 	double cn_phi = std::cos(q[IR3::w]);
 	double sn_phi = std::sin(q[IR3::w]);
 	return {

--- a/gyronimo/metrics/morphism_spherical.cc
+++ b/gyronimo/metrics/morphism_spherical.cc
@@ -17,124 +17,62 @@
 
 // @morphism_spherical.cc, this file is part of ::gyronimo::
 
-#include <cmath>
 #include <gyronimo/metrics/morphism_spherical.hh>
+
+#include <cmath>
 
 namespace gyronimo {
 
-//! Maps spherical coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
-/*!
-	In spherical coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( r, \theta, \phi \right) @f$.
-	Implements the coordinate transformation:
-	@f{gather*}{
-		\begin{aligned}
-			x &= L_{ref} \, r \, \cos \phi \, \sin \theta \\
-			y &= L_{ref} \, r \, \sin \phi \, \sin \theta \\
-			z &= L_{ref} \, r \, \cos \theta
-		\end{aligned}
-    @f}
-*/
-IR3 morphism_spherical::operator()(const IR3 &q) const {
-	double r = Lref_ * q[IR3::u];
-	double cn_theta = std::cos(q[IR3::v]);
-	double sn_theta = std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	return {r * cn_phi * sn_theta, 
-			r * sn_phi * sn_theta, 
-			r * cn_theta};
+IR3 morphism_spherical::operator()(const IR3& q) const {
+  double r = Lref_ * q[IR3::u];
+  double cn_theta = std::cos(q[IR3::v]);
+  double sn_theta = std::sin(q[IR3::v]);
+  double cn_phi = std::cos(q[IR3::w]);
+  double sn_phi = std::sin(q[IR3::w]);
+  return {r * cn_phi * sn_theta, r * sn_phi * sn_theta, r * cn_theta};
+}
+IR3 morphism_spherical::inverse(const IR3& x) const {
+  double r_squared = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
+  return {iLref_ * std::sqrt(r_squared + x[IR3::w] * x[IR3::w]),
+      std::atan2(sqrt(r_squared), x[IR3::w]), std::atan2(x[IR3::v], x[IR3::u])};
+}
+dIR3 morphism_spherical::del(const IR3& q) const {
+  double r = q[IR3::u];
+  double cn_theta = Lref_ * std::cos(q[IR3::v]);
+  double sn_theta = Lref_ * std::sin(q[IR3::v]);
+  double cn_phi = std::cos(q[IR3::w]);
+  double sn_phi = std::sin(q[IR3::w]);
+  return {cn_phi * sn_theta, r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
+          sn_phi * sn_theta, r * sn_phi * cn_theta, r * cn_phi * sn_theta,
+          cn_theta, -r * sn_theta, 0};
+}
+ddIR3 morphism_spherical::ddel(const IR3& q) const {
+  double r = q[IR3::u];
+  double cn_theta = Lref_ * std::cos(q[IR3::v]);
+  double sn_theta = Lref_ * std::sin(q[IR3::v]);
+  double cn_phi = std::cos(q[IR3::w]);
+  double sn_phi = std::sin(q[IR3::w]);
+  return {0, cn_phi * cn_theta, -sn_phi * sn_theta,
+      -r * cn_phi * sn_theta, -r * sn_phi * cn_theta, -r * cn_phi * sn_theta,
+      0, sn_phi * cn_theta, cn_phi * sn_theta,
+      -r * sn_phi * sn_theta, r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
+      0, -sn_theta, 0,
+      -r * cn_theta, 0, 0};
+}
+double morphism_spherical::jacobian(const IR3& q) const {
+  return Lref3_ * q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
+}
+dIR3 morphism_spherical::del_inverse(const IR3& q) const {
+  double ir = 1 / q[IR3::u];
+  double cn_theta = iLref_ * std::cos(q[IR3::v]);
+  double sn_theta = std::sin(q[IR3::v]);
+  double csc_theta = iLref_ / sn_theta;
+  sn_theta *= iLref_;
+  double cn_phi = std::cos(q[IR3::w]);
+  double sn_phi = std::sin(q[IR3::w]);
+  return {cn_phi * sn_theta, sn_phi * sn_theta, cn_theta,
+      ir * cn_phi * cn_theta, ir * sn_phi * cn_theta, -ir * sn_theta,
+          -ir * sn_phi * csc_theta, ir * cn_phi * csc_theta, 0};
 }
 
-//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into spherical coordinates @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation:
-	@f{gather*}{
-		\begin{aligned}
-			r &= \frac{1}{L_{ref}} \sqrt{x^2 + y^2 + z^2} \\
-			\theta &= \arctan \left( \frac{\sqrt{x^2 + y^2}}{z} \right) \\
-			\phi &= \arctan \left( \frac{y}{x} \right)
-		\end{aligned}
-    @f}
-*/
-IR3 morphism_spherical::inverse(const IR3 &x) const {
-	double rho = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
-	return {iLref_ * std::sqrt(rho + x[IR3::w] * x[IR3::w]), 
-			std::atan2(sqrt(rho), x[IR3::w]), 
-			std::atan2(x[IR3::v], x[IR3::u])};
-}
-
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the coordinate transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}_r &= \left( L_{ref} \, \cos \phi \, \sin \theta, L_{ref} \, \sin \phi \, \sin \theta, L_{ref} \, \cos \theta \right) \\
-			\textbf{e}_\theta &= \left( L_{ref} \, r \, \cos \phi \, \cos \theta, L_{ref} \, r \, \sin \phi \, \cos \theta, - L_{ref} \, r \, \sin \theta \right) \\
-			\textbf{e}_\phi &= \left( - L_{ref} \, r \, \sin \phi \, \sin \theta, L_{ref} \, r\, \cos \phi \, \sin \theta, 0 \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_spherical::del(const IR3 &q) const {
-	double r = q[IR3::u];
-	double cn_theta = Lref_ * std::cos(q[IR3::v]);
-	double sn_theta = Lref_ * std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	return {
-		cn_phi * sn_theta,  r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
-		sn_phi * sn_theta,  r * sn_phi * cn_theta,  r * cn_phi * sn_theta,
-				 cn_theta, -r * 		 sn_theta,  		0
-	};
-}
-
-//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
-ddIR3 morphism_spherical::ddel(const IR3 &q) const {
-	double r = q[IR3::u];
-	double cn_theta = Lref_ * std::cos(q[IR3::v]);
-	double sn_theta = Lref_ * std::sin(q[IR3::v]);
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	return {
-	// iuu		iuv						iuw					ivv						ivw						iww
-		0, cn_phi * cn_theta, -sn_phi * sn_theta, -r * cn_phi * sn_theta, -r * sn_phi * cn_theta, -r * cn_phi * sn_theta,
-		0, sn_phi * cn_theta,  cn_phi * sn_theta, -r * sn_phi * sn_theta,  r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
-		0, 		   -sn_theta,				   0, 		   -r * cn_theta,					   0,			0
-	};
-}
-
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-/*!
-	Implements the Jacobian in spherical coordinates: 
-	@f$ J = L_{ref}^3 \, r^2 \, \sin \theta @f$
-*/
-double morphism_spherical::jacobian(const IR3 &q) const {
-	return Lref_3_ * q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
-}
-
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
-/*!
-	Implements the inverse transformation's first derivatives:
-	@f{gather*}{
-		\begin{aligned}
-			\textbf{e}^r &= \left( \frac{1}{L_{ref}} \, \cos \phi \, \sin \theta, \frac{1}{L_{ref}} \, \sin \phi \, \sin \theta, \frac{1}{L_{ref}} \, \cos \theta \right) \\
-			\textbf{e}^\theta &= \left( \frac{1}{L_{ref} \, r} \, \cos \phi \, \cos \theta, \frac{1}{L_{ref} \, r} \, \sin \phi \, \cos \theta, -\frac{1}{L_{ref} \, r} \, \sin \theta \right) \\
-			\textbf{e}^\phi &= \left( -\frac{\sin \phi}{L_{ref} \, r \, \sin \theta}, \frac{\cos \phi}{L_{ref} \, r \, \sin \theta}, 0 \right)
-		\end{aligned}
-    @f}
-*/
-dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
-	double ir = 1 / q[IR3::u];
-	double cn_theta = iLref_ * std::cos(q[IR3::v]);
-	double sn_theta = std::sin(q[IR3::v]);
-	double csc_theta = iLref_ / sn_theta;
-	sn_theta *= iLref_;
-	double cn_phi = std::cos(q[IR3::w]);
-	double sn_phi = std::sin(q[IR3::w]);
-	return {
-			   cn_phi * sn_theta, 		 sn_phi * sn_theta, 	   cn_theta,
-		  ir * cn_phi * cn_theta,   ir * sn_phi * cn_theta, - ir * sn_theta,
-		- ir * sn_phi * csc_theta,  ir * cn_phi * csc_theta, 	0
-	};
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism_spherical.cc
+++ b/gyronimo/metrics/morphism_spherical.cc
@@ -1,0 +1,69 @@
+#include <gyronimo/metrics/morphism_spherical.hh>
+
+namespace gyronimo {
+
+// Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+IR3 morphism_spherical::operator()(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::w]);
+	double sn_theta = std::sin(q[IR3::w]);
+	double cn_phi = std::cos(q[IR3::v]);
+	double sn_phi = std::sin(q[IR3::v]);
+	return {r * cn_phi * sn_theta, r * sn_phi * sn_theta, r * cn_theta};
+}
+
+// Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+IR3 morphism_spherical::inverse(const IR3 &x) const {
+	double rho = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
+	return {std::sqrt(rho + x[IR3::w] * x[IR3::w]), std::atan2(x[IR3::u], x[IR3::v]), std::atan2(x[IR3::w], sqrt(rho))};
+}
+
+// Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+dIR3 morphism_spherical::del(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::w]);
+	double sn_theta = std::sin(q[IR3::w]);
+	double cn_phi = std::cos(q[IR3::v]);
+	double sn_phi = std::sin(q[IR3::v]);
+	return {
+		cn_phi * sn_theta, - r * sn_phi * sn_theta, r * cn_phi * cn_theta,
+		sn_phi * sn_theta,   r * cn_phi * sn_theta, r * sn_phi * cn_theta,
+				 cn_theta, 						 0, - r * sn_theta
+	};
+}
+
+dSM3 morphism_spherical::g_del(const IR3 &q) const {
+	double r = q[IR3::u];
+	double sn_theta = std::sin(q[IR3::w]);
+	double sn_2theta = std::sin(2 * q[IR3::w]);
+	return {
+		0, 0, 0, // g_uu
+		0, 0, 0, // g_uv
+		0, 0, 0, // g_uw
+		2 * r * sn_theta * sn_theta, 0, r * r * sn_2theta, // g_vv
+		0, 0, 0, // g_vw
+		2 * r, 0, 0  // g_ww
+	};
+}
+
+// Returns the jacobian of the transformation in point `q`.
+double morphism_spherical::jacobian(const IR3 &q) const {
+	return q[IR3::u] * q[IR3::u] * sin(IR3::w);
+}
+
+// Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
+	double ir = 1 / q[IR3::u];
+	double cn_theta = std::cos(q[IR3::w]);
+	double sn_theta = std::sin(q[IR3::w]);
+	double csc_theta = 1 / sn_theta;
+	double cn_phi = std::cos(q[IR3::v]);
+	double sn_phi = std::sin(q[IR3::v]);
+	return {
+			   cn_phi * sn_theta, 		sn_phi * sn_theta, 		cn_theta,
+		- ir * sn_phi * csc_theta, ir * cn_phi * csc_theta, 			0,
+		  ir * cn_phi * cn_theta,  ir * sn_phi * cn_theta, - ir * sn_theta
+	};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/morphism_spherical.cc
+++ b/gyronimo/metrics/morphism_spherical.cc
@@ -21,7 +21,18 @@
 
 namespace gyronimo {
 
-//! Maps the spherical coordinates `q = (r, \theta, \phi)` into cartesian coordinates `x`.
+//! Maps spherical coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
+/*!
+	In spherical coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( r, \theta, \phi \right) @f$.
+	Implements the coordinate transformation:
+	@f{gather*}{
+		\begin{aligned}
+			x &= r \, \cos \phi \, \sin \theta \\
+			y &= r \, \sin \phi \, \sin \theta \\
+			z &= r \, \cos \theta
+		\end{aligned}
+    @f}
+*/
 IR3 morphism_spherical::operator()(const IR3 &q) const {
 	double r = q[IR3::u];
 	double cn_theta = std::cos(q[IR3::v]);
@@ -31,13 +42,33 @@ IR3 morphism_spherical::operator()(const IR3 &q) const {
 	return {r * cn_phi * sn_theta, r * sn_phi * sn_theta, r * cn_theta};
 }
 
-//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `(r, \theta, \phi)`.
+//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into spherical coordinates @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation:
+	@f{gather*}{
+		\begin{aligned}
+			r &= \sqrt{x^2 + y^2 + z^2} \\
+			\theta &= \arctan \left( \frac{\sqrt{x^2 + y^2}}{z} \right) \\
+			\phi &= \arctan \left( \frac{y}{x} \right)
+		\end{aligned}
+    @f}
+*/
 IR3 morphism_spherical::inverse(const IR3 &x) const {
 	double rho = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
 	return {std::sqrt(rho + x[IR3::w] * x[IR3::w]), std::atan2(sqrt(rho), x[IR3::w]), std::atan2(x[IR3::v], x[IR3::u])};
 }
 
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the coordinate transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}_r &= \left( \cos \phi \, \sin \theta, \sin \phi \, \sin \theta, \cos \theta \right) \\
+			\textbf{e}_\theta &= \left( r \, \cos \phi \, \cos \theta, r \, \sin \phi \, \cos \theta, -r \, \sin \theta \right) \\
+			\textbf{e}_\phi &= \left( -r \, \sin \phi \, \sin \theta, r\, \cos \phi \, \sin \theta, 0 \right)
+		\end{aligned}
+    @f}
+*/
 dIR3 morphism_spherical::del(const IR3 &q) const {
 	double r = q[IR3::u];
 	double cn_theta = std::cos(q[IR3::w]);
@@ -51,12 +82,41 @@ dIR3 morphism_spherical::del(const IR3 &q) const {
 	};
 }
 
-//! General-purpose implementation of the Jacobian of the transformation in point `q`.
+//! Returns the morphism's second derivatives, calculated in point @f$ q^\alpha @f$.
+ddIR3 morphism_spherical::del2(const IR3 &q) const {
+	double r = q[IR3::u];
+	double cn_theta = std::cos(q[IR3::w]);
+	double sn_theta = std::sin(q[IR3::w]);
+	double cn_phi = std::cos(q[IR3::v]);
+	double sn_phi = std::sin(q[IR3::v]);
+	return {
+	// iuu		iuv					iuw						ivv						ivw						iww
+		0, cn_phi * cn_theta, -sn_phi * sn_theta, -r * cn_phi * sn_theta, -r * sn_phi * cn_theta, -r * cn_phi * sn_theta,
+		0, sn_phi * cn_theta,  cn_phi * sn_theta, -r * sn_phi * sn_theta,  r * cn_phi * cn_theta, -r * sn_phi * sn_theta,
+		0, 		   -sn_theta,				   0, 		   -r * cn_theta,					   0,		0
+	};
+}
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+/*!
+	Implements the Jacobian in spherical coordinates: 
+	@f$ J = r^2 \, \sin \theta @f$
+*/
 double morphism_spherical::jacobian(const IR3 &q) const {
 	return q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
 }
 
-//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point @f$ q^\alpha @f$.
+/*!
+	Implements the inverse transformation's first derivatives:
+	@f{gather*}{
+		\begin{aligned}
+			\textbf{e}^r &= \left( \cos \phi \, \sin \theta, \sin \phi \, \sin \theta, \cos \theta \right) \\
+			\textbf{e}^\theta &= \left( \frac{1}{r} \, \cos \phi \, \cos \theta, \frac{1}{r} \, \sin \phi \, \cos \theta, -\frac{1}{r} \, \sin \theta \right) \\
+			\textbf{e}^\phi &= \left( -\frac{\sin \phi}{r \, \sin \theta}, \frac{\cos \phi}{r \, \sin \theta}, 0 \right)
+		\end{aligned}
+    @f}
+*/
 dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
 	double ir = 1 / q[IR3::u];
 	double cn_theta = std::cos(q[IR3::w]);

--- a/gyronimo/metrics/morphism_spherical.cc
+++ b/gyronimo/metrics/morphism_spherical.cc
@@ -1,24 +1,43 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_spherical.cc, this file is part of ::gyronimo::
+
 #include <gyronimo/metrics/morphism_spherical.hh>
 
 namespace gyronimo {
 
-// Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+//! Maps the spherical coordinates `q = (r, \theta, \phi)` into cartesian coordinates `x`.
 IR3 morphism_spherical::operator()(const IR3 &q) const {
 	double r = q[IR3::u];
-	double cn_theta = std::cos(q[IR3::w]);
-	double sn_theta = std::sin(q[IR3::w]);
-	double cn_phi = std::cos(q[IR3::v]);
-	double sn_phi = std::sin(q[IR3::v]);
+	double cn_theta = std::cos(q[IR3::v]);
+	double sn_theta = std::sin(q[IR3::v]);
+	double cn_phi = std::cos(q[IR3::w]);
+	double sn_phi = std::sin(q[IR3::w]);
 	return {r * cn_phi * sn_theta, r * sn_phi * sn_theta, r * cn_theta};
 }
 
-// Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `(r, \theta, \phi)`.
 IR3 morphism_spherical::inverse(const IR3 &x) const {
 	double rho = x[IR3::u] * x[IR3::u] + x[IR3::v] * x[IR3::v];
-	return {std::sqrt(rho + x[IR3::w] * x[IR3::w]), std::atan2(x[IR3::u], x[IR3::v]), std::atan2(x[IR3::w], sqrt(rho))};
+	return {std::sqrt(rho + x[IR3::w] * x[IR3::w]), std::atan2(sqrt(rho), x[IR3::w]), std::atan2(x[IR3::v], x[IR3::u])};
 }
 
-// Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point `q`.
 dIR3 morphism_spherical::del(const IR3 &q) const {
 	double r = q[IR3::u];
 	double cn_theta = std::cos(q[IR3::w]);
@@ -26,32 +45,18 @@ dIR3 morphism_spherical::del(const IR3 &q) const {
 	double cn_phi = std::cos(q[IR3::v]);
 	double sn_phi = std::sin(q[IR3::v]);
 	return {
-		cn_phi * sn_theta, - r * sn_phi * sn_theta, r * cn_phi * cn_theta,
-		sn_phi * sn_theta,   r * cn_phi * sn_theta, r * sn_phi * cn_theta,
-				 cn_theta, 						 0, - r * sn_theta
+		cn_phi * sn_theta, r * cn_phi * cn_theta, - r * sn_phi * sn_theta,
+		sn_phi * sn_theta, r * sn_phi * cn_theta,   r * cn_phi * sn_theta,
+				 cn_theta, 		  - r * sn_theta, 	0
 	};
 }
 
-dSM3 morphism_spherical::g_del(const IR3 &q) const {
-	double r = q[IR3::u];
-	double sn_theta = std::sin(q[IR3::w]);
-	double sn_2theta = std::sin(2 * q[IR3::w]);
-	return {
-		0, 0, 0, // g_uu
-		0, 0, 0, // g_uv
-		0, 0, 0, // g_uw
-		2 * r * sn_theta * sn_theta, 0, r * r * sn_2theta, // g_vv
-		0, 0, 0, // g_vw
-		2 * r, 0, 0  // g_ww
-	};
-}
-
-// Returns the jacobian of the transformation in point `q`.
+//! General-purpose implementation of the Jacobian of the transformation in point `q`.
 double morphism_spherical::jacobian(const IR3 &q) const {
-	return q[IR3::u] * q[IR3::u] * sin(IR3::w);
+	return q[IR3::u] * q[IR3::u] * std::sin(q[IR3::v]);
 }
 
-// Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
 dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
 	double ir = 1 / q[IR3::u];
 	double cn_theta = std::cos(q[IR3::w]);
@@ -60,9 +65,9 @@ dIR3 morphism_spherical::del_inverse(const IR3 &q) const {
 	double cn_phi = std::cos(q[IR3::v]);
 	double sn_phi = std::sin(q[IR3::v]);
 	return {
-			   cn_phi * sn_theta, 		sn_phi * sn_theta, 		cn_theta,
-		- ir * sn_phi * csc_theta, ir * cn_phi * csc_theta, 			0,
-		  ir * cn_phi * cn_theta,  ir * sn_phi * cn_theta, - ir * sn_theta
+			   cn_phi * sn_theta, 		sn_phi * sn_theta, 		  cn_theta,
+		  ir * cn_phi * cn_theta,  ir * sn_phi * cn_theta, - ir * sn_theta,
+		- ir * sn_phi * csc_theta, ir * cn_phi * csc_theta, 	0
 	};
 }
 

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -1,0 +1,43 @@
+
+#ifndef GYRONIMO_MORPHISM_SPHERICAL
+#define GYRONIMO_MORPHISM_SPHERICAL
+
+#include <cmath>
+
+#include <gyronimo/metrics/morphism.hh>
+
+namespace gyronimo {
+
+class morphism_spherical : public morphism {
+
+public:
+
+	//! Class Constructor
+	morphism_spherical() : morphism() {};
+
+	//! Class Destructor
+	~morphism_spherical() {};
+
+	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
+	IR3 operator()(const IR3 &q) const override;
+
+	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
+	IR3 inverse(const IR3 &x) const override;
+
+	//! Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
+	dIR3 del(const IR3 &q) const override;
+	dSM3 g_del(const IR3 &q) const override;
+
+	//! Returns the jacobian of the transformation in point `q`.
+	double jacobian(const IR3 &q) const override;
+
+	//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
+	dIR3 del_inverse(const IR3 &q) const override;
+
+private:
+
+}; // end class morphism_spherical
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_MORPHISM_SPHERICAL

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -36,6 +36,7 @@ public:
 	virtual IR3 operator()(const IR3 &q) const override;
 	virtual IR3 inverse(const IR3 &x) const override;
 	virtual dIR3 del(const IR3 &q) const override;
+	virtual ddIR3 del2(const IR3 &q) const override;
 
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -40,7 +40,7 @@ public:
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
-	double r0() {return r0_;};
+	double r0() const {return r0_;};
 
 private:
 	const double r0_, ir0_, r0_3_;

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Paulo Rodrigues.
+// Copyright (C) 2022 Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,8 +20,6 @@
 #ifndef GYRONIMO_MORPHISM_SPHERICAL
 #define GYRONIMO_MORPHISM_SPHERICAL
 
-#include <cmath>
-
 #include <gyronimo/metrics/morphism.hh>
 
 namespace gyronimo {
@@ -30,18 +28,22 @@ class morphism_spherical : public morphism {
 
 public:
 
-	morphism_spherical() : morphism() {};
+	morphism_spherical(const double &r0) 
+		: morphism(), r0_(r0), ir0_(1/r0), r0_3_(r0*r0*r0) {};
 	virtual ~morphism_spherical() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
 	virtual IR3 inverse(const IR3 &x) const override;
 	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 del2(const IR3 &q) const override;
+	virtual ddIR3 ddel(const IR3 &q) const override;
 
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
+	double r0() {return r0_;};
+
 private:
+	const double r0_, ir0_, r0_3_;
 
 }; // end class morphism_spherical
 

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -1,3 +1,21 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Paulo Rodrigues.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_spherical.hh, this file is part of ::gyronimo::
 
 #ifndef GYRONIMO_MORPHISM_SPHERICAL
 #define GYRONIMO_MORPHISM_SPHERICAL
@@ -12,27 +30,15 @@ class morphism_spherical : public morphism {
 
 public:
 
-	//! Class Constructor
 	morphism_spherical() : morphism() {};
+	virtual ~morphism_spherical() override {};
 
-	//! Class Destructor
-	~morphism_spherical() {};
+	virtual IR3 operator()(const IR3 &q) const override;
+	virtual IR3 inverse(const IR3 &x) const override;
+	virtual dIR3 del(const IR3 &q) const override;
 
-	//! Maps the curvilinear coordinates `q` into cartesian coordinates `x`.
-	IR3 operator()(const IR3 &q) const override;
-
-	//! Inverse transform from cartesian coordinates `x` into curvilinear coordinates `q`.
-	IR3 inverse(const IR3 &x) const override;
-
-	//! Returns the morphism's derivatives, correspondent to the covariant basis vectors in point `q`.
-	dIR3 del(const IR3 &q) const override;
-	dSM3 g_del(const IR3 &q) const override;
-
-	//! Returns the jacobian of the transformation in point `q`.
-	double jacobian(const IR3 &q) const override;
-
-	//! Returns the morphism's inverse derivatives, correspondent to the contravariant basis vectors in point `q`.
-	dIR3 del_inverse(const IR3 &q) const override;
+	virtual double jacobian(const IR3 &q) const override;
+	virtual dIR3 del_inverse(const IR3 &q) const override;
 
 private:
 

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -28,8 +28,8 @@ class morphism_spherical : public morphism {
 
 public:
 
-	morphism_spherical(const double &r0) 
-		: morphism(), r0_(r0), ir0_(1/r0), r0_3_(r0*r0*r0) {};
+	morphism_spherical(const double &Lref) 
+		: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {};
 	virtual ~morphism_spherical() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
@@ -40,10 +40,10 @@ public:
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
-	double r0() {return r0_;};
+	double Lref() {return Lref_;};
 
 private:
-	const double r0_, ir0_, r0_3_;
+	const double Lref_, iLref_, Lref_3_;
 
 }; // end class morphism_spherical
 

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -24,29 +24,33 @@
 
 namespace gyronimo {
 
+//! Morphism for spherical coordinates.
+/*!
+    The three contravariant coordinates are the distance to the origin
+    normalised to `Lref` in SI units, the angle measured from the `z` axis
+    (i.e., co-latitude measured from the north pole), and the angle measured
+    from the `x` axis counterclockwise when seen from the north pole.
+*/
 class morphism_spherical : public morphism {
+ public:
+  morphism_spherical(const double& Lref)
+      : morphism(), Lref_(Lref), iLref_(1 / Lref),
+        Lref3_(Lref * Lref * Lref) {};
+  virtual ~morphism_spherical() override {};
 
-public:
+  virtual IR3 operator()(const IR3& q) const override;
+  virtual IR3 inverse(const IR3& x) const override;
+  virtual dIR3 del(const IR3& q) const override;
+  virtual ddIR3 ddel(const IR3& q) const override;
 
-	morphism_spherical(const double &Lref) 
-		: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {};
-	virtual ~morphism_spherical() override {};
+  virtual double jacobian(const IR3& q) const override;
+  virtual dIR3 del_inverse(const IR3& q) const override;
 
-	virtual IR3 operator()(const IR3 &q) const override;
-	virtual IR3 inverse(const IR3 &x) const override;
-	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 ddel(const IR3 &q) const override;
+  double Lref() const { return Lref_; };
+ private:
+  const double Lref_, iLref_, Lref3_;
+};
 
-	virtual double jacobian(const IR3 &q) const override;
-	virtual dIR3 del_inverse(const IR3 &q) const override;
+}  // end namespace gyronimo
 
-	double Lref() const {return Lref_;};
-
-private:
-	const double Lref_, iLref_, Lref_3_;
-
-}; // end class morphism_spherical
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_MORPHISM_SPHERICAL
+#endif  // GYRONIMO_MORPHISM_SPHERICAL

--- a/gyronimo/metrics/morphism_spherical.hh
+++ b/gyronimo/metrics/morphism_spherical.hh
@@ -28,8 +28,8 @@ class morphism_spherical : public morphism {
 
 public:
 
-	morphism_spherical(const double &r0) 
-		: morphism(), r0_(r0), ir0_(1/r0), r0_3_(r0*r0*r0) {};
+	morphism_spherical(const double &Lref) 
+		: morphism(), Lref_(Lref), iLref_(1/Lref), Lref_3_(Lref*Lref*Lref) {};
 	virtual ~morphism_spherical() override {};
 
 	virtual IR3 operator()(const IR3 &q) const override;
@@ -40,10 +40,10 @@ public:
 	virtual double jacobian(const IR3 &q) const override;
 	virtual dIR3 del_inverse(const IR3 &q) const override;
 
-	double r0() const {return r0_;};
+	double Lref() const {return Lref_;};
 
 private:
-	const double r0_, ir0_, r0_3_;
+	const double Lref_, iLref_, Lref_3_;
 
 }; // end class morphism_spherical
 

--- a/gyronimo/metrics/morphism_vmec.cc
+++ b/gyronimo/metrics/morphism_vmec.cc
@@ -17,278 +17,203 @@
 
 // @mrophism_vmec.cc, this file is part of ::gyronimo::
 
-#include <gyronimo/metrics/morphism_vmec.hh>
-#include <numbers>
 #include <gyronimo/core/multiroot.hh>
+#include <gyronimo/metrics/morphism_vmec.hh>
 
-namespace gyronimo{
+#include <numbers>
 
-morphism_vmec::morphism_vmec(const parser_vmec *p, 
-		const interpolator1d_factory *ifactory)
-		: parser_(p), xm_(p->xm()), xn_(p->xn()) {
+namespace gyronimo {
 
-	//set radial grid block
-    dblock_adapter s_range(p->radius());
-    // set spectral components 
-    Rmnc_ = new interpolator1d* [xm_.size()];
-    Zmns_ = new interpolator1d* [xm_.size()];
-
-	for(size_t i = 0; i < xm_.size(); ++i) {
-		std::slice s_cut (i, s_range.size(), xm_.size());
-		narray_type rmnc_i = (p->rmnc())[s_cut];
-		Rmnc_[i] = ifactory->interpolate_data( s_range, dblock_adapter(rmnc_i));
-		narray_type zmns_i = (p->zmns())[s_cut];
-		Zmns_[i] = ifactory->interpolate_data( s_range, dblock_adapter(zmns_i));
-	}
+morphism_vmec::morphism_vmec(
+    const parser_vmec* p, const interpolator1d_factory* ifactory)
+    : parser_(p), xm_(p->xm()), xn_(p->xn()) {
+  dblock_adapter s_range(p->radius());
+  Rmnc_ = new interpolator1d*[xm_.size()];
+  Zmns_ = new interpolator1d*[xm_.size()];
+  for (size_t i = 0; i < xm_.size(); ++i) {
+    std::slice s_cut(i, s_range.size(), xm_.size());
+    narray_type rmnc_i = (p->rmnc())[s_cut];
+    Rmnc_[i] = ifactory->interpolate_data(s_range, dblock_adapter(rmnc_i));
+    narray_type zmns_i = (p->zmns())[s_cut];
+    Zmns_[i] = ifactory->interpolate_data(s_range, dblock_adapter(zmns_i));
+  }
 }
-
 morphism_vmec::~morphism_vmec() {
-	if(Rmnc_) {
-		for(size_t i = 0; i < xm_.size(); ++i)
-			if(Rmnc_[i]) delete Rmnc_[i];
-		delete Rmnc_;
-	}
-	if(Zmns_) {
-		for(size_t i = 0; i < xm_.size(); ++i)
-			if(Zmns_[i]) delete Zmns_[i];
-		delete Zmns_;
-	}
+  if (Rmnc_) {
+    for (size_t i = 0; i < xm_.size(); ++i)
+      if (Rmnc_[i]) delete Rmnc_[i];
+    delete Rmnc_;
+  }
+  if (Zmns_) {
+    for (size_t i = 0; i < xm_.size(); ++i)
+      if (Zmns_[i]) delete Zmns_[i];
+    delete Zmns_;
+  }
 }
-
-//! Maps `VMEC` coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
-/*!
-	In `VMEC` coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( s, \zeta, \theta \right) @f$
-*/
 IR3 morphism_vmec::operator()(const IR3& q) const {
-	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
-	double R = 0.0, Z = 0.0;
+  double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+  double R = 0.0, Z = 0.0;
 
-	#pragma omp parallel for reduction(+: R, Z)
-	for (size_t i = 0; i < xm_.size(); ++i) {  
-		double m = xm_[i], n = xn_[i];
-		double angle_mn = m*theta - n*zeta;
-		double cosmn = std::cos( angle_mn );
-		double sinmn = std::sin( angle_mn );
-		// assuming for now that vmec equilibrium has stellarator symmetry.
-		R += (*Rmnc_[i])(s) * cosmn; 
-		Z += (*Zmns_[i])(s) * sinmn;
-	}
-
-	return {R * std::cos(zeta), R * std::sin(zeta), Z};
+#pragma omp parallel for reduction(+ : R, Z)
+  for (size_t i = 0; i < xm_.size(); ++i) {
+    double m = xm_[i], n = xn_[i];
+    double angle_mn = m * theta - n * zeta;
+    double cosmn = std::cos(angle_mn), sinmn = std::sin(angle_mn);
+    R += (*Rmnc_[i])(s)*cosmn; // assuming stellarator symmetry
+    Z += (*Zmns_[i])(s)*sinmn;
+  }
+  return {R * std::cos(zeta), R * std::sin(zeta), Z};
 }
-
-//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into `VMEC` coordinates @f$ q^\alpha @f$.
 IR3 morphism_vmec::inverse(const IR3& X) const {
-	typedef std::array<double, 2> IR2;
-	double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
-	double zeta = std::atan2(y, x);
-	double r = std::sqrt(x*x + y*y);
+  typedef std::array<double, 2> IR2;
+  double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
+  double r = std::sqrt(x * x + y * y), zeta = std::atan2(y, x);
 
-	std::function<IR2(const IR2&)> zero_function =
-		[&](const IR2& args) {
-			auto [s, theta] = reflection_past_axis(args[0], args[1]);
-			IR3 cyl = transform2cylindrical(IR3({s, zeta, theta}));
-			double R = cyl[IR3::u], Z = cyl[IR3::w];
-			return IR2({R-r, Z-z});
-		};
-	IR3 axis = transform2cylindrical({0, zeta, 0});
-	double R0 = axis[IR3::u], Z0 = axis[IR3::w];
-	IR2 guess = {0.5, std::atan2(z-Z0, r-R0)};
-	IR2 roots = multiroot(1.0e-13, 100)(zero_function, guess);
-	auto [s, theta] = reflection_past_axis(roots[0], roots[1]);
-	return {s, zeta, theta};
+  std::function<IR2(const IR2&)> zero_function = [&](const IR2& args) {
+    auto [s, theta] = reflection_past_axis(args[0], args[1]);
+    auto [R, Z] = get_rz(IR3({s, zeta, theta}));
+    return IR2({R - r, Z - z});
+  };
+  auto [R0, Z0] = get_rz({0, zeta, 0});
+  IR2 guess = {0.5, std::atan2(z - Z0, r - R0)};
+  IR2 roots = multiroot(1.0e-13, 100)(zero_function, guess);
+  auto [s, theta] = reflection_past_axis(roots[0], roots[1]);
+  return {s, zeta, theta};
 }
-
-//! Translates the curvilinear position `q` by the cartesian vector `delta`
-/*!
-	Implements the rule:
-	@f$ q^\alpha = Q^\alpha \left( \textbf{X}\left(\right) + \Delta \right) @f$
-*/
-IR3 morphism_vmec::translation(const IR3 &q, const IR3 &delta) const {
-	typedef std::array<double, 2> IR2;
-	IR3 X = (*this)(q);
-	double Xt = X[IR3::u] + delta[IR3::u];
-	double Yt = X[IR3::v] + delta[IR3::v];
-	double Zt = X[IR3::w] + delta[IR3::w];
-	double Rt = std::sqrt(Xt*Xt + Yt*Yt);
-	double zeta = std::atan2(Yt, Xt);
-	std::function<IR2(const IR2&)> zero_function =
-		[&](const IR2& args) {
-			auto [s, theta] = reflection_past_axis(args[0], args[1]);
-			IR3 cyl = transform2cylindrical(IR3({s, zeta, theta}));
-			double R = cyl[IR3::u], Z = cyl[IR3::w];
-			return IR2({R-Rt, Z-Zt});
-		};
-	IR2 guess = {q[IR3::u], q[IR3::w]};
-	IR2 roots = multiroot(1.0e-12, 100)(zero_function, guess);
-	auto [s, theta] = reflection_past_axis(roots[0], roots[1]);
-	return {s, zeta, theta};
+IR3 morphism_vmec::translation(const IR3& q, const IR3& delta) const {
+  typedef std::array<double, 2> IR2;
+  IR3 X = (*this)(q);
+  double Xt = X[IR3::u] + delta[IR3::u];
+  double Yt = X[IR3::v] + delta[IR3::v];
+  double Zt = X[IR3::w] + delta[IR3::w];
+  double Rt = std::sqrt(Xt * Xt + Yt * Yt);
+  double zeta = std::atan2(Yt, Xt);
+  std::function<IR2(const IR2&)> zero_function = [&](const IR2& args) {
+    auto [s, theta] = reflection_past_axis(args[0], args[1]);
+    auto [R, Z] = get_rz(IR3({s, zeta, theta}));
+    return IR2({R - Rt, Z - Zt});
+  };
+  IR2 guess = {q[IR3::u], q[IR3::w]};
+  IR2 roots = multiroot(1.0e-12, 100)(zero_function, guess);
+  auto [s, theta] = reflection_past_axis(roots[0], roots[1]);
+  return {s, zeta, theta};
 }
-
-//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
 dIR3 morphism_vmec::del(const IR3& q) const {
-	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
-	double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0, dR_dzeta = 0.0;
-	double dZ_ds = 0.0, dZ_dtheta = 0.0, dZ_dzeta = 0.0;
-	double sn_zeta = std::sin(zeta);
-	double cn_zeta = std::cos(zeta);
-
-	#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dR_dzeta, dZ_ds, dZ_dtheta, dZ_dzeta)
-	for (size_t i = 0; i < xm_.size(); ++i) {  
-		double m = xm_[i]; double n = xn_[i];
-		double angle_mn = m*theta - n*zeta;
-		double cosmn = std::cos(angle_mn);
-		double sinmn = std::sin(angle_mn);
-		double rmnc_i = (*Rmnc_[i])(s); 
-		double zmns_i = (*Zmns_[i])(s);
-		// assuming for now that vmec equilibrium has stellarator symmetry.
-		R += rmnc_i * cosmn;
-		dR_ds += (*Rmnc_[i]).derivative(s) * cosmn; 
-		dR_dtheta += m * rmnc_i * sinmn; 
-		dR_dzeta += n * rmnc_i * sinmn;
-		dZ_ds += (*Zmns_[i]).derivative(s) * sinmn; 
-		dZ_dtheta += m * zmns_i * cosmn; 
-		dZ_dzeta += n * zmns_i * cosmn; 
-	}
-	dR_dtheta = -dR_dtheta;
-	dZ_dzeta  = -dZ_dzeta;
-
-	return {
-		dR_ds*cn_zeta, dR_dzeta*cn_zeta - R*sn_zeta, dR_dtheta*cn_zeta,
-		dR_ds*sn_zeta, dR_dzeta*sn_zeta + R*cn_zeta, dR_dtheta*sn_zeta,
-		dZ_ds		 , dZ_dzeta					   , dZ_dtheta
-	};
+  double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+  double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0, dR_dzeta = 0.0;
+  double dZ_ds = 0.0, dZ_dtheta = 0.0, dZ_dzeta = 0.0;
+  double sn_zeta = std::sin(zeta);
+  double cn_zeta = std::cos(zeta);
+#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dR_dzeta, dZ_ds, dZ_dtheta, dZ_dzeta)
+  for (size_t i = 0; i < xm_.size(); ++i) {
+    double m = xm_[i];
+    double n = xn_[i];
+    double angle_mn = m * theta - n * zeta;
+    double cosmn = std::cos(angle_mn), sinmn = std::sin(angle_mn);
+    double rmnc_i = (*Rmnc_[i])(s), zmns_i = (*Zmns_[i])(s);
+    R += rmnc_i * cosmn; // assuming stellarator symmetry
+    dR_ds += (*Rmnc_[i]).derivative(s) * cosmn;
+    dR_dtheta += m * rmnc_i * sinmn;
+    dR_dzeta += n * rmnc_i * sinmn;
+    dZ_ds += (*Zmns_[i]).derivative(s) * sinmn;
+    dZ_dtheta += m * zmns_i * cosmn;
+    dZ_dzeta += n * zmns_i * cosmn;
+  }
+  dR_dtheta = -dR_dtheta;
+  dZ_dzeta = -dZ_dzeta;
+  return {dR_ds * cn_zeta, dR_dzeta * cn_zeta - R * sn_zeta,
+      dR_dtheta * cn_zeta, dR_ds * sn_zeta, dR_dzeta * sn_zeta + R * cn_zeta,
+      dR_dtheta * sn_zeta, dZ_ds, dZ_dzeta, dZ_dtheta};
 }
-
-//! Returns the morphism's second derivatives, calculated in point `q`.
 ddIR3 morphism_vmec::ddel(const IR3& q) const {
-	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
-	double cn = std::cos(zeta);
-	double sn = std::sin(zeta);
+  double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+  double cn = std::cos(zeta), sn = std::sin(zeta);
+  double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0, dR_dzeta = 0.0;
+  double d2R_ds2 = 0.0, d2R_dsdtheta = 0.0, d2R_dsdzeta = 0.0;
+  double d2R_dzeta2 = 0.0, d2R_dzetadtheta = 0.0, d2R_dtheta2 = 0.0;
+  double dZ_ds = 0.0, dZ_dtheta = 0.0, dZ_dzeta = 0.0;
+  double d2Z_ds2 = 0.0, d2Z_dsdtheta = 0.0, d2Z_dsdzeta = 0.0;
+  double d2Z_dzeta2 = 0.0, d2Z_dzetadtheta = 0.0, d2Z_dtheta2 = 0.0;
 
-	double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0, dR_dzeta = 0.0;
-	double d2R_ds2 = 0.0, d2R_dsdtheta = 0.0, d2R_dsdzeta = 0.0;
-	double d2R_dzeta2 = 0.0, d2R_dzetadtheta = 0.0, d2R_dtheta2 = 0.0;
+#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dR_dzeta, d2R_ds2, d2R_dsdtheta, d2R_dsdzeta, d2R_dtheta2, d2R_dthetadzeta, d2R_dzeta2, Z, dZ_ds ,dZ_dtheta, dZ_dzeta, d2Z_ds2, d2Z_dsdtheta, d2Z_dsdzeta, d2Z_dtheta2, d2Z_dthetadzeta, d2Z_dzeta2)
+  for (size_t i = 0; i < xm_.size(); ++i) {
+    double m = xm_[i], n = xn_[i];
+    double cosmn = std::cos(m * theta - n * zeta);
+    double sinmn = std::sin(m * theta - n * zeta);
+    double rmnc_i = (*Rmnc_[i])(s), zmns_i = (*Zmns_[i])(s);
+    double d_rmnc_i = (*Rmnc_[i]).derivative(s);
+    double d_zmns_i = (*Zmns_[i]).derivative(s);
+    double d2_rmnc_i = (*Rmnc_[i]).derivative2(s);
+    double d2_zmns_i = (*Zmns_[i]).derivative2(s);
+    R += rmnc_i * cosmn; // assuming stellarator symmetry
+    dR_ds += d_rmnc_i * cosmn;
+    dR_dzeta += n * rmnc_i * sinmn;
+    dR_dtheta -= m * rmnc_i * sinmn;
+    d2R_ds2 += d2_rmnc_i * cosmn;
+    d2R_dsdzeta += n * d_rmnc_i * sinmn;
+    d2R_dsdtheta -= m * d_rmnc_i * sinmn;
+    d2R_dzeta2 -= n * n * rmnc_i * cosmn;
+    d2R_dzetadtheta += m * n * rmnc_i * cosmn;
+    d2R_dtheta2 -= m * m * rmnc_i * cosmn;
+    dZ_ds += d_zmns_i * sinmn;
+    dZ_dzeta -= n * zmns_i * cosmn;
+    dZ_dtheta += m * zmns_i * cosmn;
+    d2Z_ds2 += d2_zmns_i * sinmn;
+    d2Z_dsdzeta -= n * d_zmns_i * cosmn;
+    d2Z_dsdtheta += m * d_zmns_i * cosmn;
+    d2Z_dzeta2 -= n * n * zmns_i * sinmn;
+    d2Z_dzetadtheta += m * n * zmns_i * sinmn;
+    d2Z_dtheta2 -= m * m * zmns_i * sinmn;
+  }
+  return {d2R_ds2 * cn, d2R_dsdzeta * cn - dR_ds * sn, d2R_dsdtheta * cn,
+      (d2R_dzeta2 - R) * cn - 2 * dR_dzeta * sn,
+      d2R_dzetadtheta * cn - dR_dtheta * sn, d2R_dtheta2 * cn, d2R_ds2 * sn,
+      d2R_dsdzeta * sn + dR_ds * cn, d2R_dsdtheta * sn,
+      (d2R_dzeta2 - R) * sn + 2 * dR_dzeta * cn,
+      d2R_dzetadtheta * sn + dR_dtheta * cn,
+      d2R_dtheta2 * sn, d2Z_ds2, d2Z_dsdzeta,
+      d2Z_dsdtheta, d2Z_dzeta2, d2Z_dzetadtheta, d2Z_dtheta2};
+}
+double morphism_vmec::jacobian(const IR3& q) const {
+  double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+  double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0;
+  double dZ_ds = 0.0, dZ_dtheta = 0.0;
+  double sn_zeta = std::sin(zeta), cn_zeta = std::cos(zeta);
 
-	double dZ_ds = 0.0, dZ_dtheta = 0.0, dZ_dzeta = 0.0;
-	double d2Z_ds2 = 0.0, d2Z_dsdtheta = 0.0, d2Z_dsdzeta = 0.0;
-	double d2Z_dzeta2 = 0.0, d2Z_dzetadtheta = 0.0, d2Z_dtheta2 = 0.0;
+#pragma omp parallel for reduction(+: R, Z, dR_ds, dR_dtheta, dR_dzeta, dZ_ds, dZ_dtheta, dZ_dzeta)
+  for (size_t i = 0; i < xm_.size(); ++i) {
+    double m = xm_[i], n = xn_[i];
+    double angle_mn = m * theta - n * zeta;
+    double cosmn = std::cos(angle_mn), sinmn = std::sin(angle_mn);
+    double rmnc_i = (*Rmnc_[i])(s), zmns_i = (*Zmns_[i])(s);
+    R += rmnc_i * cosmn; // assuming stellarator symmetry
+    dR_ds += (*Rmnc_[i]).derivative(s) * cosmn;
+    dR_dtheta += m * rmnc_i * sinmn;
+    dZ_ds += (*Zmns_[i]).derivative(s) * sinmn;
+    dZ_dtheta += m * zmns_i * cosmn;
+  }
+  dR_dtheta = -dR_dtheta;
+  return R * (dR_ds * dZ_dtheta - dR_dtheta * dZ_ds);
+}
+std::pair<double, double> morphism_vmec::get_rz(const IR3& position) const {
+  double u = position[gyronimo::IR3::u];
+  double v = position[gyronimo::IR3::v];
+  double w = position[gyronimo::IR3::w];
+  double R = 0.0, Z = 0.0;
 
-	#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dR_dzeta, d2R_ds2, d2R_dsdtheta, d2R_dsdzeta, d2R_dtheta2, d2R_dthetadzeta, d2R_dzeta2, Z, dZ_ds ,dZ_dtheta, dZ_dzeta, d2Z_ds2, d2Z_dsdtheta, d2Z_dsdzeta, d2Z_dtheta2, d2Z_dthetadzeta, d2Z_dzeta2)
-	for (size_t i = 0; i < xm_.size(); ++i) {  
-		double m = xm_[i]; double n = xn_[i];
-		double cosmn = std::cos( m*theta - n*zeta );
-		double sinmn = std::sin( m*theta - n*zeta );
-		double rmnc_i = (*Rmnc_[i])(s); 
-		double zmns_i = (*Zmns_[i])(s);
-		double d_rmnc_i = (*Rmnc_[i]).derivative(s); 
-		double d_zmns_i = (*Zmns_[i]).derivative(s); 
-		double d2_rmnc_i = (*Rmnc_[i]).derivative2(s);
-		double d2_zmns_i = (*Zmns_[i]).derivative2(s);
-		// assuming for now that vmec equilibrium has stellarator symmetry.
-		R += rmnc_i * cosmn;
-		dR_ds += d_rmnc_i * cosmn; 
-		dR_dzeta += n * rmnc_i * sinmn;
-		dR_dtheta -= m * rmnc_i * sinmn;
-
-		d2R_ds2 += d2_rmnc_i * cosmn; 
-		d2R_dsdzeta += n * d_rmnc_i * sinmn;
-		d2R_dsdtheta -= m * d_rmnc_i * sinmn;
-		d2R_dzeta2 -= n * n * rmnc_i * cosmn;
-		d2R_dzetadtheta += m * n * rmnc_i * cosmn;
-		d2R_dtheta2 -= m * m * rmnc_i * cosmn;
-
-		dZ_ds += d_zmns_i * sinmn; 
-		dZ_dzeta -= n * zmns_i * cosmn; 
-		dZ_dtheta += m * zmns_i * cosmn; 
-
-		d2Z_ds2 += d2_zmns_i * sinmn;
-		d2Z_dsdzeta -= n * d_zmns_i * cosmn;
-		d2Z_dsdtheta += m * d_zmns_i * cosmn;
-		d2Z_dzeta2 -= n * n * zmns_i * sinmn;
-		d2Z_dzetadtheta += m * n * zmns_i * sinmn;
-		d2Z_dtheta2 -= m * m * zmns_i * sinmn;
-	}
-
-	return {
-		d2R_ds2*cn, d2R_dsdzeta*cn-dR_ds*sn, d2R_dsdtheta*cn, (d2R_dzeta2-R)*cn-2*dR_dzeta*sn, d2R_dzetadtheta*cn-dR_dtheta*sn, d2R_dtheta2*cn,
-		d2R_ds2*sn, d2R_dsdzeta*sn+dR_ds*cn, d2R_dsdtheta*sn, (d2R_dzeta2-R)*sn+2*dR_dzeta*cn, d2R_dzetadtheta*sn+dR_dtheta*cn, d2R_dtheta2*sn,
-		d2Z_ds2   , d2Z_dsdzeta            , d2Z_dsdtheta   ,  d2Z_dzeta2                    , d2Z_dzetadtheta                , d2Z_dtheta2
-	};
+#pragma omp parallel for reduction(+ : R, Z)
+  for (size_t i = 0; i < xm_.size(); ++i) {
+    double m = xm_[i], n = xn_[i];
+    R += (*Rmnc_[i])(u)*std::cos(m * w - n * v);
+    Z += (*Zmns_[i])(u)*std::sin(m * w - n * v);
+  }
+  return {R, Z};
+}
+std::pair<double, double> morphism_vmec::reflection_past_axis(
+    double s, double theta) const {
+  if (s < 0)
+    return {-s, theta + std::numbers::pi};
+  else return {s, theta};
 }
 
-//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
-double morphism_vmec::jacobian(const IR3&q) const {
-	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
-	double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0;
-	double dZ_ds = 0.0, dZ_dtheta = 0.0;
-	double sn_zeta = std::sin(zeta);
-	double cn_zeta = std::cos(zeta);
-
-	#pragma omp parallel for reduction(+: R, Z, dR_ds, dR_dtheta, dR_dzeta, dZ_ds, dZ_dtheta, dZ_dzeta)
-	for (size_t i = 0; i < xm_.size(); ++i) {  
-		double m = xm_[i]; double n = xn_[i];
-		double angle_mn = m*theta - n*zeta;
-		double cosmn = std::cos(angle_mn);
-		double sinmn = std::sin(angle_mn);
-		double rmnc_i = (*Rmnc_[i])(s); 
-		double zmns_i = (*Zmns_[i])(s);
-		// assuming for now that vmec equilibrium has stellarator symmetry.
-		R += rmnc_i * cosmn;
-		dR_ds += (*Rmnc_[i]).derivative(s) * cosmn; 
-		dR_dtheta += m * rmnc_i * sinmn;
-		dZ_ds += (*Zmns_[i]).derivative(s) * sinmn; 
-		dZ_dtheta += m * zmns_i * cosmn;
-	}
-	dR_dtheta = -dR_dtheta;
-
-	return R * (dR_ds * dZ_dtheta - dR_dtheta * dZ_ds);
-}
-
-// //@todo move this to jacobian and think about testing this by calling the parent
-// double morphism_vmec::jacobian_vmec(const IR3& position) const {
-// 	double s = position[IR3::u];
-// 	double zeta = position[IR3::v];
-// 	double theta = position[IR3::w];
-// 	double J = 0.0;
-// 	#pragma omp parallel for reduction(+: J)
-// 	for (size_t i = 0; i < xm_nyq_.size(); i++) {  
-// 		J += (*gmnc_[i])(s) * std::cos( xm_nyq_[i]*theta - xn_nyq_[i]*zeta );
-// 	};
-// 	// left-handed VMEC coordinate system is re-oriented 
-// 	// to u = Phi/Phi_bnd, v = zeta, w = theta for J>0
-// 	// should we check/assume that signgs is always negative?
-// 	return -J;
-// }
-
-IR3 morphism_vmec::transform2cylindrical(const IR3& position) const {
-	double u = position[gyronimo::IR3::u];
-	double v = position[gyronimo::IR3::v];
-	double w = position[gyronimo::IR3::w];
-	double R = 0.0, Z = 0.0;
-
-	#pragma omp parallel for reduction(+: R, Z)
-	for (size_t i = 0; i < xm_.size(); ++i) {
-		double m = xm_[i]; double n = xn_[i];
-		R+= (*Rmnc_[i])(u) * std::cos( m*w - n*v ); 
-		Z+= (*Zmns_[i])(u) * std::sin( m*w - n*v );
-	}
-	return  {R, v, Z};
-}
-
-// double morphism_vmec::reduce_2pi(double angle) const {
-// 	double l = 2*std::numbers::pi;
-// 	angle -= l*std::floor(angle/l);
-// 	return angle;
-// }
-
-std::tuple<double, double> morphism_vmec::reflection_past_axis(
-		double s, double theta) const {
-	if(s < 0)
-		// return {-s, reduce_2pi(theta + std::numbers::pi)};
-		return {-s, theta + std::numbers::pi};
-	else
-		return {s, theta};
-}
-
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/metrics/morphism_vmec.cc
+++ b/gyronimo/metrics/morphism_vmec.cc
@@ -1,0 +1,263 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @mrophism_vmec.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/metrics/morphism_vmec.hh>
+#include <numbers>
+#include <gyronimo/core/multiroot.hh>
+
+namespace gyronimo{
+
+morphism_vmec::morphism_vmec(const parser_vmec *p, 
+		const interpolator1d_factory *ifactory)
+		: parser_(p), xm_(p->xm()), xn_(p->xn()) {
+
+	//set radial grid block
+    dblock_adapter s_range(p->radius());
+    // set spectral components 
+    Rmnc_ = new interpolator1d* [xm_.size()];
+    Zmns_ = new interpolator1d* [xm_.size()];
+
+	for(size_t i = 0; i < xm_.size(); ++i) {
+		std::slice s_cut (i, s_range.size(), xm_.size());
+		narray_type rmnc_i = (p->rmnc())[s_cut];
+		Rmnc_[i] = ifactory->interpolate_data( s_range, dblock_adapter(rmnc_i));
+		narray_type zmns_i = (p->zmns())[s_cut];
+		Zmns_[i] = ifactory->interpolate_data( s_range, dblock_adapter(zmns_i));
+	}
+}
+
+morphism_vmec::~morphism_vmec() {
+	if(Rmnc_) {
+		for(size_t i = 0; i < xm_.size(); ++i)
+			if(Rmnc_[i]) delete Rmnc_[i];
+		delete Rmnc_;
+	}
+	if(Zmns_) {
+		for(size_t i = 0; i < xm_.size(); ++i)
+			if(Zmns_[i]) delete Zmns_[i];
+		delete Zmns_;
+	}
+}
+
+//! Maps `VMEC` coordinates @f$ q^\alpha @f$ into cartesian coordinates @f$ \textbf{x} @f$.
+/*!
+	In `VMEC` coordinates, @f$ \left( q^1, q^2, q^3 \right) = \left( s, \zeta, \theta \right) @f$
+*/
+IR3 morphism_vmec::operator()(const IR3& q) const {
+	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+	double R = 0.0, Z = 0.0;
+
+	for (size_t i = 0; i < xm_.size(); ++i) {  
+		double m = xm_[i], n = xn_[i];
+		double angle_mn = m*theta - n*zeta;
+		double cosmn = std::cos( angle_mn );
+		double sinmn = std::sin( angle_mn );
+		// assuming for now that vmec equilibrium has stellarator symmetry.
+		R += (*Rmnc_[i])(s) * cosmn; 
+		Z += (*Zmns_[i])(s) * sinmn;
+	}
+
+	return {R * std::cos(zeta), R * std::sin(zeta), Z};
+}
+
+//! Inverse transform from cartesian coordinates @f$ \textbf{x} @f$ into `VMEC` coordinates @f$ q^\alpha @f$.
+IR3 morphism_vmec::inverse(const IR3& X) const {
+	typedef std::array<double, 2> IR2;
+	double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
+	double zeta = std::atan2(y, x);
+	double r = std::sqrt(x*x + y*y);
+
+	std::function<IR2(const IR2&)> zero_function =
+		[&](const IR2& args) {
+			auto [s, theta] = reflection_past_axis(args[0], args[1]);
+			IR3 cyl = transform2cylindrical(IR3({s, zeta, theta}));
+			double R = cyl[IR3::u], Z = cyl[IR3::w];
+			return IR2({R-r, Z-z});
+		};
+	IR3 axis = transform2cylindrical({0, zeta, 0});
+	double R0 = axis[IR3::u], Z0 = axis[IR3::w];
+	IR2 guess = {0.5, std::atan2(z-Z0, r-R0)};
+	IR2 roots = multiroot(1.0e-15, 100)(zero_function, guess);
+	auto [s, theta] = reflection_past_axis(roots[0], roots[1]);
+	return {s, zeta, theta};
+}
+
+//! Returns the morphism's first derivatives, correspondent to the covariant basis vectors in point @f$ q^\alpha @f$.
+dIR3 morphism_vmec::del(const IR3& q) const {
+	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+	double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0, dR_dzeta = 0.0;
+	double dZ_ds = 0.0, dZ_dtheta = 0.0, dZ_dzeta = 0.0;
+	double sn_zeta = std::sin(zeta);
+	double cn_zeta = std::cos(zeta);
+
+	for (size_t i = 0; i < xm_.size(); ++i) {  
+		double m = xm_[i]; double n = xn_[i];
+		double angle_mn = m*theta - n*zeta;
+		double cosmn = std::cos(angle_mn);
+		double sinmn = std::sin(angle_mn);
+		double rmnc_i = (*Rmnc_[i])(s); 
+		double zmns_i = (*Zmns_[i])(s);
+		// assuming for now that vmec equilibrium has stellarator symmetry.
+		R += rmnc_i * cosmn;
+		dR_ds += (*Rmnc_[i]).derivative(s) * cosmn; 
+		dR_dtheta += m * rmnc_i * sinmn; 
+		dR_dzeta += n * rmnc_i * sinmn;
+		dZ_ds += (*Zmns_[i]).derivative(s) * sinmn; 
+		dZ_dtheta += m * zmns_i * cosmn; 
+		dZ_dzeta += n * zmns_i * cosmn; 
+	}
+	dR_dtheta = -dR_dtheta;
+	dZ_dzeta  = -dZ_dzeta;
+
+	return {
+		dR_ds*cn_zeta, dR_dzeta*cn_zeta - R*sn_zeta, dR_dtheta*cn_zeta,
+		dR_ds*sn_zeta, dR_dzeta*sn_zeta + R*cn_zeta, dR_dtheta*sn_zeta,
+		dZ_ds		 , dZ_dzeta					   , dZ_dtheta
+	};
+}
+
+//! Returns the morphism's second derivatives, calculated in point `q`.
+ddIR3 morphism_vmec::ddel(const IR3& q) const {
+	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+	double cn = std::cos(zeta);
+	double sn = std::sin(zeta);
+
+	double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0, dR_dzeta = 0.0;
+	double d2R_ds2 = 0.0, d2R_dsdtheta = 0.0, d2R_dsdzeta = 0.0;
+	double d2R_dzeta2 = 0.0, d2R_dzetadtheta = 0.0, d2R_dtheta2 = 0.0;
+
+	double dZ_ds = 0.0, dZ_dtheta = 0.0, dZ_dzeta = 0.0;
+	double d2Z_ds2 = 0.0, d2Z_dsdtheta = 0.0, d2Z_dsdzeta = 0.0;
+	double d2Z_dzeta2 = 0.0, d2Z_dzetadtheta = 0.0, d2Z_dtheta2 = 0.0;
+
+	for (size_t i = 0; i < xm_.size(); ++i) {  
+		double m = xm_[i]; double n = xn_[i];
+		double cosmn = std::cos( m*theta - n*zeta );
+		double sinmn = std::sin( m*theta - n*zeta );
+		double rmnc_i = (*Rmnc_[i])(s); 
+		double zmns_i = (*Zmns_[i])(s);
+		double d_rmnc_i = (*Rmnc_[i]).derivative(s); 
+		double d_zmns_i = (*Zmns_[i]).derivative(s); 
+		double d2_rmnc_i = (*Rmnc_[i]).derivative2(s);
+		double d2_zmns_i = (*Zmns_[i]).derivative2(s);
+		// assuming for now that vmec equilibrium has stellarator symmetry.
+		R += rmnc_i * cosmn;
+		dR_ds += d_rmnc_i * cosmn; 
+		dR_dzeta += n * rmnc_i * sinmn;
+		dR_dtheta -= m * rmnc_i * sinmn;
+
+		d2R_ds2 += d2_rmnc_i * cosmn; 
+		d2R_dsdzeta += n * d_rmnc_i * sinmn;
+		d2R_dsdtheta -= m * d_rmnc_i * sinmn;
+		d2R_dzeta2 -= n * n * rmnc_i * cosmn;
+		d2R_dzetadtheta += m * n * rmnc_i * cosmn;
+		d2R_dtheta2 -= m * m * rmnc_i * cosmn;
+
+		dZ_ds += d_zmns_i * sinmn; 
+		dZ_dzeta -= n * zmns_i * cosmn; 
+		dZ_dtheta += m * zmns_i * cosmn; 
+
+		d2Z_ds2 += d2_zmns_i * sinmn;
+		d2Z_dsdzeta -= n * d_zmns_i * cosmn;
+		d2Z_dsdtheta += m * d_zmns_i * cosmn;
+		d2Z_dzeta2 -= n * n * zmns_i * sinmn;
+		d2Z_dzetadtheta += m * n * zmns_i * sinmn;
+		d2Z_dtheta2 -= m * m * zmns_i * sinmn;
+	}
+
+	return {
+		d2R_ds2*cn, d2R_dsdzeta*cn-dR_ds*sn, d2R_dsdtheta*cn, (d2R_dzeta2-R)*cn-2*dR_dzeta*sn, d2R_dzetadtheta*cn-dR_dtheta*sn, d2R_dtheta2*cn,
+		d2R_ds2*sn, d2R_dsdzeta*sn+dR_ds*cn, d2R_dsdtheta*sn, (d2R_dzeta2-R)*sn+2*dR_dzeta*cn, d2R_dzetadtheta*sn+dR_dtheta*cn, d2R_dtheta2*sn,
+		d2Z_ds2   , d2Z_dsdzeta            , d2Z_dsdtheta   ,  d2Z_dzeta2                    , d2Z_dzetadtheta                , d2Z_dtheta2
+	};
+}
+
+//! General-purpose implementation of the Jacobian of the transformation in point @f$ q^\alpha @f$.
+double morphism_vmec::jacobian(const IR3&q) const {
+	double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
+	double R = 0.0, dR_ds = 0.0, dR_dtheta = 0.0;
+	double dZ_ds = 0.0, dZ_dtheta = 0.0;
+	double sn_zeta = std::sin(zeta);
+	double cn_zeta = std::cos(zeta);
+
+	for (size_t i = 0; i < xm_.size(); ++i) {  
+		double m = xm_[i]; double n = xn_[i];
+		double angle_mn = m*theta - n*zeta;
+		double cosmn = std::cos(angle_mn);
+		double sinmn = std::sin(angle_mn);
+		double rmnc_i = (*Rmnc_[i])(s); 
+		double zmns_i = (*Zmns_[i])(s);
+		// assuming for now that vmec equilibrium has stellarator symmetry.
+		R += rmnc_i * cosmn;
+		dR_ds += (*Rmnc_[i]).derivative(s) * cosmn; 
+		dR_dtheta += m * rmnc_i * sinmn;
+		dZ_ds += (*Zmns_[i]).derivative(s) * sinmn; 
+		dZ_dtheta += m * zmns_i * cosmn;
+	}
+	dR_dtheta = -dR_dtheta;
+
+	return R * (dR_ds * dZ_dtheta - dR_dtheta * dZ_ds);
+}
+
+// //@todo move this to jacobian and think about testing this by calling the parent
+// double morphism_vmec::jacobian_vmec(const IR3& position) const {
+// 	double s = position[IR3::u];
+// 	double zeta = position[IR3::v];
+// 	double theta = position[IR3::w];
+// 	double J = 0.0;
+// 	#pragma omp parallel for reduction(+: J)
+// 	for (size_t i = 0; i < xm_nyq_.size(); i++) {  
+// 		J += (*gmnc_[i])(s) * std::cos( xm_nyq_[i]*theta - xn_nyq_[i]*zeta );
+// 	};
+// 	// left-handed VMEC coordinate system is re-oriented 
+// 	// to u = Phi/Phi_bnd, v = zeta, w = theta for J>0
+// 	// should we check/assume that signgs is always negative?
+// 	return -J;
+// }
+
+IR3 morphism_vmec::transform2cylindrical(const IR3& position) const {
+	double u = position[gyronimo::IR3::u];
+	double v = position[gyronimo::IR3::v];
+	double w = position[gyronimo::IR3::w];
+	double R = 0.0, Z = 0.0;
+
+	#pragma omp parallel for reduction(+: R, Z)
+	for (size_t i = 0; i < xm_.size(); ++i) {
+		double m = xm_[i]; double n = xn_[i];
+		R+= (*Rmnc_[i])(u) * std::cos( m*w - n*v ); 
+		Z+= (*Zmns_[i])(u) * std::sin( m*w - n*v );
+	}
+	return  {R, v, Z};
+}
+
+double morphism_vmec::reduce_2pi(double angle) const {
+	double l = 2*std::numbers::pi;
+	angle -= l*std::floor(angle/l);
+	return angle;
+}
+
+std::tuple<double, double> morphism_vmec::reflection_past_axis(
+		double s, double theta) const {
+	if(s < 0)
+		return {-s, reduce_2pi(theta + std::numbers::pi)};
+	else
+		return {s, theta};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/morphism_vmec.hh
+++ b/gyronimo/metrics/morphism_vmec.hh
@@ -20,45 +20,42 @@
 #ifndef GYRONIMO_MORPHISM_VMEC
 #define GYRONIMO_MORPHISM_VMEC
 
-#include <gyronimo/parsers/parser_vmec.hh>
 #include <gyronimo/interpolators/interpolator1d.hh>
 #include <gyronimo/metrics/morphism.hh>
+#include <gyronimo/parsers/parser_vmec.hh>
 
-namespace gyronimo{
+namespace gyronimo {
 
 //! Morphism in `VMEC` curvilinear coordinates.
 class morphism_vmec : public morphism {
-public:
-	typedef std::valarray<double> narray_type;
+ public:
+  typedef std::valarray<double> narray_type;
 
-	morphism_vmec(
-		const parser_vmec *parser, const interpolator1d_factory *ifactory);
-	virtual ~morphism_vmec() override;
+  morphism_vmec(
+      const parser_vmec* parser, const interpolator1d_factory* ifactory);
+  virtual ~morphism_vmec() override;
 
-	virtual IR3 operator()(const IR3 &q) const override;
-	virtual IR3 inverse(const IR3 &x) const override;
-	virtual IR3 translation(const IR3 &q, const IR3 &delta) const override;
-	virtual dIR3 del(const IR3 &q) const override;
-	virtual ddIR3 ddel(const IR3 &q) const override;
+  virtual IR3 operator()(const IR3& q) const override;
+  virtual IR3 inverse(const IR3& x) const override;
+  virtual IR3 translation(const IR3& q, const IR3& delta) const override;
+  virtual dIR3 del(const IR3& q) const override;
+  virtual ddIR3 ddel(const IR3& q) const override;
 
-	virtual double jacobian(const IR3 &q) const override;
-	// double jacobian_vmec(const IR3& position) const;
+  virtual double jacobian(const IR3& q) const override;
 
-	const parser_vmec* parser() const {return parser_;};
-private:
+  const parser_vmec* parser() const { return parser_; };
+ private:
+  const parser_vmec* parser_;
+  narray_type xm_, xn_;
 
-	const parser_vmec* parser_;
-	narray_type xm_, xn_;
+  interpolator1d** Rmnc_;
+  interpolator1d** Zmns_;
+  interpolator1d** gmnc_;
 
-	interpolator1d **Rmnc_;
-	interpolator1d **Zmns_;
-	interpolator1d **gmnc_;
-
-	virtual IR3 transform2cylindrical(const IR3& position) const;
-	double reduce_2pi(double angle) const;
-	std::tuple<double, double> reflection_past_axis(double s, double theta) const;
+  std::pair<double, double> get_rz(const IR3& position) const;
+  std::pair<double, double> reflection_past_axis(double s, double theta) const;
 };
 
-} // end namespace gyronimo
+}  // end namespace gyronimo
 
-#endif // GYRONIMO_MORPHISM_VMEC
+#endif  // GYRONIMO_MORPHISM_VMEC

--- a/gyronimo/metrics/morphism_vmec.hh
+++ b/gyronimo/metrics/morphism_vmec.hh
@@ -37,6 +37,7 @@ public:
 
 	virtual IR3 operator()(const IR3 &q) const override;
 	virtual IR3 inverse(const IR3 &x) const override;
+	virtual IR3 translation(const IR3 &q, const IR3 &delta) const override;
 	virtual dIR3 del(const IR3 &q) const override;
 	virtual ddIR3 ddel(const IR3 &q) const override;
 

--- a/gyronimo/metrics/morphism_vmec.hh
+++ b/gyronimo/metrics/morphism_vmec.hh
@@ -1,0 +1,63 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @morphism_vmec.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_MORPHISM_VMEC
+#define GYRONIMO_MORPHISM_VMEC
+
+#include <gyronimo/parsers/parser_vmec.hh>
+#include <gyronimo/interpolators/interpolator1d.hh>
+#include <gyronimo/metrics/morphism.hh>
+
+namespace gyronimo{
+
+//! Morphism in `VMEC` curvilinear coordinates.
+class morphism_vmec : public morphism {
+public:
+	typedef std::valarray<double> narray_type;
+
+	morphism_vmec(
+		const parser_vmec *parser, const interpolator1d_factory *ifactory);
+	virtual ~morphism_vmec() override;
+
+	virtual IR3 operator()(const IR3 &q) const override;
+	virtual IR3 inverse(const IR3 &x) const override;
+	virtual dIR3 del(const IR3 &q) const override;
+	virtual ddIR3 ddel(const IR3 &q) const override;
+
+	virtual double jacobian(const IR3 &q) const override;
+	// double jacobian_vmec(const IR3& position) const;
+
+	const parser_vmec* parser() const {return parser_;};
+private:
+
+	const parser_vmec* parser_;
+	narray_type xm_, xn_;
+
+	interpolator1d **Rmnc_;
+	interpolator1d **Zmns_;
+	interpolator1d **gmnc_;
+
+	virtual IR3 transform2cylindrical(const IR3& position) const;
+	double reduce_2pi(double angle) const;
+	std::tuple<double, double> reflection_past_axis(double s, double theta) const;
+};
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_MORPHISM_VMEC

--- a/gyronimo/parsers/parser_helena.cc
+++ b/gyronimo/parsers/parser_helena.cc
@@ -102,7 +102,16 @@ parser_helena::parser_helena(const std::string& filename) {
   rgeo_ = radius_/eps_*rmag_;
   this->build_auxiliar_data();
 }
- 
+
+//! Reduces an arbitrary angle chi to the interval [0:2pi] (or [0:pi] if sym).
+double parser_helena::reduce_chi(double chi) const {
+  double l = 2*std::numbers::pi;
+  chi -= l*std::floor(chi/l);
+  if(is_symmetric_ && chi > std::numbers::pi)
+      chi = l - chi;
+  return chi;
+}
+
 //! Builds up some useful flux-function 2D arrays.
 /*
     Each flux-function value is copied over all poloidal samples along the flux

--- a/gyronimo/parsers/parser_helena.cc
+++ b/gyronimo/parsers/parser_helena.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -103,12 +103,11 @@ parser_helena::parser_helena(const std::string& filename) {
   this->build_auxiliar_data();
 }
 
-//! Reduces an arbitrary angle chi to the interval [0:2pi] (or [0:pi] if sym).
+//! Reduces `chi` to the interval [0:2pi] (or [0:pi] if sym).
 double parser_helena::reduce_chi(double chi) const {
   double l = 2*std::numbers::pi;
   chi -= l*std::floor(chi/l);
-  if(is_symmetric_ && chi > std::numbers::pi)
-      chi = l - chi;
+  if(is_symmetric_ && chi > std::numbers::pi) chi = l - chi;
   return chi;
 }
 

--- a/gyronimo/parsers/parser_helena.hh
+++ b/gyronimo/parsers/parser_helena.hh
@@ -97,6 +97,7 @@ class parser_helena {
   const narray_type& covariant_B3() const {return covariant_B3_;};
   const narray_type& contravariant_B2() const {return contravariant_B2_;};
   const narray_type& contravariant_B3() const {return contravariant_B3_;};
+  double reduce_chi(double chi) const;
 
  private:
   bool is_symmetric_;

--- a/gyronimo/parsers/parser_helena.hh
+++ b/gyronimo/parsers/parser_helena.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/misc/apps/heltrace.cc
+++ b/misc/apps/heltrace.cc
@@ -139,7 +139,8 @@ int main(int argc, char* argv[]) {
   gyronimo::parser_helena hmap(command_line[1]);
   gyronimo::bicubic_gsl_factory ifactory(false,
       (hmap.is_symmetric() ? 0 : 9), (hmap.is_symmetric() ? 9 : 0));
-  gyronimo::metric_helena g(&hmap, &ifactory);
+  gyronimo::morphism_helena m(&hmap, &ifactory);
+  gyronimo::metric_helena g(&m);
   gyronimo::equilibrium_helena heq(&g, &ifactory);
 
 // Reads parameters from the command line:

--- a/misc/apps/heltrace.cc
+++ b/misc/apps/heltrace.cc
@@ -140,7 +140,7 @@ int main(int argc, char* argv[]) {
   gyronimo::bicubic_gsl_factory ifactory(false,
       (hmap.is_symmetric() ? 0 : 9), (hmap.is_symmetric() ? 9 : 0));
   gyronimo::morphism_helena m(&hmap, &ifactory);
-  gyronimo::metric_helena g(&m);
+  gyronimo::metric_helena g(&m, &ifactory);
   gyronimo::equilibrium_helena heq(&g, &ifactory);
 
 // Reads parameters from the command line:

--- a/misc/apps/vmecdump.cc
+++ b/misc/apps/vmecdump.cc
@@ -31,6 +31,7 @@
 #include <gyronimo/version.hh>
 #include <gyronimo/core/linspace.hh>
 #include <gyronimo/parsers/parser_vmec.hh>
+#include <gyronimo/metrics/morphism_vmec.hh>
 #include <gyronimo/metrics/metric_vmec.hh>
 #include <gyronimo/fields/equilibrium_vmec.hh>
 #include <gyronimo/interpolators/cubic_gsl.hh>
@@ -50,7 +51,7 @@ void print_help() {
   std::cout << "      -phi               - phi coordinate\n";
   std::cout << "      -Z                 - Z coordinate\n";
   std::cout << "      -jacobian          - jacobian of the metric\n";
-  std::cout << "      -jacobian_vmec     - jacobian of the metric (from vmec)\n";
+//   std::cout << "      -jacobian_vmec     - jacobian of the metric (from vmec)\n";
   std::cout << "  -radius         Prints radial grid.\n";
   std::cout << "  -iota           Prints 'iota' profile.\n";
   std::cout << "  -q              Prints 'q' safety factor profile.\n";
@@ -59,7 +60,7 @@ void print_help() {
   std::exit(0);
 }
 
-enum Scalar { R_cyl, phi_cyl, Z_cyl, Bnorm, Bnorm_vmec, jacobian, jacobian_vmec };
+enum Scalar { R_cyl, phi_cyl, Z_cyl, Bnorm, Bnorm_vmec, jacobian/*, jacobian_vmec*/ };
 typedef std::valarray<double> narray_type;
 enum class Out_format {table, python};
 
@@ -97,7 +98,7 @@ int main(int argc, char* argv[]) {
     if (command_line["R"]) scalar = R_cyl;
     if (command_line["Z"]) scalar = Z_cyl;
     if (command_line["jacobian"]) scalar = jacobian;
-    if (command_line["jacobian_vmec"]) scalar = jacobian_vmec;
+    // if (command_line["jacobian_vmec"]) scalar = jacobian_vmec;
 
     print_surface(scalar, vmec, &ifactory, ntheta, nzeta);
     std::exit(0);
@@ -168,7 +169,8 @@ void print_surface(const Scalar scalar,
                    const gyronimo::interpolator1d_factory *ifactory,
                    const int ntheta, const int nzeta) {
 
-  gyronimo::metric_vmec g(&vmap, ifactory);
+  gyronimo::morphism_vmec m(&vmap, ifactory);
+  gyronimo::metric_vmec g(&m, ifactory);
   gyronimo::equilibrium_vmec veq(&g, ifactory);
   gyronimo::dblock_adapter s_range(vmap.radius());
   gyronimo::interpolator1d **Rmnc = new gyronimo::interpolator1d* [vmap.xm().size()];
@@ -202,7 +204,7 @@ void print_surface(const Scalar scalar,
           case R_cyl: std::cout << R ; break;
           case Z_cyl: std::cout << Z ; break;
           case jacobian: std::cout << g.jacobian(p); break;
-          case jacobian_vmec: std::cout << g.jacobian_vmec(p); break;
+        //   case jacobian_vmec: std::cout << g.jacobian_vmec(p); break;
         }
         if(++j < nzeta) std::cout << " ";
       }
@@ -260,11 +262,12 @@ void debug(const gyronimo::parser_vmec& vmec ) {
   std::cin >> u >> v >> w;
   gyronimo::IR3 x {u, v, w};
   gyronimo::cubic_gsl_factory ifactory;
-  gyronimo::metric_vmec g(&vmec, &ifactory);
+  gyronimo::morphism_vmec m(&vmec, &ifactory);
+  gyronimo::metric_vmec g(&m, &ifactory);
   auto metric_at_x = g(x);
   auto dmetric_at_x = g.del(x);
   auto jacobian_at_x = g.jacobian(x);
-  auto J_at_x = g.jacobian_vmec(x);
+//   auto J_at_x = g.jacobian_vmec(x);
   gyronimo::equilibrium_vmec veq(&g, &ifactory);
   auto B_at_x = veq.contravariant(x, 0.0);
   auto norm_b = veq.magnitude(x, 0.0);
@@ -303,7 +306,7 @@ void debug(const gyronimo::parser_vmec& vmec ) {
       << dmetric_at_x[gyronimo::dSM3::www] << "] "
       << std::endl;
   std::cout << "J = " << jacobian_at_x << std::endl;
-  std::cout << "J (vmec)= " << J_at_x << std::endl;
+//   std::cout << "J (vmec)= " << J_at_x << std::endl;
   std::cout << "B = ("
         << B_at_x[gyronimo::IR3::u] << ", "
         << B_at_x[gyronimo::IR3::v] << ", "

--- a/misc/apps/vmectrace.cc
+++ b/misc/apps/vmectrace.cc
@@ -72,7 +72,7 @@ public:
     double v_parallel = gc_pointer_->get_vpp(s);
     double bphi = eq_pointer_->covariant_versor(x, t)[gyronimo::IR3::w];
     double flux = x[gyronimo::IR3::u]*x[gyronimo::IR3::u];
-    gyronimo::IR3 X = eq_pointer_->metric()->transform2cylindrical(x);
+    // gyronimo::IR3 X = eq_pointer_->metric()->transform2cylindrical(x);
     std::cout << t << " "
         << x[gyronimo::IR3::u] << " "
         << x[gyronimo::IR3::v] << " "
@@ -80,10 +80,10 @@ public:
         << v_parallel << " "
         << -zstar_*flux + vstar_*v_parallel*bphi << " "
         << gc_pointer_->energy_perpendicular(s, t) << " "
-        << gc_pointer_->energy_parallel(s) << " " 
-        << X[gyronimo::IR3::u] << " "
-        << X[gyronimo::IR3::v] << " "
-        << X[gyronimo::IR3::w] << "\n";
+        << gc_pointer_->energy_parallel(s) << " ";
+        // << X[gyronimo::IR3::u] << " "
+        // << X[gyronimo::IR3::v] << " "
+        // << X[gyronimo::IR3::w] << "\n";
   };
 private:
   double zstar_, vstar_;
@@ -147,7 +147,8 @@ int main(int argc, char* argv[]) {
   }
   gyronimo::parser_vmec vmap(command_line[1]);
   gyronimo::cubic_gsl_factory ifactory;
-  gyronimo::metric_vmec g(&vmap, &ifactory);
+  gyronimo::morphism_vmec m(&vmap, &ifactory);
+  gyronimo::metric_vmec g(&m, &ifactory);
   gyronimo::equilibrium_vmec veq(&g, &ifactory);
 
 // Reads parameters from the command line:


### PR DESCRIPTION
+ Split between general `metric_covariant` (i.e., defined independently of the coordinate transformation) and `metric_connected`, that is, those connected to a specific coordinate transformation represented by a given `morphism`;
+ Connect specialised `morphisms` to their respective metrics (cartesian, cylindrical, spherical, polar torus, helena, and vmec);
+ Extend differential geometry functionality (Christoffel symbols and related contractions);
+ Assorted bug fixes;