### PR TITLE
Fix inner structure of `castor` eigenmodes

### DIFF
--- a/gyronimo/dynamics/guiding_centre.cc
+++ b/gyronimo/dynamics/guiding_centre.cc
@@ -39,9 +39,9 @@ guiding_centre::guiding_centre(
       electric_field_(E), magnetic_field_(B),
       Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref),
       Bfield_time_factor_(Lref/(Vref*B->t_factor())),
-      Efield_time_factor_(E ? Lref/(Vref*E->t_factor()) : 0.0) {
-  Oref_tilde_ = qom*codata::e/codata::m_proton*B->m_factor()*Tref_;
-  iOref_tilde_ = 1.0/Oref_tilde_;
+      Efield_time_factor_(E ? Lref/(Vref*E->t_factor()) : 0) {
+  iOref_tilde_ = 1.0/(qom*codata::e/codata::m_proton*B->m_factor()*Tref_);
+  Eref_tilde_ = (E ? E->m_factor() : 0)/(Vref_*B->m_factor()*iOref_tilde_);
 }
 
 //! Evaluates the time derivative `dxdt` of the dynamical state `x` at time `t`.
@@ -75,7 +75,7 @@ guiding_centre::state guiding_centre::operator()(
       1.0 + inverse_omega_tilde*vpp*inner_product(covariant_b, curlb));
   IR3 drifter = 0.5*mu_tilde_*gradB + vpp*partial_t_b;
   if (electric_field_)
-      drifter -= Oref_tilde_*electric_field_->covariant(position, Etime);
+      drifter -= Eref_tilde_*electric_field_->covariant(position, Etime);
 
   IR3 dot_X = prefactor*(vpp*contravariant_b +
       inverse_omega_tilde*(

--- a/gyronimo/dynamics/guiding_centre.hh
+++ b/gyronimo/dynamics/guiding_centre.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -52,16 +52,16 @@ namespace gyronimo {
     All variables are adimensional: the position `X` of the guiding centre is
     normalised to a reference length `Lref`, the time to `Tref`, and the
     parallel velocity to `Vref`=`Lref`/`Tref`. Reference length and velocity are
-    supplied to the constructor in SI units, other normalisations are done
+    supplied to the constructor in SI units, further normalisations are done
     internally assuming *bona-fide* electromagnetic fields derived from
-    `IR3field`, with @f$\tilde{B} = B/B_{ref}@f$ whilst Faraday's law demands
-    the ratio between the reference magnitudes of the electric and magnetic
-    fields to match `Vref`. Other normalisations are @f$\tilde{\Omega} = \Omega
-    T_{ref} = \tilde{\Omega}_{ref} \tilde{B}@f$, @f$\tilde{\mathbf{E}} =
-    \tilde{\Omega}_{ref} (\mathbf{E}/E_{ref})@f$, and the magnetic moment is
-    normalised to the ratio `Uref`/`Bref`, where `Uref` is the kinetic energy
-    corresponding to `Vref`. Moreover, @f$\tilde{\nabla} = L_{ref} \nabla@f$ and
-    @f$\mathbf{b} = \mathbf{B}/B@f$.
+    `IR3field`: @f$\tilde{B} = B/B_{ref}@f$ and @f$\tilde{\mathbf{E}} =
+    \tilde{E}_{ref} (\mathbf{E}/E_{ref})@f$, with @f$\tilde{E}_{ref} =
+    \tilde{\Omega}_{ref} (E_{ref} V_{ref}^{-1} B_{ref}^{-1})@f$ an adimensional
+    constant. Other normalisations are @f$\tilde{\Omega} = \Omega T_{ref} =
+    \tilde{\Omega}_{ref} \tilde{B}@f$, while the magnetic moment is normalised
+    to the ratio `Uref`/`Bref` and `Uref` is the kinetic energy corresponding to
+    `Vref`.  Moreover, @f$\tilde{\nabla} = L_{ref} \nabla@f$ and @f$\mathbf{b} =
+    \mathbf{B}/B@f$.
 
     The equations are implemented in a coordinate-invariant form and will work
     out-of-the-box with any coordinates defined in the `metric_covariant` object
@@ -101,7 +101,8 @@ class guiding_centre {
   double Vref() const {return Vref_;};
   double mu_tilde() const {return mu_tilde_;};
   double qom_tilde() const {return qom_tilde_;};
-  double Oref_tilde() const {return Oref_tilde_;};
+  double Eref_tilde() const {return Eref_tilde_;};
+  double Oref_tilde() const {return 1.0/iOref_tilde_;};
   const IR3field* electric_field() const {return electric_field_;};
   const IR3field_c1* magnetic_field() const {return magnetic_field_;};
 
@@ -111,7 +112,7 @@ class guiding_centre {
   const double qom_tilde_, mu_tilde_;
   const double Lref_, Vref_, Tref_;
   const double Bfield_time_factor_, Efield_time_factor_;
-  double Oref_tilde_, iOref_tilde_;
+  double iOref_tilde_, Eref_tilde_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/fields/eigenmode_castor_a.cc
+++ b/gyronimo/fields/eigenmode_castor_a.cc
@@ -47,6 +47,19 @@ eigenmode_castor_a::eigenmode_castor_a(
   norm_factor_ = 1.0/ranges::max(
       views::transform(parser_->s(), max_magnitude_at_radius));
 }
+
+eigenmode_castor_a::eigenmode_castor_a(
+    double m_factor, double t_factor,
+    const parser_castor *p, const metric_helena *g,
+    const interpolator1d_factory* ifactory, double norm_factor)
+    : IR3field(m_factor, t_factor, g),
+      norm_factor_(norm_factor), parser_(p), metric_(g),
+      w_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+      tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
+      tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
+      tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
+}
+
 IR3 eigenmode_castor_a::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];

--- a/gyronimo/fields/eigenmode_castor_a.cc
+++ b/gyronimo/fields/eigenmode_castor_a.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -28,13 +28,24 @@ eigenmode_castor_a::eigenmode_castor_a(
     const interpolator1d_factory* ifactory)
     : IR3field(m_factor, t_factor, g),
       norm_factor_(1.0), parser_(p), metric_(g),
-      w_(p->w_real(), p->w_imag()), i_n_tor_(0.0, p->n_tor()),
+      w_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
-  norm_factor_ = 1.0/std::ranges::max(
-      parser_->s() | std::views::transform(
-          [this](double s){return this->magnitude({s, 0, 0}, 0);}));
+  using namespace std;
+  auto max_magnitude_at_radius = [this](double s) {
+    auto highest_harmonic = ranges::max(views::transform(
+        this->parser_->m(), [](auto m) {return abs(m);}));
+    size_t chi_range_size = (size_t)(8*highest_harmonic);
+    double delta_chi = 2*numbers::pi/chi_range_size;
+    auto chi_range = views::transform(
+        views::iota(0u, chi_range_size), bind_front(multiplies{}, delta_chi));
+    return ranges::max(views::transform(
+        chi_range,
+        [this, s](double chi){return this->magnitude({s, chi, 0}, 0);}));
+  };
+  norm_factor_ = 1.0/ranges::max(
+      views::transform(parser_->s(), max_magnitude_at_radius));
 }
 IR3 eigenmode_castor_a::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];

--- a/gyronimo/fields/eigenmode_castor_a.cc
+++ b/gyronimo/fields/eigenmode_castor_a.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021-2023 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues and João Palma.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,13 +22,15 @@
 
 namespace gyronimo{
 
+//! Normalises native `castor` harmonics to the poloidal-section maximum.
 eigenmode_castor_a::eigenmode_castor_a(
-    double m_factor, double t_factor,
+    double m_factor, double v_alfven,
     const parser_castor *p, const metric_helena *g,
     const interpolator1d_factory* ifactory)
-    : IR3field(m_factor, t_factor, g),
-      norm_factor_(1.0), parser_(p), metric_(g),
-      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+    : IR3field(m_factor, g->parser()->rmag()/v_alfven, g),
+      native_factor_(1.0), parser_(p), metric_(g),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()),
+      i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
@@ -44,32 +46,43 @@ eigenmode_castor_a::eigenmode_castor_a(
         chi_range,
         [this, s](double chi){return this->magnitude({s, chi, 0}, 0);}));
   };
-  norm_factor_ = 1.0/ranges::max(
+  native_factor_ = 1.0/ranges::max(
       views::transform(parser_->s(), max_magnitude_at_radius));
 }
 
+//! Builds with normalisation compatible with a parent `eigenmode_castor_b`.
 eigenmode_castor_a::eigenmode_castor_a(
-    double m_factor, double t_factor,
-    const parser_castor *p, const metric_helena *g,
-    const interpolator1d_factory* ifactory, double norm_factor)
-    : IR3field(m_factor, t_factor, g),
-      norm_factor_(norm_factor), parser_(p), metric_(g),
-      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
-      tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
-      tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
-      tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
+    const eigenmode_castor_b* parent, const interpolator1d_factory* ifactory)
+    : IR3field(
+          parent->m_factor()*(parent->v_alfven()*parent->t_factor()),
+          parent->t_factor(),
+          static_cast<const metric_helena*>(parent->metric())),
+      native_factor_(parent->native_factor()),
+      parser_(parent->parser()),
+      metric_(static_cast<const metric_helena*>(parent->metric())),
+      eigenvalue_(parent->parser()->eigenvalue_real(),
+          parent->parser()->eigenvalue_imag()),
+      i_n_tor_(0.0, parent->parser()->n_tor()),
+      tildeA1_(parent->parser()->s(), parent->parser()->a1_real(),
+          parent->parser()->a1_imag(), parent->parser()->m(), ifactory),
+      tildeA2_(parent->parser()->s(), parent->parser()->a2_real(),
+          parent->parser()->a2_imag(), parent->parser()->m(), ifactory),
+      tildeA3_(parent->parser()->s(), parent->parser()->a3_real(),
+          parent->parser()->a3_imag(), parent->parser()->m(), ifactory) {
 }
 
 IR3 eigenmode_castor_a::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
   double chi = metric_->reduce_chi(position[IR3::v]);
-  std::complex<double> factor = norm_factor_*std::exp(eigenvalue_*time + i_n_tor_*phi);
+  std::complex<double> factor =
+      native_factor_*std::exp(eigenvalue_*time + i_n_tor_*phi);
   return {
       std::real(factor*(this->tildeA1_(s, chi))),
           std::real(factor*(this->tildeA2_(s, chi))),
               std::real(factor*(this->tildeA3_(s, chi)))};
 }
+
 IR3 eigenmode_castor_a::contravariant(const IR3& position, double time) const {
   return this->metric()->
       to_contravariant(this->covariant(position, time), position);

--- a/gyronimo/fields/eigenmode_castor_a.cc
+++ b/gyronimo/fields/eigenmode_castor_a.cc
@@ -28,7 +28,7 @@ eigenmode_castor_a::eigenmode_castor_a(
     const interpolator1d_factory* ifactory)
     : IR3field(m_factor, t_factor, g),
       norm_factor_(1.0), parser_(p), metric_(g),
-      w_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
@@ -54,7 +54,7 @@ eigenmode_castor_a::eigenmode_castor_a(
     const interpolator1d_factory* ifactory, double norm_factor)
     : IR3field(m_factor, t_factor, g),
       norm_factor_(norm_factor), parser_(p), metric_(g),
-      w_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
@@ -64,7 +64,7 @@ IR3 eigenmode_castor_a::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
   double chi = metric_->reduce_chi(position[IR3::v]);
-  std::complex<double> factor = norm_factor_*std::exp(w_*time + i_n_tor_*phi);
+  std::complex<double> factor = norm_factor_*std::exp(eigenvalue_*time + i_n_tor_*phi);
   return {
       std::real(factor*(this->tildeA1_(s, chi))),
           std::real(factor*(this->tildeA2_(s, chi))),

--- a/gyronimo/fields/eigenmode_castor_a.hh
+++ b/gyronimo/fields/eigenmode_castor_a.hh
@@ -37,10 +37,17 @@ namespace gyronimo {
     @f]
     Each @f$ \tilde{A}_k^m(s) @f$ is a `fourier_complex` object with underlying
     `interpolator1d` type set by `ifactory`. The time normalisation `t_factor`
-    is the ratio @f$R_0/v_A(0)@f$ of the axis radius to the on-axis Alfven
-    velocity. The field is normalised to its maximum magnitude over the
-    low-field side (@f$\chi = 0@f$), its actual amplitude being set by
-    `m_factor` (SI).
+    **must** be set to the ratio @f$R_0/v_A(0)@f$ of the axis radius to the
+    on-axis Alfven velocity. The field is normalised internally by setting its
+    maximum magnitude over the poloidal cross section (@f$\phi = 0@f$) to the
+    value `m_factor` (SI).
+
+    @todo higher-order derivatives from the interpolators seem to produce noisy
+    magnetic fields; implement derivatives produced by castor itself (from the
+    internal hermite elements, not yet available in parser_castor).
+
+    @todo move the normalisation done in the constructor into a code block
+    common with all elements of the `eigenmode_castor_x` family.
 */
 class eigenmode_castor_a : public IR3field {
  public:

--- a/gyronimo/fields/eigenmode_castor_a.hh
+++ b/gyronimo/fields/eigenmode_castor_a.hh
@@ -72,7 +72,7 @@ class eigenmode_castor_a : public IR3field {
   double norm_factor_;
   const parser_castor *parser_;
   const metric_helena *metric_;
-  std::complex<double> w_, i_n_tor_;
+  std::complex<double> eigenvalue_, i_n_tor_;
   fourier_complex tildeA1_, tildeA2_, tildeA3_;
 };
 

--- a/gyronimo/fields/eigenmode_castor_a.hh
+++ b/gyronimo/fields/eigenmode_castor_a.hh
@@ -55,12 +55,18 @@ class eigenmode_castor_a : public IR3field {
       double m_factor, double t_factor,
       const parser_castor *p, const metric_helena *g,
       const interpolator1d_factory* ifactory);
+  eigenmode_castor_a(
+      double m_factor, double t_factor,
+      const parser_castor *p, const metric_helena *g,
+      const interpolator1d_factory* ifactory, 
+      double norm_factor);
   virtual ~eigenmode_castor_a() override {};
 
   virtual IR3 covariant(const IR3& position, double time) const override;
   virtual IR3 contravariant(const IR3& position, double time) const override;
 
   const parser_castor* parser() const {return parser_;};
+  double get_norm_factor(){return norm_factor_;};
 
  private:
   double norm_factor_;

--- a/gyronimo/fields/eigenmode_castor_a.hh
+++ b/gyronimo/fields/eigenmode_castor_a.hh
@@ -20,59 +20,64 @@
 #ifndef GYRONIMO_EIGENMODE_CASTOR_A
 #define GYRONIMO_EIGENMODE_CASTOR_A
 
-#include <gyronimo/fields/IR3field.hh>
-#include <gyronimo/parsers/parser_castor.hh>
-#include <gyronimo/metrics/metric_helena.hh>
-#include <gyronimo/interpolators/interpolator1d.hh>
-#include <gyronimo/interpolators/fourier_complex.hh>
+#include <gyronimo/fields/eigenmode_castor_b.hh>
 
 namespace gyronimo {
 
-//! Vector-potential eigenvector from `CASTOR` ceig output file.
+//! Vector-potential eigenvector from a `CASTOR` output file.
 /*!
-    The **covariant** components of the potential vector are represented as:
+    The vector-potential, divided by `m_factor` (SI), is the adimensional
+    perturbation that `CASTOR` relates with the magnetic-field via
+    @f$\mathbf{B}_\mathrm{cas} = \tilde{\nabla} \times
+    \mathbf{A}_\mathrm{cas}@f$, i.e., the adimensional equation 2.18 in [W.
+    Kerner *et al*., J. Comput. Phys. **142**, 271 (1998)], where @f$
+    \tilde{\nabla} = R_0 \nabla @f$, and @f$R_0@f$ is the magnetic axis radius.
+    Its covariant components are represented as:
     @f[
-      A_k(s, \chi, \phi, t) =
-          e^{i \omega t + i n \phi} \sum_m \tilde{A}_k^m(s) e^{i m \chi}.
+      A_k^\mathrm{cas}(s, \chi, \phi, t) = e^{\lambda t + i n \phi}
+          \sum_m \hat{A}_{k,m}^\mathrm{cas}(s) e^{i m \chi}.
     @f]
-    Each @f$ \tilde{A}_k^m(s) @f$ is a `fourier_complex` object with underlying
-    `interpolator1d` type set by `ifactory`. The time normalisation `t_factor`
-    **must** be set to the ratio @f$R_0/v_A(0)@f$ of the axis radius to the
-    on-axis Alfven velocity. The field is normalised internally by setting its
-    maximum magnitude over the poloidal cross section (@f$\phi = 0@f$) to the
-    value `m_factor` (SI).
+    Each @f$ \hat{A}^\mathrm{cas}_{k,m}(s) @f$ is a `fourier_complex` object
+    with underlying `interpolator1d` type set by `ifactory`. The time
+    normalisation is set to the Alfven time @f$R_0/v_A^0@f$, with @f$v_A^0@f$
+    the Alfven velocity on axis that is supplied to the constructor via
+    `v_alfven` (SI). At construction, the field @f$\mathbf{A}_\mathrm{cas}@f$ is
+    multiplied by a given constant (returned by `native_factor()`) devised in
+    order to set its maximum magnitude over the poloidal cross section (i.e.,
+    @f$\phi = 0, t = 0@f$) to unity. An alternative constructor allows the
+    normalisation factors to be automatically deduced in order to enforce
+    compatibility with a parent `eigenmode_castor_b` object.
 
     @todo higher-order derivatives from the interpolators seem to produce noisy
     magnetic fields; implement derivatives produced by castor itself (from the
     internal hermite elements, not yet available in parser_castor).
 
     @todo move the normalisation done in the constructor into a code block
-    common with all elements of the `eigenmode_castor_x` family.
+    common with all elements of the `eigenmode_castor_x` family. Extend
+    automatic normalisation construction to other eigenmode types.
 */
 class eigenmode_castor_a : public IR3field {
  public:
   eigenmode_castor_a(
-      double m_factor, double t_factor,
+      double m_factor, double v_alfven,
       const parser_castor *p, const metric_helena *g,
       const interpolator1d_factory* ifactory);
   eigenmode_castor_a(
-      double m_factor, double t_factor,
-      const parser_castor *p, const metric_helena *g,
-      const interpolator1d_factory* ifactory, 
-      double norm_factor);
+      const eigenmode_castor_b* parent, const interpolator1d_factory* ifactory);
   virtual ~eigenmode_castor_a() override {};
 
   virtual IR3 covariant(const IR3& position, double time) const override;
   virtual IR3 contravariant(const IR3& position, double time) const override;
 
   const parser_castor* parser() const {return parser_;};
-  double get_norm_factor(){return norm_factor_;};
+  double native_factor() const {return native_factor_;};
+  double v_alfven() const {return metric_->parser()->rmag()/this->t_factor();};
 
  private:
-  double norm_factor_;
+  double native_factor_;
   const parser_castor *parser_;
   const metric_helena *metric_;
-  std::complex<double> eigenvalue_, i_n_tor_;
+  const std::complex<double> eigenvalue_, i_n_tor_;
   fourier_complex tildeA1_, tildeA2_, tildeA3_;
 };
 

--- a/gyronimo/fields/eigenmode_castor_b.cc
+++ b/gyronimo/fields/eigenmode_castor_b.cc
@@ -29,7 +29,7 @@ eigenmode_castor_b::eigenmode_castor_b(
     : IR3field_c1(m_factor, t_factor, g),
       norm_factor_(1.0),
       parser_(p), metric_(g),
-      w_(p->eigenvalue_real(), p->eigenvalue_imag()),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()),
       n_tor_squared_(p->n_tor()*p->n_tor()),
       i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
@@ -58,7 +58,7 @@ eigenmode_castor_b::eigenmode_castor_b(
     : IR3field_c1(m_factor, t_factor, g),
       norm_factor_(norm_factor),
       parser_(p), metric_(g),
-      w_(p->eigenvalue_real(), p->eigenvalue_imag()),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()),
       n_tor_squared_(p->n_tor()*p->n_tor()),
       i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
@@ -120,8 +120,7 @@ IR3 eigenmode_castor_b::partial_t_contravariant(
   double phi = position[IR3::w];
   double chi = metric_->reduce_chi(position[IR3::v]);
   std::complex<double> factor = norm_factor_*this->exp_wt_nphi(time, phi);
-  using namespace std::complex_literals;
-  factor *= 1i*w_/this->metric()->jacobian(position);
+  factor *= eigenvalue_/this->metric()->jacobian(position);
   return {
       std::real(factor*(this->d2A3(s, chi) - this->d3A2(s, chi))),
       std::real(factor*(this->d3A1(s, chi) - this->d1A3(s, chi))),
@@ -132,7 +131,7 @@ inline
 std::complex<double> eigenmode_castor_b::exp_wt_nphi(
     double time, double phi) const {
   using namespace std::complex_literals;
-  return std::exp(w_*time + 1i*parser_->n_tor()*phi);
+  return std::exp(eigenvalue_*time + 1i*parser_->n_tor()*phi);
 }
 inline
 std::complex<double> eigenmode_castor_b::d1A2(double s, double chi) const {

--- a/gyronimo/fields/eigenmode_castor_b.cc
+++ b/gyronimo/fields/eigenmode_castor_b.cc
@@ -51,6 +51,21 @@ eigenmode_castor_b::eigenmode_castor_b(
       views::transform(parser_->s(), max_magnitude_at_radius));
 }
 
+eigenmode_castor_b::eigenmode_castor_b(
+    double m_factor, double t_factor,
+    const parser_castor *p, const metric_helena *g,
+    const interpolator1d_factory* ifactory, double norm_factor)
+    : IR3field_c1(m_factor, t_factor, g),
+      norm_factor_(norm_factor),
+      parser_(p), metric_(g),
+      w_(p->eigenvalue_real(), p->eigenvalue_imag()),
+      n_tor_squared_(p->n_tor()*p->n_tor()),
+      i_n_tor_(0.0, p->n_tor()),
+      tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
+      tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
+      tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
+}
+
 //! Magnetic field \f$B^i = \epsilon^{ijk}/\sqrt{g} \partial_j A_k\f$.
 IR3 eigenmode_castor_b::contravariant(const IR3& position, double time) const {
   double s = position[IR3::u];

--- a/gyronimo/fields/eigenmode_castor_b.cc
+++ b/gyronimo/fields/eigenmode_castor_b.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -29,15 +29,26 @@ eigenmode_castor_b::eigenmode_castor_b(
     : IR3field_c1(m_factor, t_factor, g),
       norm_factor_(1.0),
       parser_(p), metric_(g),
-      w_(p->w_real(), p->w_imag()),
+      w_(p->eigenvalue_real(), p->eigenvalue_imag()),
       n_tor_squared_(p->n_tor()*p->n_tor()),
       i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
-  norm_factor_ = 1.0/std::ranges::max(
-      parser_->s() | std::views::transform(
-          [this](double s){return this->magnitude({s, 0, 0}, 0);}));
+  using namespace std;
+  auto max_magnitude_at_radius = [this](double s) {
+    auto highest_harmonic = ranges::max(views::transform(
+        this->parser_->m(), [](auto m) {return abs(m);}));
+    size_t chi_range_size = (size_t)(8*highest_harmonic);
+    double delta_chi = 2*numbers::pi/chi_range_size;
+    auto chi_range = views::transform(
+        views::iota(0u, chi_range_size), bind_front(multiplies{}, delta_chi));
+    return ranges::max(views::transform(
+        chi_range,
+        [this, s](double chi){return this->magnitude({s, chi, 0}, 0);}));
+  };
+  norm_factor_ = 1.0/ranges::max(
+      views::transform(parser_->s(), max_magnitude_at_radius));
 }
 
 //! Magnetic field \f$B^i = \epsilon^{ijk}/\sqrt{g} \partial_j A_k\f$.

--- a/gyronimo/fields/eigenmode_castor_b.hh
+++ b/gyronimo/fields/eigenmode_castor_b.hh
@@ -28,40 +28,43 @@
 
 namespace gyronimo {
 
-//! Magnetic-field eigenvector from `CASTOR` ceig output file.
+//! Magnetic-field eigenvector from a `CASTOR` output file.
 /*!
-    The magnetic-field contravariant components are extracted as @f$\mathbf{B} =
-    \nabla \times \mathbf{A}@f$ from the covariant components of the
-    vector-potential represented as:
+    The magnetic-field, divided by `m_factor` (SI), is the adimensional magnetic
+    perturbation as defined by `CASTOR` from the vector-potential via
+    @f$\mathbf{B}_\mathrm{cas} = \tilde{\nabla} \times
+    \mathbf{A}_\mathrm{cas}@f$, i.e., the adimensional equation 2.18 in [W.
+    Kerner *et al*., J. Comput. Phys. **142**, 271 (1998)], where @f$
+    \tilde{\nabla} = R_0 \nabla @f$, and @f$R_0@f$ is the magnetic axis radius.
+    On the other hand, covariant components of the adimensional vector-potential
+    as defined by `CASTOR` are represented as:
     @f[
-      A_k(s, \chi, \phi, t) =
-          e^{i \omega t + i n \phi} \sum_m \tilde{A}_k^m(s) e^{i m \chi}.
+      A_k^\mathrm{cas}(s, \chi, \phi, t) = e^{\lambda t + i n \phi}
+          \sum_m \hat{A}_{k,m}^\mathrm{cas}(s) e^{i m \chi}.
     @f]
-    Each @f$ \tilde{A}_k^m(s) @f$ is a `fourier_complex` object with underlying
-    `interpolator1d` type set by `ifactory`. The time normalisation `t_factor`
-    **must** be set to the ratio @f$R_0/v_A(0)@f$ of the axis radius to the
-    on-axis Alfven velocity. The field is normalised internally by setting its
-    maximum magnitude over the poloidal cross section (@f$\phi = 0@f$) to the
-    value `m_factor` (SI).
+    Each @f$ \hat{A}^\mathrm{cas}_{k,m}(s) @f$ is a `fourier_complex` object
+    with underlying `interpolator1d` type set by `ifactory`. The time
+    normalisation is set to the Alfven time @f$R_0/v_A^0@f$, with @f$v_A^0@f$
+    the Alfven velocity on axis that is supplied to the constructor via
+    `v_alfven` (SI). At construction, the field @f$\mathbf{B}_\mathrm{cas}@f$ is
+    multiplied by a given constant (returned by `native_factor()`) devised in
+    order to set its maximum magnitude over the poloidal cross section (i.e.,
+    @f$\phi = 0, t = 0@f$) to unity.
 
     @todo higher-order derivatives from the interpolators seem to produce noisy
     magnetic fields; implement derivatives produced by castor itself (from the
     internal hermite elements, not yet available in parser_castor).
 
     @todo move the normalisation done in the constructor into a code block
-    common with all elements of the `eigenmode_castor_x` family.
+    common with all elements of the `eigenmode_castor_x` family, along with the
+    common interface.
 */
 class eigenmode_castor_b : public IR3field_c1 {
  public:
   eigenmode_castor_b(
-      double m_factor, double t_factor,
+      double m_factor, double v_alfven,
       const parser_castor *p, const metric_helena *g,
       const interpolator1d_factory* ifactory);
-  eigenmode_castor_b(
-      double m_factor, double t_factor,
-      const parser_castor *p, const metric_helena *g,
-      const interpolator1d_factory* ifactory, 
-      double norm_factor);
   virtual ~eigenmode_castor_b() override {};
 
   virtual IR3 contravariant(const IR3& position, double time) const override;
@@ -71,41 +74,42 @@ class eigenmode_castor_b : public IR3field_c1 {
       const IR3& position, double time) const override;
 
   const parser_castor* parser() const {return parser_;};
-  double get_norm_factor(){return norm_factor_;};
+  double native_factor() const {return native_factor_;};
+  double v_alfven() const {return metric_->parser()->rmag()/this->t_factor();};
 
  private:
-  double norm_factor_;
+  double native_factor_;
   const parser_castor *parser_;
   const metric_helena *metric_;
   double n_tor_squared_;
   std::complex<double> eigenvalue_, i_n_tor_;
   fourier_complex tildeA1_, tildeA2_, tildeA3_;
 
-  std::complex<double> exp_wt_nphi(double time, double phi) const;
-  std::complex<double> d1A2(double s, double chi) const;
-  std::complex<double> d1A3(double s, double chi) const;
-  std::complex<double> d2A1(double s, double chi) const;
-  std::complex<double> d2A3(double s, double chi) const;
-  std::complex<double> d3A1(double s, double chi) const;
-  std::complex<double> d3A2(double s, double chi) const;
-  std::complex<double> d11A2(double s, double chi) const;
-  std::complex<double> d11A3(double s, double chi) const;
-  std::complex<double> d21A1(double s, double chi) const;
-  std::complex<double> d21A3(double s, double chi) const;
-  std::complex<double> d31A1(double s, double chi) const;
-  std::complex<double> d31A2(double s, double chi) const;
-  std::complex<double> d12A2(double s, double chi) const;
-  std::complex<double> d12A3(double s, double chi) const;
-  std::complex<double> d22A1(double s, double chi) const;
-  std::complex<double> d22A3(double s, double chi) const;
-  std::complex<double> d32A1(double s, double chi) const;
-  std::complex<double> d32A2(double s, double chi) const;
-  std::complex<double> d13A2(double s, double chi) const;
-  std::complex<double> d13A3(double s, double chi) const;
-  std::complex<double> d23A1(double s, double chi) const;
-  std::complex<double> d23A3(double s, double chi) const;
-  std::complex<double> d33A1(double s, double chi) const;
-  std::complex<double> d33A2(double s, double chi) const;
+  inline std::complex<double> exp_wt_nphi(double time, double phi) const;
+  inline std::complex<double> d1A2(double s, double chi) const;
+  inline std::complex<double> d1A3(double s, double chi) const;
+  inline std::complex<double> d2A1(double s, double chi) const;
+  inline std::complex<double> d2A3(double s, double chi) const;
+  inline std::complex<double> d3A1(double s, double chi) const;
+  inline std::complex<double> d3A2(double s, double chi) const;
+  inline std::complex<double> d11A2(double s, double chi) const;
+  inline std::complex<double> d11A3(double s, double chi) const;
+  inline std::complex<double> d21A1(double s, double chi) const;
+  inline std::complex<double> d21A3(double s, double chi) const;
+  inline std::complex<double> d31A1(double s, double chi) const;
+  inline std::complex<double> d31A2(double s, double chi) const;
+  inline std::complex<double> d12A2(double s, double chi) const;
+  inline std::complex<double> d12A3(double s, double chi) const;
+  inline std::complex<double> d22A1(double s, double chi) const;
+  inline std::complex<double> d22A3(double s, double chi) const;
+  inline std::complex<double> d32A1(double s, double chi) const;
+  inline std::complex<double> d32A2(double s, double chi) const;
+  inline std::complex<double> d13A2(double s, double chi) const;
+  inline std::complex<double> d13A3(double s, double chi) const;
+  inline std::complex<double> d23A1(double s, double chi) const;
+  inline std::complex<double> d23A3(double s, double chi) const;
+  inline std::complex<double> d33A1(double s, double chi) const;
+  inline std::complex<double> d33A2(double s, double chi) const;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/fields/eigenmode_castor_b.hh
+++ b/gyronimo/fields/eigenmode_castor_b.hh
@@ -78,7 +78,7 @@ class eigenmode_castor_b : public IR3field_c1 {
   const parser_castor *parser_;
   const metric_helena *metric_;
   double n_tor_squared_;
-  std::complex<double> w_, i_n_tor_;
+  std::complex<double> eigenvalue_, i_n_tor_;
   fourier_complex tildeA1_, tildeA2_, tildeA3_;
 
   std::complex<double> exp_wt_nphi(double time, double phi) const;

--- a/gyronimo/fields/eigenmode_castor_b.hh
+++ b/gyronimo/fields/eigenmode_castor_b.hh
@@ -57,6 +57,11 @@ class eigenmode_castor_b : public IR3field_c1 {
       double m_factor, double t_factor,
       const parser_castor *p, const metric_helena *g,
       const interpolator1d_factory* ifactory);
+  eigenmode_castor_b(
+      double m_factor, double t_factor,
+      const parser_castor *p, const metric_helena *g,
+      const interpolator1d_factory* ifactory, 
+      double norm_factor);
   virtual ~eigenmode_castor_b() override {};
 
   virtual IR3 contravariant(const IR3& position, double time) const override;
@@ -66,6 +71,7 @@ class eigenmode_castor_b : public IR3field_c1 {
       const IR3& position, double time) const override;
 
   const parser_castor* parser() const {return parser_;};
+  double get_norm_factor(){return norm_factor_;};
 
  private:
   double norm_factor_;

--- a/gyronimo/fields/eigenmode_castor_b.hh
+++ b/gyronimo/fields/eigenmode_castor_b.hh
@@ -39,14 +39,17 @@ namespace gyronimo {
     @f]
     Each @f$ \tilde{A}_k^m(s) @f$ is a `fourier_complex` object with underlying
     `interpolator1d` type set by `ifactory`. The time normalisation `t_factor`
-    is the ratio @f$R_0/v_A(0)@f$ of the axis radius to the on-axis Alfven
-    velocity. The field is normalised to its maximum magnitude over the
-    low-field side (@f$\chi = 0@f$), its actual amplitude being set by
-    `m_factor` (SI).
+    **must** be set to the ratio @f$R_0/v_A(0)@f$ of the axis radius to the
+    on-axis Alfven velocity. The field is normalised internally by setting its
+    maximum magnitude over the poloidal cross section (@f$\phi = 0@f$) to the
+    value `m_factor` (SI).
 
     @todo higher-order derivatives from the interpolators seem to produce noisy
     magnetic fields; implement derivatives produced by castor itself (from the
     internal hermite elements, not yet available in parser_castor).
+
+    @todo move the normalisation done in the constructor into a code block
+    common with all elements of the `eigenmode_castor_x` family.
 */
 class eigenmode_castor_b : public IR3field_c1 {
  public:

--- a/gyronimo/fields/eigenmode_castor_e.cc
+++ b/gyronimo/fields/eigenmode_castor_e.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -23,13 +23,13 @@ namespace gyronimo{
 
 IR3 eigenmode_castor_e::covariant(const IR3& position, double time) const {
   IR3 A = A_.covariant(position, time);
-  return {std::real(-iw_*A[IR3::u]),
-      std::real(-iw_*A[IR3::v]), std::real(-iw_*A[IR3::w])};
+  return {std::real(eigenvalue_*A[IR3::u]),
+      std::real(eigenvalue_*A[IR3::v]), std::real(eigenvalue_*A[IR3::w])};
 }
 IR3 eigenmode_castor_e::contravariant(const IR3& position, double time) const {
   IR3 A = A_.contravariant(position, time);
-  return {std::real(-iw_*A[IR3::u]),
-      std::real(-iw_*A[IR3::v]), std::real(-iw_*A[IR3::w])};
+  return {std::real(eigenvalue_*A[IR3::u]),
+      std::real(eigenvalue_*A[IR3::v]), std::real(eigenvalue_*A[IR3::w])};
 }
 
 } // end namespace gyronimo.

--- a/gyronimo/fields/eigenmode_castor_e.cc
+++ b/gyronimo/fields/eigenmode_castor_e.cc
@@ -22,13 +22,15 @@
 
 namespace gyronimo{
 
+//! Normalises native `castor` harmonics to the poloidal-section maximum.
 eigenmode_castor_e::eigenmode_castor_e(
-    double m_factor, double t_factor,
+    double m_factor, double v_alfven,
     const parser_castor *p, const metric_helena *g,
     const interpolator1d_factory* ifactory)
-    : IR3field(m_factor, t_factor, g),
-      norm_factor_(1.0), parser_(p), metric_(g),
-      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+    : IR3field(m_factor, g->parser()->rmag()/v_alfven, g),
+      native_factor_(1.0), parser_(p), metric_(g),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()),
+      i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
@@ -44,27 +46,35 @@ eigenmode_castor_e::eigenmode_castor_e(
         chi_range,
         [this, s](double chi){return this->magnitude({s, chi, 0}, 0);}));
   };
-  norm_factor_ = 1.0/ranges::max(
+  native_factor_ = 1.0/ranges::max(
       views::transform(parser_->s(), max_magnitude_at_radius));
 }
 
+//! Builds with normalisation compatible with a parent `eigenmode_castor_b`.
 eigenmode_castor_e::eigenmode_castor_e(
-    double m_factor, double t_factor,
-    const parser_castor *p, const metric_helena *g,
-    const interpolator1d_factory* ifactory, double norm_factor)
-    : IR3field(m_factor, t_factor, g),
-      norm_factor_(norm_factor), parser_(p), metric_(g),
-      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
-      tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
-      tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
-      tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
+    const eigenmode_castor_b* parent, const interpolator1d_factory* ifactory)
+    : IR3field(parent->m_factor()*parent->v_alfven(), parent->t_factor(),
+          static_cast<const metric_helena*>(parent->metric())),
+      native_factor_(parent->native_factor()),
+      parser_(parent->parser()),
+      metric_(static_cast<const metric_helena*>(parent->metric())),
+      eigenvalue_(parent->parser()->eigenvalue_real(),
+          parent->parser()->eigenvalue_imag()),
+      i_n_tor_(0.0, parent->parser()->n_tor()),
+      tildeA1_(parent->parser()->s(), parent->parser()->a1_real(),
+          parent->parser()->a1_imag(), parent->parser()->m(), ifactory),
+      tildeA2_(parent->parser()->s(), parent->parser()->a2_real(),
+          parent->parser()->a2_imag(), parent->parser()->m(), ifactory),
+      tildeA3_(parent->parser()->s(), parent->parser()->a3_real(),
+          parent->parser()->a3_imag(), parent->parser()->m(), ifactory) {
 }
 
 IR3 eigenmode_castor_e::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
   double chi = metric_->reduce_chi(position[IR3::v]);
-  std::complex<double> factor = -eigenvalue_*norm_factor_*std::exp(eigenvalue_*time + i_n_tor_*phi);
+  std::complex<double> factor =
+      -eigenvalue_*native_factor_*std::exp(eigenvalue_*time + i_n_tor_*phi);
   return {
       std::real(factor*(this->tildeA1_(s, chi))),
           std::real(factor*(this->tildeA2_(s, chi))),

--- a/gyronimo/fields/eigenmode_castor_e.cc
+++ b/gyronimo/fields/eigenmode_castor_e.cc
@@ -28,7 +28,7 @@ eigenmode_castor_e::eigenmode_castor_e(
     const interpolator1d_factory* ifactory)
     : IR3field(m_factor, t_factor, g),
       norm_factor_(1.0), parser_(p), metric_(g),
-      w_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
@@ -54,7 +54,7 @@ eigenmode_castor_e::eigenmode_castor_e(
     const interpolator1d_factory* ifactory, double norm_factor)
     : IR3field(m_factor, t_factor, g),
       norm_factor_(norm_factor), parser_(p), metric_(g),
-      w_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
+      eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()), i_n_tor_(0.0, p->n_tor()),
       tildeA1_(p->s(), p->a1_real(), p->a1_imag(), p->m(), ifactory),
       tildeA2_(p->s(), p->a2_real(), p->a2_imag(), p->m(), ifactory),
       tildeA3_(p->s(), p->a3_real(), p->a3_imag(), p->m(), ifactory) {
@@ -64,7 +64,7 @@ IR3 eigenmode_castor_e::covariant(const IR3& position, double time) const {
   double s = position[IR3::u];
   double phi = position[IR3::w];
   double chi = metric_->reduce_chi(position[IR3::v]);
-  std::complex<double> factor = -w_*norm_factor_*std::exp(w_*time + i_n_tor_*phi);
+  std::complex<double> factor = -eigenvalue_*norm_factor_*std::exp(eigenvalue_*time + i_n_tor_*phi);
   return {
       std::real(factor*(this->tildeA1_(s, chi))),
           std::real(factor*(this->tildeA2_(s, chi))),

--- a/gyronimo/fields/eigenmode_castor_e.hh
+++ b/gyronimo/fields/eigenmode_castor_e.hh
@@ -34,25 +34,32 @@ namespace gyronimo {
     magnitude over the poloidal cross section (@f$\phi = 0@f$) to the value
     `m_factor` (SI).
 */
+
 class eigenmode_castor_e : public IR3field {
  public:
   eigenmode_castor_e(
       double m_factor, double t_factor,
       const parser_castor *p, const metric_helena *g,
-      const interpolator1d_factory* ifactory)
-      : IR3field(m_factor, t_factor, g),
-        eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()),
-        A_(m_factor*t_factor, t_factor, p, g, ifactory) {};
+      const interpolator1d_factory* ifactory);
+  eigenmode_castor_e(
+      double m_factor, double t_factor,
+      const parser_castor *p, const metric_helena *g,
+      const interpolator1d_factory* ifactory, 
+      double norm_factor);
   virtual ~eigenmode_castor_e() override {};
 
   virtual IR3 covariant(const IR3& position, double time) const override;
   virtual IR3 contravariant(const IR3& position, double time) const override;
 
-  const parser_castor* parser() const {return A_.parser();};
+  const parser_castor* parser() const {return parser_;};
+  double get_norm_factor(){return norm_factor_;};
 
  private:
-  std::complex<double> eigenvalue_;
-  eigenmode_castor_a A_;
+  double norm_factor_;
+  const parser_castor *parser_;
+  const metric_helena *metric_;
+  std::complex<double> w_, i_n_tor_;
+  fourier_complex tildeA1_, tildeA2_, tildeA3_;
 };
 
 } // end namespace gyronimo.

--- a/gyronimo/fields/eigenmode_castor_e.hh
+++ b/gyronimo/fields/eigenmode_castor_e.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -27,10 +27,12 @@ namespace gyronimo {
 //! Electric-field eigenvector from `CASTOR` ceig output file.
 /*!
     The electric-field **covariant** components are extracted as @f$\mathbf{E} =
-    - \partial_t \mathbf{A} = i \omega \mathbf{A} @f$ from the vector potential
-    stored in a `eigenmode_castor_a`, with a similar normalisation to the
-    on-axis Alfven time. The normalisation of the electric-field magnitude is
-    set by `m_factor` (SI).
+    - \partial_t \mathbf{A}@f$ from the vector potential stored in a
+    `eigenmode_castor_a` object. The time normalisation `t_factor` **must** be
+    set to the ratio @f$R_0/v_A(0)@f$ of the axis radius to the on-axis Alfven
+    velocity. The field is normalised internally by setting its maximum
+    magnitude over the poloidal cross section (@f$\phi = 0@f$) to the value
+    `m_factor` (SI).
 */
 class eigenmode_castor_e : public IR3field {
  public:
@@ -39,7 +41,7 @@ class eigenmode_castor_e : public IR3field {
       const parser_castor *p, const metric_helena *g,
       const interpolator1d_factory* ifactory)
       : IR3field(m_factor, t_factor, g),
-        iw_(-p->w_imag(), p->w_real()),
+        eigenvalue_(p->eigenvalue_real(), p->eigenvalue_imag()),
         A_(m_factor*t_factor, t_factor, p, g, ifactory) {};
   virtual ~eigenmode_castor_e() override {};
 
@@ -49,7 +51,7 @@ class eigenmode_castor_e : public IR3field {
   const parser_castor* parser() const {return A_.parser();};
 
  private:
-  std::complex<double> iw_;
+  std::complex<double> eigenvalue_;
   eigenmode_castor_a A_;
 };
 

--- a/gyronimo/fields/eigenmode_castor_e.hh
+++ b/gyronimo/fields/eigenmode_castor_e.hh
@@ -58,7 +58,7 @@ class eigenmode_castor_e : public IR3field {
   double norm_factor_;
   const parser_castor *parser_;
   const metric_helena *metric_;
-  std::complex<double> w_, i_n_tor_;
+  std::complex<double> eigenvalue_, i_n_tor_;
   fourier_complex tildeA1_, tildeA2_, tildeA3_;
 };
 

--- a/gyronimo/fields/linear_combo.hh
+++ b/gyronimo/fields/linear_combo.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,6 +26,13 @@
 namespace gyronimo {
 
 //! Linear combination of `N` IR3 fields (*shared* coordinates).
+/*!
+    Combines a collection of `IR3field` objects into a single IR3 field. The
+    resulting object has its magnitude normalised to `m_factor` and its time
+    normalised to `t_factor`. Therefore, the weighting factor corresponding to
+    the k-th field `field_set_[k]` is `field_set_[k]->m_factor()/m_factor`.
+    Combinations of fields with different time normalisations are supported.
+*/
 template<size_t N>
 class linear_combo : public IR3field {
  public:

--- a/gyronimo/fields/linear_combo_c1.hh
+++ b/gyronimo/fields/linear_combo_c1.hh
@@ -93,7 +93,7 @@ IR3 linear_combo_c1<N>::partial_t_contravariant(
     const IR3& position, double time) const {
   IR3 acc = {0, 0, 0};
   for (size_t i = 0; i < N; i++) acc +=
-      m_ratio_[i]*field_set_[i]->partial_t_contravariant(
+      m_ratio_[i]*t_ratio_[i]*field_set_[i]->partial_t_contravariant(
           position, t_ratio_[i]*time);
   return acc;
 }

--- a/gyronimo/fields/linear_combo_c1.hh
+++ b/gyronimo/fields/linear_combo_c1.hh
@@ -26,6 +26,14 @@
 namespace gyronimo {
 
 //! Linear combination of `N` differentiable IR3 fields (*shared* coordinates).
+/*!
+    Combines a collection of `IR3field_c1` objects into a single differentiable
+    IR3 field. The resulting object has its magnitude normalised to `m_factor`
+    and its time normalised to `t_factor`. Therefore, the weighting factor
+    corresponding to the k-th field `field_set_[k]` is
+    `field_set_[k]->m_factor()/m_factor`. Combinations of fields with different
+    time normalisations are supported.
+*/
 template<size_t N>
 class linear_combo_c1 : public IR3field_c1 {
  public:

--- a/gyronimo/metrics/metric_covariant.cc
+++ b/gyronimo/metrics/metric_covariant.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,18 +26,20 @@ namespace gyronimo {
 //! General-purpose implementation of the Jacobian.
 double metric_covariant::jacobian(const IR3& r) const {
   SM3 g = (*this)(r);
-  double J = g[SM3::uu]*g[SM3::vv]*g[SM3::ww] + 2.0*g[SM3::uv]*g[SM3::uw]*g[SM3::vw] -
-             g[SM3::uv]*g[SM3::uv]*g[SM3::ww] - g[SM3::uu]*g[SM3::vw]*g[SM3::vw] -
-             g[SM3::uw]*g[SM3::uw]*g[SM3::vv];
-  double signJ = (J < 0) ? -1 : 1;
-  return  signJ * std::sqrt( signJ * J);
+  double det_g = g[SM3::uu]*g[SM3::vv]*g[SM3::ww] +
+      2.0*g[SM3::uv]*g[SM3::uw]*g[SM3::vw] - g[SM3::uv]*g[SM3::uv]*g[SM3::ww] -
+      g[SM3::uu]*g[SM3::vw]*g[SM3::vw] - g[SM3::uw]*g[SM3::uw]*g[SM3::vv];
+  return std::sqrt(det_g);
 }
 
 //! General-purpose implementation of the Jacobian gradient.
 IR3 metric_covariant::del_jacobian(const IR3& r) const {
   SM3 g = (*this)(r);
   dSM3 dg = this->del(r);
-  return {
+  double det_g = g[SM3::uu]*g[SM3::vv]*g[SM3::ww] +
+      2.0*g[SM3::uv]*g[SM3::uw]*g[SM3::vw] - g[SM3::uv]*g[SM3::uv]*g[SM3::ww] -
+      g[SM3::uu]*g[SM3::vw]*g[SM3::vw] - g[SM3::uw]*g[SM3::uw]*g[SM3::vv];
+  IR3 grad_det_g = {
       2.0*g[SM3::vw]*(
           g[SM3::uw]*dg[dSM3::uvu] +
           g[SM3::uv]*dg[dSM3::uwu] - g[SM3::uu]*dg[dSM3::vwu]) -
@@ -71,6 +73,7 @@ IR3 metric_covariant::del_jacobian(const IR3& r) const {
       g[SM3::uw]*g[SM3::uw]*dg[dSM3::vvw] +
       g[SM3::uu]*g[SM3::ww]*dg[dSM3::vvw] + 
       2.0*g[SM3::uv]*g[SM3::uw]*dg[dSM3::vww]};
+  return (0.5/std::sqrt(det_g))*grad_det_g;
 }
 
 //! General-purpose product of a covariant metric and a contravariant vector.

--- a/gyronimo/parsers/parser_castor.cc
+++ b/gyronimo/parsers/parser_castor.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -30,7 +30,8 @@ parser_castor::parser_castor(const std::string &filename) {
   input_stream.open(filename);
   if (input_stream.rdstate() != std::ios_base::goodbit)
     error(__func__, __FILE__, __LINE__, "cannot open input file.", 1);
-  input_stream >> n_psi_ >> n_harm_ >> n_tor_ >> w_imag_ >> w_real_;
+  input_stream >> n_psi_ >> n_harm_ >> n_tor_
+      >> eigenvalue_real_ >> eigenvalue_imag_;
   m_.resize(n_harm_); input_stream >> m_;
   s_.resize(n_psi_);
   this->initialise_variable_chunk(input_stream, v1_real_, v1_imag_);

--- a/gyronimo/parsers/parser_castor.hh
+++ b/gyronimo/parsers/parser_castor.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021 Paulo Rodrigues.
+// Copyright (C) 2021-2023 Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -45,8 +45,8 @@ class parser_castor {
   size_t n_psi() const {return n_psi_;};
   size_t n_harm() const {return n_harm_;};
   double n_tor() const {return n_tor_;};
-  double w_real() const {return w_real_;};
-  double w_imag() const {return w_imag_;};
+  double eigenvalue_real() const {return eigenvalue_real_;};
+  double eigenvalue_imag() const {return eigenvalue_imag_;};
   const narray_type& s() const {return s_;};
   const narray_type& m() const {return m_;};
   const narray_type& t_real() const {return t_real_;};
@@ -69,7 +69,7 @@ class parser_castor {
  private:
   double n_tor_;
   size_t n_psi_, n_harm_;
-  double w_real_, w_imag_;
+  double eigenvalue_real_, eigenvalue_imag_;
   narray_type s_, m_;
   narray_type rho_real_, rho_imag_, t_real_, t_imag_;
   narray_type v1_real_, v1_imag_, v2_real_, v2_imag_, v3_real_, v3_imag_;

--- a/gyronimo/parsers/parser_castor.hh
+++ b/gyronimo/parsers/parser_castor.hh
@@ -25,14 +25,13 @@
 
 namespace gyronimo {
 
-//! Parsing object for `CASTOR` ceig output files.
+//! Parsing object for `CASTOR` output files.
 /*!
-    Reads and parses a ceig output file produced by the MHD eigenvalue code
-    `CASTOR` [K. Kerner *et al*., J. Comput. Phys. **142**, 271 (1998)]. The
-    variables v1, v2, v3, a2, a3, t, and rho are provided as defined in the
-    published paper. As an exception, a1 is provided as the true first covariant
-    component of the potential vector, not the product -i*a1 stored in the ceig
-    file.
+    Reads and parses an output file produced by the MHD eigenvalue code `CASTOR`
+    [K. Kerner *et al*., J. Comput. Phys. **142**, 271 (1998)]. The variables
+    v1, v2, v3, a2, a3, t, and rho are provided as defined in the published
+    paper. As an exception, a1 is provided as the true first covariant component
+    of the vector potential, not the product -i*a1 stored in the ceig file.
 */
 
 class parser_castor {

--- a/misc/apps/heltrace.cc
+++ b/misc/apps/heltrace.cc
@@ -163,7 +163,8 @@ int main(int argc, char* argv[]) {
 
 // Prints output header:
   std::cout << "# heltrace, powered by ::gyronimo:: v"
-      << gyronimo::version_major << "." << gyronimo::version_minor << ".\n";
+      << gyronimo::version_major << "." << gyronimo::version_minor << "."
+      << gyronimo::version_patch << ".\n";
   std::cout << "# args: ";
   for(int i = 1; i < argc; i++) std::cout << argv[i] << " ";
   std::cout << std::endl;

--- a/misc/apps/vmectrace.cc
+++ b/misc/apps/vmectrace.cc
@@ -171,7 +171,8 @@ int main(int argc, char* argv[]) {
 
 // Prints output header:
   std::cout << "# vmectrace, powered by ::gyronimo:: v"
-      << gyronimo::version_major << "." << gyronimo::version_minor << ".\n";
+      << gyronimo::version_major << "." << gyronimo::version_minor << "."
+      << gyronimo::version_patch << ".\n";
   std::cout << "# args: ";
   for(int i = 1; i < argc; i++) std::cout << argv[i] << " ";
   std::cout << std::endl;


### PR DESCRIPTION
+ A, B and E fields have now an added constructor parameter to receive an external amplitude factor. This allows for consistency of the 3 fields of a single mode;
+ Bug fixed in the calculation of the E-field covariant components;
+ The E-field is now calculated independently from the A-field.