### PR TITLE
Contribute full-orbit support

### DIFF
--- a/gyronimo/core/contraction.cc
+++ b/gyronimo/core/contraction.cc
@@ -26,7 +26,7 @@ double inner_product(const IR3& A, const IR3& B) {
   return A[IR3::u]*B[IR3::u] + A[IR3::v]*B[IR3::v] + A[IR3::w]*B[IR3::w];
 }
 
-//! Cartesian cross product: A and B must be cartesian.
+//! Cartesian cross product (A and B are cartesian).
 IR3 cross_product(const IR3& A, const IR3& B) {
   return {
     A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v],
@@ -35,25 +35,16 @@ IR3 cross_product(const IR3& A, const IR3& B) {
   };
 }
 
-//! Covariant cross product: A and B must be contravariant.
+//! Covariant cross product (A and B are contravariant).
 template<>
 IR3 cross_product<covariant>(const IR3& A, const IR3& B, double jacobian) {
-  return {
-    (A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v]) * jacobian,
-    (A[IR3::w]*B[IR3::u] - A[IR3::u]*B[IR3::w]) * jacobian,
-    (A[IR3::u]*B[IR3::v] - A[IR3::v]*B[IR3::u]) * jacobian
-  };
+  return cross_product(A, B) * jacobian;
 }
 
-//! Contravariant cross product: A and B must be covariant.
+//! Contravariant cross product (A and B must be covariant).
 template<>
 IR3 cross_product<contravariant>(const IR3& A, const IR3& B, double jacobian) {
-  double ijacobian = 1.0/jacobian;
-  return {
-    (A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v]) * ijacobian,
-    (A[IR3::w]*B[IR3::u] - A[IR3::u]*B[IR3::w]) * ijacobian,
-    (A[IR3::u]*B[IR3::v] - A[IR3::v]*B[IR3::u]) * ijacobian
-  };
+  return cross_product(A, B) / jacobian;
 }
 
 //! Contraction of a symmetric 3x3 matrix and a IR^3 vector.

--- a/gyronimo/core/contraction.cc
+++ b/gyronimo/core/contraction.cc
@@ -26,12 +26,34 @@ double inner_product(const IR3& A, const IR3& B) {
   return A[IR3::u]*B[IR3::u] + A[IR3::v]*B[IR3::v] + A[IR3::w]*B[IR3::w];
 }
 
-//! Contravariant cross product: A and B must be covariant.
-IR3 cross_product(const IR3& A, const IR3& B, double jacobian) {
+//! Cartesian cross product: A and B must be cartesian.
+IR3 cross_product(const IR3& A, const IR3& B) {
   return {
-    (A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v]) / jacobian,
-    (A[IR3::w]*B[IR3::u] - A[IR3::u]*B[IR3::w]) / jacobian,
-    (A[IR3::u]*B[IR3::v] - A[IR3::v]*B[IR3::u]) / jacobian};
+    A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v],
+    A[IR3::w]*B[IR3::u] - A[IR3::u]*B[IR3::w],
+    A[IR3::u]*B[IR3::v] - A[IR3::v]*B[IR3::u]
+  };
+}
+
+//! Covariant cross product: A and B must be contravariant.
+template<>
+IR3 cross_product<covariant>(const IR3& A, const IR3& B, double jacobian) {
+  return {
+    (A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v]) * jacobian,
+    (A[IR3::w]*B[IR3::u] - A[IR3::u]*B[IR3::w]) * jacobian,
+    (A[IR3::u]*B[IR3::v] - A[IR3::v]*B[IR3::u]) * jacobian
+  };
+}
+
+//! Contravariant cross product: A and B must be covariant.
+template<>
+IR3 cross_product<contravariant>(const IR3& A, const IR3& B, double jacobian) {
+  double ijacobian = 1.0/jacobian;
+  return {
+    (A[IR3::v]*B[IR3::w] - A[IR3::w]*B[IR3::v]) * ijacobian,
+    (A[IR3::w]*B[IR3::u] - A[IR3::u]*B[IR3::w]) * ijacobian,
+    (A[IR3::u]*B[IR3::v] - A[IR3::v]*B[IR3::u]) * ijacobian
+  };
 }
 
 //! Contraction of a symmetric 3x3 matrix and a IR^3 vector.

--- a/gyronimo/core/contraction.hh
+++ b/gyronimo/core/contraction.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
+// Copyright (C) 2021-2023 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,18 +25,16 @@
 
 namespace gyronimo {
 
-//! Identifies which component (`covariant` or `contravariant`) of the vector is being considered.
-enum representation {covariant, contravariant};
-
-IR3 contraction(const SM3& g, const IR3& B);
-IR3 cross_product(const IR3& A, const IR3& B);
-template<representation>
-IR3 cross_product(const IR3& A, const IR3& B, double jacobian);
-double inner_product(const IR3& A, const IR3& B);
-
-//! Index to contract in a templated `contraction` of multi-indexed objects.
+enum variance_type {covariant, contravariant};
 enum contraction_index {first, second, third};
 
+IR3 contraction(const SM3& g, const IR3& B);
+double inner_product(const IR3& A, const IR3& B);
+IR3 cross_product(const IR3& A, const IR3& B);
+dSM3 contraction(const SM3& g, const dSM3& d, const SM3& h);
+
+template<variance_type>
+IR3 cross_product(const IR3& A, const IR3& B, double jacobian);
 template<contraction_index>
 IR3 contraction(const dIR3& dA, const IR3& B);
 template<contraction_index>
@@ -49,7 +47,6 @@ template<contraction_index, contraction_index>
 ddIR3 contraction(const dIR3& dA, const ddIR3& ddB);
 template<contraction_index, contraction_index>
 dIR3 contraction(const SM3& g, const dIR3& dB);
-dSM3 contraction(const SM3& g, const dSM3& d, const SM3& h);
 
 } // end namespace gyronimo.
 

--- a/gyronimo/core/contraction.hh
+++ b/gyronimo/core/contraction.hh
@@ -25,7 +25,12 @@
 
 namespace gyronimo {
 
+//! Identifies which component (`covariant` or `contravariant`) of the vector is being considered.
+enum representation {covariant, contravariant};
+
 IR3 contraction(const SM3& g, const IR3& B);
+IR3 cross_product(const IR3& A, const IR3& B);
+template<representation>
 IR3 cross_product(const IR3& A, const IR3& B, double jacobian);
 double inner_product(const IR3& A, const IR3& B);
 

--- a/gyronimo/dynamics/boris_push.cc
+++ b/gyronimo/dynamics/boris_push.cc
@@ -1,0 +1,57 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @boris_push.cc, this file is part of ::gyronimo::
+
+#include <cmath>
+#include <gyronimo/dynamics/boris_push.hh>
+#include <gyronimo/core/contraction.hh>
+
+namespace gyronimo {
+
+IR3 boris_push(const IR3& v_old, const double& Oref, 
+		const double& Bmag, const IR3& Bversor, const double& dt) {
+
+	// step 1
+	double T = std::tan(0.5 * Oref * dt * Bmag);
+	double S = 2 * T / (1 + T*T);
+	IR3 v_prime = v_old + T * cross_product(v_old, Bversor);
+	IR3 v_new   = v_old + S * cross_product(v_prime, Bversor);
+
+	return v_new;
+}
+
+IR3 boris_push(const IR3& v_old, const double& Oref, const IR3& Efield, 
+		const double& Bmag, const IR3& Bversor, const double& dt) {
+
+	// step 1
+	IR3 half_E_impulse = (0.5 * Oref * dt) * Efield;
+	IR3 v_minus = v_old + half_E_impulse;
+
+	// step 2
+	double T = std::tan(0.5 * Oref * dt * Bmag);
+	double S = 2 * T / (1 + T*T);
+	IR3 v_prime = v_minus + T * cross_product(v_minus, Bversor);
+	IR3 v_plus  = v_minus + S * cross_product(v_prime, Bversor);
+
+	// step 3
+	IR3 v_new = v_plus + half_E_impulse;
+
+	return v_new;
+}
+
+} // end namespace gyronimo

--- a/gyronimo/dynamics/boris_push.cc
+++ b/gyronimo/dynamics/boris_push.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Manuel Assunção.
+// Copyright (C) 2022-2023 Manuel Assunção and Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,34 +25,20 @@
 namespace gyronimo {
 
 IR3 boris_push(
-    const IR3& v_old, const double& Oref, const double& Bmag,
-    const IR3& Bversor, const double& dt) {
-  // step 1
-  double T = std::tan(0.5 * Oref * dt * Bmag);
-  double S = 2 * T / (1 + T * T);
-  IR3 v_prime = v_old + T * cross_product(v_old, Bversor);
-  IR3 v_new = v_old + S * cross_product(v_prime, Bversor);
-
-  return v_new;
+    const IR3& velocity, const double& tildeOref, const double& B, const IR3& b,
+    const double& dt) {
+  double T = std::tan(0.5 * tildeOref * dt * B), S = 2 * T / (1 + T * T);
+  IR3 v_prime = velocity + T * cross_product(velocity, b);
+  return velocity + S * cross_product(v_prime, b);
 }
 
 IR3 boris_push(
-    const IR3& v_old, const double& Oref, const IR3& Efield, const double& Bmag,
-    const IR3& Bversor, const double& dt) {
-  // step 1
-  IR3 half_E_impulse = (0.5 * Oref * dt) * Efield;
-  IR3 v_minus = v_old + half_E_impulse;
-
-  // step 2
-  double T = std::tan(0.5 * Oref * dt * Bmag);
-  double S = 2 * T / (1 + T * T);
-  IR3 v_prime = v_minus + T * cross_product(v_minus, Bversor);
-  IR3 v_plus = v_minus + S * cross_product(v_prime, Bversor);
-
-  // step 3
-  IR3 v_new = v_plus + half_E_impulse;
-
-  return v_new;
+    const IR3& velocity, const double& tildeOref, const double& tildeEref,
+    const IR3& E, const double& B, const IR3& b, const double& dt) {
+  IR3 half_E_impulse = (0.5 * tildeEref * dt) * E;
+  IR3 v_minus = velocity + half_E_impulse;
+  IR3 v_plus = boris_push(v_minus, tildeOref, B, b, dt);
+  return v_plus + half_E_impulse;
 }
 
 }  // end namespace gyronimo

--- a/gyronimo/dynamics/boris_push.cc
+++ b/gyronimo/dynamics/boris_push.cc
@@ -17,41 +17,42 @@
 
 // @boris_push.cc, this file is part of ::gyronimo::
 
-#include <cmath>
-#include <gyronimo/dynamics/boris_push.hh>
 #include <gyronimo/core/contraction.hh>
+#include <gyronimo/dynamics/boris_push.hh>
+
+#include <cmath>
 
 namespace gyronimo {
 
-IR3 boris_push(const IR3& v_old, const double& Oref, 
-		const double& Bmag, const IR3& Bversor, const double& dt) {
+IR3 boris_push(
+    const IR3& v_old, const double& Oref, const double& Bmag,
+    const IR3& Bversor, const double& dt) {
+  // step 1
+  double T = std::tan(0.5 * Oref * dt * Bmag);
+  double S = 2 * T / (1 + T * T);
+  IR3 v_prime = v_old + T * cross_product(v_old, Bversor);
+  IR3 v_new = v_old + S * cross_product(v_prime, Bversor);
 
-	// step 1
-	double T = std::tan(0.5 * Oref * dt * Bmag);
-	double S = 2 * T / (1 + T*T);
-	IR3 v_prime = v_old + T * cross_product(v_old, Bversor);
-	IR3 v_new   = v_old + S * cross_product(v_prime, Bversor);
-
-	return v_new;
+  return v_new;
 }
 
-IR3 boris_push(const IR3& v_old, const double& Oref, const IR3& Efield, 
-		const double& Bmag, const IR3& Bversor, const double& dt) {
+IR3 boris_push(
+    const IR3& v_old, const double& Oref, const IR3& Efield, const double& Bmag,
+    const IR3& Bversor, const double& dt) {
+  // step 1
+  IR3 half_E_impulse = (0.5 * Oref * dt) * Efield;
+  IR3 v_minus = v_old + half_E_impulse;
 
-	// step 1
-	IR3 half_E_impulse = (0.5 * Oref * dt) * Efield;
-	IR3 v_minus = v_old + half_E_impulse;
+  // step 2
+  double T = std::tan(0.5 * Oref * dt * Bmag);
+  double S = 2 * T / (1 + T * T);
+  IR3 v_prime = v_minus + T * cross_product(v_minus, Bversor);
+  IR3 v_plus = v_minus + S * cross_product(v_prime, Bversor);
 
-	// step 2
-	double T = std::tan(0.5 * Oref * dt * Bmag);
-	double S = 2 * T / (1 + T*T);
-	IR3 v_prime = v_minus + T * cross_product(v_minus, Bversor);
-	IR3 v_plus  = v_minus + S * cross_product(v_prime, Bversor);
+  // step 3
+  IR3 v_new = v_plus + half_E_impulse;
 
-	// step 3
-	IR3 v_new = v_plus + half_E_impulse;
-
-	return v_new;
+  return v_new;
 }
 
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/dynamics/boris_push.hh
+++ b/gyronimo/dynamics/boris_push.hh
@@ -26,57 +26,63 @@ namespace gyronimo {
 
 //! Gyronimo implementation of the Cartesian Boris push.
 /*!
-	This class implements a single step in the Boris push [C. K. Birdsall and 
-	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
-	defined only for cartesian coordinates.
-	This method assumes the electric field is zero.
-	The boris push refers to a particular way of discretizing the equation 
-	of motion for the velocity, given by:
-	@f$
-		\frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
-				\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau} 
-			= \Omega_{ref} \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
-				+\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2} 
-				\times \tilde{\textbf{B}}(\tau)
+        This class implements a single step in the Boris push [C. K. Birdsall
+   and A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
+        defined only for cartesian coordinates.
+        This method assumes the electric field is zero.
+        The boris push refers to a particular way of discretizing the equation
+        of motion for the velocity, given by:
+        @f$
+                \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
+                                \tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau}
+                        = \Omega_{ref}
+   \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
+                                +\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2}
+                                \times \tilde{\textbf{B}}(\tau)
     @f$
-	The following variables are adimensional: the time is normalized to `Tref` 
-	with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref` with 
-	@f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$ and the magnetic field 
-	to `Bref` with @f$ \tilde{\textbf{B}} = \textbf{B}/B_{ref} @f$.
-	In this normalization, the reference frequency factor is given by
-	@f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$.
+        The following variables are adimensional: the time is normalized to
+   `Tref` with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref`
+   with
+        @f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$ and the magnetic field
+        to `Bref` with @f$ \tilde{\textbf{B}} = \textbf{B}/B_{ref} @f$.
+        In this normalization, the reference frequency factor is given by
+        @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$.
 */
-IR3 boris_push(const IR3& v_old, const double& Oref, 
-		const double& Bmag, const IR3& Bversor, const double& dt);
+IR3 boris_push(
+    const IR3& v_old, const double& Oref, const double& Bmag,
+    const IR3& Bversor, const double& dt);
 
 //! Gyronimo implementation of the Cartesian Boris push.
 /*!
-	This class implements a single step in the Boris push [C. K. Birdsall and 
-	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
-	defined only for cartesian coordinates.
-	The boris push refers to a particular way of discretizing the equation 
-	of motion for the velocity, given by:
-	@f$
-		\frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
-				\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau} 
-			= \Omega_{ref} \left( \tilde{\textbf{E}}(\tau) + 
-				\frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
-				+\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2} 
-				\times \tilde{\textbf{B}}(\tau) \right)
+        This class implements a single step in the Boris push [C. K. Birdsall
+   and A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
+        defined only for cartesian coordinates.
+        The boris push refers to a particular way of discretizing the equation
+        of motion for the velocity, given by:
+        @f$
+                \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
+                                \tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau}
+                        = \Omega_{ref} \left( \tilde{\textbf{E}}(\tau) +
+                                \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
+                                +\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2}
+                                \times \tilde{\textbf{B}}(\tau) \right)
     @f$
-	The following variables are adimensional: the time is normalized to `Tref` 
-	with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref` with 
-	@f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$, the electric field to 
-	`Eref` with @f$ \tilde{\textbf{E}} = \textbf{E}/E_{ref} @f$ and the 
-	magnetic field to `Bref` with @f$ \tilde{\textbf{B}} = \textbf{B}/B_{ref} @f$.
-	In this normalization, the reference frequency factor is given by
-	@f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$, and the 
-	electric and magnetic fields are assumed to respect Faraday's law, with
-	@f$ V_{ref} = E_{ref} / B_{ref} @f$.
+        The following variables are adimensional: the time is normalized to
+   `Tref` with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref`
+   with
+        @f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$, the electric field to
+        `Eref` with @f$ \tilde{\textbf{E}} = \textbf{E}/E_{ref} @f$ and the
+        magnetic field to `Bref` with @f$ \tilde{\textbf{B}} =
+   \textbf{B}/B_{ref} @f$. In this normalization, the reference frequency factor
+   is given by
+        @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$, and the
+        electric and magnetic fields are assumed to respect Faraday's law, with
+        @f$ V_{ref} = E_{ref} / B_{ref} @f$.
 */
-IR3 boris_push(const IR3& v_old, const double& Oref, const IR3& Efield, 
-		const double& Bmag, const IR3& Bversor, const double& dt);
+IR3 boris_push(
+    const IR3& v_old, const double& Oref, const IR3& Efield, const double& Bmag,
+    const IR3& Bversor, const double& dt);
 
-} // end namespace gyronimo
+}  // end namespace gyronimo
 
-#endif // GYRONIMO_BORIS_PUSH
+#endif  // GYRONIMO_BORIS_PUSH

--- a/gyronimo/dynamics/boris_push.hh
+++ b/gyronimo/dynamics/boris_push.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Manuel Assunção.
+// Copyright (C) 2022-2023 Manuel Assunção and Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -24,64 +24,15 @@
 
 namespace gyronimo {
 
-//! Gyronimo implementation of the Cartesian Boris push.
-/*!
-        This class implements a single step in the Boris push [C. K. Birdsall
-   and A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
-        defined only for cartesian coordinates.
-        This method assumes the electric field is zero.
-        The boris push refers to a particular way of discretizing the equation
-        of motion for the velocity, given by:
-        @f$
-                \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
-                                \tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau}
-                        = \Omega_{ref}
-   \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
-                                +\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2}
-                                \times \tilde{\textbf{B}}(\tau)
-    @f$
-        The following variables are adimensional: the time is normalized to
-   `Tref` with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref`
-   with
-        @f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$ and the magnetic field
-        to `Bref` with @f$ \tilde{\textbf{B}} = \textbf{B}/B_{ref} @f$.
-        In this normalization, the reference frequency factor is given by
-        @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$.
-*/
+//! Boris cartesian-velocity pusher (magnetic field only).
 IR3 boris_push(
-    const IR3& v_old, const double& Oref, const double& Bmag,
-    const IR3& Bversor, const double& dt);
+    const IR3& velocity, const double& tildeOref, const double& B, const IR3& b,
+    const double& dt);
 
-//! Gyronimo implementation of the Cartesian Boris push.
-/*!
-        This class implements a single step in the Boris push [C. K. Birdsall
-   and A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
-        defined only for cartesian coordinates.
-        The boris push refers to a particular way of discretizing the equation
-        of motion for the velocity, given by:
-        @f$
-                \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
-                                \tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau}
-                        = \Omega_{ref} \left( \tilde{\textbf{E}}(\tau) +
-                                \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
-                                +\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2}
-                                \times \tilde{\textbf{B}}(\tau) \right)
-    @f$
-        The following variables are adimensional: the time is normalized to
-   `Tref` with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref`
-   with
-        @f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$, the electric field to
-        `Eref` with @f$ \tilde{\textbf{E}} = \textbf{E}/E_{ref} @f$ and the
-        magnetic field to `Bref` with @f$ \tilde{\textbf{B}} =
-   \textbf{B}/B_{ref} @f$. In this normalization, the reference frequency factor
-   is given by
-        @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$, and the
-        electric and magnetic fields are assumed to respect Faraday's law, with
-        @f$ V_{ref} = E_{ref} / B_{ref} @f$.
-*/
+//! Boris velocity pusher (electric and magnetic fields).
 IR3 boris_push(
-    const IR3& v_old, const double& Oref, const IR3& Efield, const double& Bmag,
-    const IR3& Bversor, const double& dt);
+    const IR3& velocity, const double& tildeOref, const double& tildeEref,
+    const IR3& E, const double& B, const IR3& b, const double& dt);
 
 }  // end namespace gyronimo
 

--- a/gyronimo/dynamics/boris_push.hh
+++ b/gyronimo/dynamics/boris_push.hh
@@ -1,0 +1,82 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @boris_push.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_BORIS_PUSH
+#define GYRONIMO_BORIS_PUSH
+
+#include <gyronimo/core/IR3algebra.hh>
+
+namespace gyronimo {
+
+//! Gyronimo implementation of the Cartesian Boris push.
+/*!
+	This class implements a single step in the Boris push [C. K. Birdsall and 
+	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
+	defined only for cartesian coordinates.
+	This method assumes the electric field is zero.
+	The boris push refers to a particular way of discretizing the equation 
+	of motion for the velocity, given by:
+	@f$
+		\frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
+				\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau} 
+			= \Omega_{ref} \frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
+				+\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2} 
+				\times \tilde{\textbf{B}}(\tau)
+    @f$
+	The following variables are adimensional: the time is normalized to `Tref` 
+	with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref` with 
+	@f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$ and the magnetic field 
+	to `Bref` with @f$ \tilde{\textbf{B}} = \textbf{B}/B_{ref} @f$.
+	In this normalization, the reference frequency factor is given by
+	@f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$.
+*/
+IR3 boris_push(const IR3& v_old, const double& Oref, 
+		const double& Bmag, const IR3& Bversor, const double& dt);
+
+//! Gyronimo implementation of the Cartesian Boris push.
+/*!
+	This class implements a single step in the Boris push [C. K. Birdsall and 
+	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
+	defined only for cartesian coordinates.
+	The boris push refers to a particular way of discretizing the equation 
+	of motion for the velocity, given by:
+	@f$
+		\frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)-
+				\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{\Delta\tau} 
+			= \Omega_{ref} \left( \tilde{\textbf{E}}(\tau) + 
+				\frac{\tilde{\textbf{v}}(\tau+\Delta\tau/2)
+				+\tilde{\textbf{v}}(\tau-\Delta\tau/2)}{2} 
+				\times \tilde{\textbf{B}}(\tau) \right)
+    @f$
+	The following variables are adimensional: the time is normalized to `Tref` 
+	with @f$ t=T_{ref}\,\tau @f$, the velocity to `Vref`=`Lref`/`Tref` with 
+	@f$ \textbf{v}=V_{ref}\,\tilde{\textbf{v}} @f$, the electric field to 
+	`Eref` with @f$ \tilde{\textbf{E}} = \textbf{E}/E_{ref} @f$ and the 
+	magnetic field to `Bref` with @f$ \tilde{\textbf{B}} = \textbf{B}/B_{ref} @f$.
+	In this normalization, the reference frequency factor is given by
+	@f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$, and the 
+	electric and magnetic fields are assumed to respect Faraday's law, with
+	@f$ V_{ref} = E_{ref} / B_{ref} @f$.
+*/
+IR3 boris_push(const IR3& v_old, const double& Oref, const IR3& Efield, 
+		const double& Bmag, const IR3& Bversor, const double& dt);
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_BORIS_PUSH

--- a/gyronimo/dynamics/cartesian_boris.cc
+++ b/gyronimo/dynamics/cartesian_boris.cc
@@ -17,155 +17,162 @@
 
 // @cartesian_boris.cc, this file is part of ::gyronimo::
 
-#include <gyronimo/dynamics/cartesian_boris.hh>
 #include <gyronimo/core/codata.hh>
 #include <gyronimo/core/error.hh>
-#include <gyronimo/metrics/metric_cartesian.hh>
 #include <gyronimo/dynamics/boris_push.hh>
-
+#include <gyronimo/dynamics/cartesian_boris.hh>
 #include <gyronimo/dynamics/lorentz.hh>
 #include <gyronimo/dynamics/odeint_adapter.hh>
+#include <gyronimo/metrics/metric_cartesian.hh>
+
 #include <boost/numeric/odeint.hpp>
 
 namespace gyronimo {
 
 /*!
-	Class constructor.
-	Takes a reference length `Lref`, a reference velocity `Vref`, 
-	the charge-over-mass ratio `qom`, an electric field `Efield`
-	and a magnetic field `Bfield`. The field `Bfield`
-	cannot be `nullptr`.
+        Class constructor.
+        Takes a reference length `Lref`, a reference velocity `Vref`,
+        the charge-over-mass ratio `qom`, an electric field `Efield`
+        and a magnetic field `Bfield`. The field `Bfield`
+        cannot be `nullptr`.
 */
-cartesian_boris::cartesian_boris(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield)
-		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), qom_(qom),
-		Oref_(Bfield ? qom * codata::e / 
-			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
-		electric_field_(Efield), magnetic_field_(Bfield),
-		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
-		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
-		metric_(Bfield ? dynamic_cast<const metric_cartesian*>(Bfield->metric()) : nullptr),
-		my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
+cartesian_boris::cartesian_boris(
+    const double& Lref, const double& Vref, const double& qom,
+    const IR3field* Efield, const IR3field* Bfield)
+    : Lref_(Lref), Vref_(Vref), Tref_(Lref / Vref), qom_(qom),
+      Oref_(
+          Bfield
+              ? qom * codata::e / codata::m_proton * Bfield->m_factor() * Tref_
+              : 1.0),
+      electric_field_(Efield), magnetic_field_(Bfield),
+      iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+      iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+      metric_(
+          Bfield ? dynamic_cast<const metric_cartesian*>(Bfield->metric())
+                 : nullptr),
+      my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
+  // test if fields exist
+  // if(!Efield) error(__func__, __FILE__, __LINE__,
+  // 							" Efield cannot be nullptr.",
+  // 1);
+  if (!Bfield)
+    error(__func__, __FILE__, __LINE__, " Bfield cannot be nullptr.", 1);
 
-	// test if fields exist
-	// if(!Efield) error(__func__, __FILE__, __LINE__, 
-	// 							" Efield cannot be nullptr.", 1);
-	if(!Bfield) error(__func__, __FILE__, __LINE__, 
-								" Bfield cannot be nullptr.", 1);
+  // test if fields are cartesian
+  if (!metric_)
+    error(
+        __func__, __FILE__, __LINE__,
+        " Bfield must be in cartesian coordinates.", 1);
+  if (Efield) {
+    const metric_covariant* Emetric = Efield->metric();
+    if (Emetric != metric_)
+      error(
+          __func__, __FILE__, __LINE__,
+          " Efield must be in cartesian coordinates.", 1);
+  }
 
-	// test if fields are cartesian
-	if(!metric_)
-		error(__func__, __FILE__, __LINE__, 
-			" Bfield must be in cartesian coordinates.", 1);
-	if(Efield) {
-		const metric_covariant *Emetric = Efield->metric();
-		if(Emetric != metric_)
-			error(__func__, __FILE__, __LINE__, 
-				" Efield must be in cartesian coordinates.", 1);
-	}
-
-	// test if normalization factors are consistent
-	if(Efield) {
-		double E_m_factor = Efield->m_factor();
-		double B_m_factor = Bfield->m_factor();
-		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
-			error(__func__, __FILE__, __LINE__, 
-				" inconsistent Efield and Bfield.", 1);
-	}
+  // test if normalization factors are consistent
+  if (Efield) {
+    double E_m_factor = Efield->m_factor();
+    double B_m_factor = Bfield->m_factor();
+    if (std::abs(1.0 - E_m_factor / (Vref_ * B_m_factor)) > 1.0e-14)
+      error(
+          __func__, __FILE__, __LINE__, " inconsistent Efield and Bfield.", 1);
+  }
 }
 
 //! Performs a time step `dt` update to the state `in` and returns the result.
 cartesian_boris::state cartesian_boris::do_step(
-		const cartesian_boris::state &in, const double &time, const double &dt) const {
-	
-	// extract position and velocity from state
-	IR3 x_old = {in[0], in[1], in[2]};
-	IR3 v_old = {in[3], in[4], in[5]};
+    const cartesian_boris::state& in, const double& time,
+    const double& dt) const {
+  // extract position and velocity from state
+  IR3 x_old = {in[0], in[1], in[2]};
+  IR3 v_old = {in[3], in[4], in[5]};
 
-	// calculate fields
-	IR3 Efield = {0.0, 0.0, 0.0};
-	if(electric_field_) {
-		double Etime = time * iEfield_time_factor_;
-		Efield = electric_field_->contravariant(x_old, Etime);
-	}
-	double Btime = time * iBfield_time_factor_;
-	double Bmag = magnetic_field_->magnitude(x_old, Btime);
-	IR3 Bversor = magnetic_field_->contravariant_versor(x_old, Btime);
+  // calculate fields
+  IR3 Efield = {0.0, 0.0, 0.0};
+  if (electric_field_) {
+    double Etime = time * iEfield_time_factor_;
+    Efield = electric_field_->contravariant(x_old, Etime);
+  }
+  double Btime = time * iBfield_time_factor_;
+  double Bmag = magnetic_field_->magnitude(x_old, Btime);
+  IR3 Bversor = magnetic_field_->contravariant_versor(x_old, Btime);
 
-	// perform cartesian_boris step
-	IR3 v_new = electric_field_ ? 
-		boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt) :
-		boris_push(v_old, Oref_, Bmag, Bversor, dt);
-	IR3 x_new = x_old + (Lref_*dt) * v_new;
+  // perform cartesian_boris step
+  IR3 v_new = electric_field_
+      ? boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt)
+      : boris_push(v_old, Oref_, Bmag, Bversor, dt);
+  IR3 x_new = x_old + (Lref_ * dt) * v_new;
 
-	return {x_new[IR3::u], x_new[IR3::v], x_new[IR3::w],
-			v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+  return {x_new[IR3::u], x_new[IR3::v], x_new[IR3::w],
+          v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
 }
 
 //! Returns the `cartesian_boris::state` state from a point in SI phase-space.
-cartesian_boris::state cartesian_boris::generate_state(const IR3 &pos, const IR3 &vel) const {
-	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
-			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+cartesian_boris::state cartesian_boris::generate_state(
+    const IR3& pos, const IR3& vel) const {
+  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+          vel[IR3::u], vel[IR3::v], vel[IR3::w]};
 }
 
 //! Returns the vector position of the state in SI units.
-IR3 cartesian_boris::get_position(const state &s) const {
-	return {s[0], s[1], s[2]};
+IR3 cartesian_boris::get_position(const state& s) const {
+  return {s[0], s[1], s[2]};
 }
 
 //! Returns the vector velocity of the state in SI units.
-IR3 cartesian_boris::get_velocity(const state &s) const {
-	return {s[3], s[4], s[5]};
+IR3 cartesian_boris::get_velocity(const state& s) const {
+  return {s[3], s[4], s[5]};
 }
 
 //! Returns the kinetic energy of the state, normalized to `Uref`.
-double cartesian_boris::energy_kinetic(const state &s) const {
-	return s[3]*s[3]+s[4]*s[4]+s[5]*s[5];
+double cartesian_boris::energy_kinetic(const state& s) const {
+  return s[3] * s[3] + s[4] * s[4] + s[5] * s[5];
 }
 
 //! Returns the parallel energy of the state, normalized to `Uref`.
-double cartesian_boris::energy_parallel(const state &s, double &time) const {
-	IR3 x = {s[0], s[1], s[2]};
-	IR3 v = {s[3], s[4], s[5]};
-	double Btime = time * iBfield_time_factor_;
-	IR3 b = magnetic_field_->contravariant_versor(x, Btime);
-	double vpar = inner_product(v, b);
-	return vpar*vpar;
+double cartesian_boris::energy_parallel(const state& s, double& time) const {
+  IR3 x = {s[0], s[1], s[2]};
+  IR3 v = {s[3], s[4], s[5]};
+  double Btime = time * iBfield_time_factor_;
+  IR3 b = magnetic_field_->contravariant_versor(x, Btime);
+  double vpar = inner_product(v, b);
+  return vpar * vpar;
 }
 
 //! Returns the perpendicular energy of the state, normalized to `Uref`.
-double cartesian_boris::energy_perpendicular(const state &s, double &time) const {
-	IR3 x = {s[0], s[1], s[2]};
-	IR3 v = {s[3], s[4], s[5]};
-	double Btime = time * iBfield_time_factor_;
-	IR3 b = magnetic_field_->contravariant_versor(x, Btime);
-	IR3 vperp = cross_product(v, b);
-	return inner_product(vperp, vperp);
+double cartesian_boris::energy_perpendicular(
+    const state& s, double& time) const {
+  IR3 x = {s[0], s[1], s[2]};
+  IR3 v = {s[3], s[4], s[5]};
+  double Btime = time * iBfield_time_factor_;
+  IR3 b = magnetic_field_->contravariant_versor(x, Btime);
+  IR3 vperp = cross_product(v, b);
+  return inner_product(vperp, vperp);
 }
 
 cartesian_boris::state cartesian_boris::generate_initial_state(
-		const IR3 &pos, const IR3 &vel, const double &time, const double &dt) const {
+    const IR3& pos, const IR3& vel, const double& time,
+    const double& dt) const {
+  // state s0 = {
+  //     pos[IR3::u], pos[IR3::v], pos[IR3::w],
+  //     vel[IR3::u], vel[IR3::v], vel[IR3::w]
+  // };
+  // state s1 = do_step(s0, time, -0.5*dt);
 
-    // state s0 = {
-    //     pos[IR3::u], pos[IR3::v], pos[IR3::w], 
-    //     vel[IR3::u], vel[IR3::v], vel[IR3::w]
-    // };
-	// state s1 = do_step(s0, time, -0.5*dt);
+  // return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
 
-	// return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
-    
-    lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
-    odeint_adapter<gyronimo::lorentz> sys(&lo);
-    boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
-	lorentz::state inout = {
-		pos[IR3::u], pos[IR3::v], pos[IR3::w],
-		vel[IR3::u], vel[IR3::v], vel[IR3::w]
-	};
-	rk4.do_step(sys, inout, time, -0.5*dt);
-    IR3 vmh = {inout[3], inout[4], inout[5]};
+  lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
+  odeint_adapter<gyronimo::lorentz> sys(&lo);
+  boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
+  lorentz::state inout = {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+                          vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+  rk4.do_step(sys, inout, time, -0.5 * dt);
+  IR3 vmh = {inout[3], inout[4], inout[5]};
 
-	return {pos[IR3::u], pos[IR3::v], pos[IR3::w], 
-            vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
+  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+          vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
 }
 
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/dynamics/cartesian_boris.cc
+++ b/gyronimo/dynamics/cartesian_boris.cc
@@ -41,7 +41,7 @@ cartesian_boris::cartesian_boris(const double &Lref, const double &Vref,
 		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
 		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
 		metric_(Bfield ? dynamic_cast<const metric_cartesian*>(Bfield->metric()) : nullptr),
-		morph_(metric_ ? metric_->morph() : nullptr) {
+		my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
 
 	// test if fields exist
 	// if(!Efield) error(__func__, __FILE__, __LINE__, 
@@ -139,19 +139,13 @@ double cartesian_boris::energy_perpendicular(const state &s, double &time) const
 	return inner_product(vperp, vperp);
 }
 
-//! Creates the first `cartesian_boris::state` from a point in cartesian phase-space.
 cartesian_boris::state cartesian_boris::generate_initial_state(
-		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
-		const double &time, const double &dt) const {
+		const IR3 &pos, const IR3 &vel, const double &time, const double &dt) const {
 
-	state s0 = {
-		cartesian_position[IR3::u],
-		cartesian_position[IR3::v],
-		cartesian_position[IR3::w],
-		cartesian_velocity[IR3::u],
-		cartesian_velocity[IR3::v],
-		cartesian_velocity[IR3::w]
-	};
+    state s0 = {
+        pos[IR3::u], pos[IR3::v], pos[IR3::w], 
+        vel[IR3::u], vel[IR3::v], vel[IR3::w]
+    };
 	state s1 = do_step(s0, time, -0.5*dt);
 
 	return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};

--- a/gyronimo/dynamics/cartesian_boris.cc
+++ b/gyronimo/dynamics/cartesian_boris.cc
@@ -1,0 +1,160 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @cartesian_boris.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/dynamics/cartesian_boris.hh>
+#include <gyronimo/core/codata.hh>
+#include <gyronimo/core/error.hh>
+#include <gyronimo/metrics/metric_cartesian.hh>
+#include <gyronimo/dynamics/boris_push.hh>
+
+namespace gyronimo {
+
+/*!
+	Class constructor.
+	Takes a reference length `Lref`, a reference velocity `Vref`, 
+	the charge-over-mass ratio `qom`, an electric field `Efield`
+	and a magnetic field `Bfield`. The field `Bfield`
+	cannot be `nullptr`.
+*/
+cartesian_boris::cartesian_boris(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield)
+		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), qom_(qom),
+		Oref_(Bfield ? qom * codata::e / 
+			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
+		electric_field_(Efield), magnetic_field_(Bfield),
+		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+		metric_(Bfield ? dynamic_cast<const metric_cartesian*>(Bfield->metric()) : nullptr),
+		morph_(metric_ ? metric_->morph() : nullptr) {
+
+	// test if fields exist
+	// if(!Efield) error(__func__, __FILE__, __LINE__, 
+	// 							" Efield cannot be nullptr.", 1);
+	if(!Bfield) error(__func__, __FILE__, __LINE__, 
+								" Bfield cannot be nullptr.", 1);
+
+	// test if fields are cartesian
+	if(!metric_)
+		error(__func__, __FILE__, __LINE__, 
+			" Bfield must be in cartesian coordinates.", 1);
+	if(Efield) {
+		const metric_covariant *Emetric = Efield->metric();
+		if(Emetric != metric_)
+			error(__func__, __FILE__, __LINE__, 
+				" Efield must be in cartesian coordinates.", 1);
+	}
+
+	// test if normalization factors are consistent
+	if(Efield) {
+		double E_m_factor = Efield->m_factor();
+		double B_m_factor = Bfield->m_factor();
+		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
+			error(__func__, __FILE__, __LINE__, 
+				" inconsistent Efield and Bfield.", 1);
+	}
+}
+
+//! Performs a time step `dt` update to the state `in` and returns the result.
+cartesian_boris::state cartesian_boris::do_step(
+		const cartesian_boris::state &in, const double &time, const double &dt) const {
+	
+	// extract position and velocity from state
+	IR3 x_old = {in[0], in[1], in[2]};
+	IR3 v_old = {in[3], in[4], in[5]};
+
+	// calculate fields
+	IR3 Efield = {0.0, 0.0, 0.0};
+	if(electric_field_) {
+		double Etime = time * iEfield_time_factor_;
+		Efield = electric_field_->contravariant(x_old, Etime);
+	}
+	double Btime = time * iBfield_time_factor_;
+	double Bmag = magnetic_field_->magnitude(x_old, Btime);
+	IR3 Bversor = magnetic_field_->contravariant_versor(x_old, Btime);
+
+	// perform cartesian_boris step
+	IR3 v_new = electric_field_ ? 
+		boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt) :
+		boris_push(v_old, Oref_, Bmag, Bversor, dt);
+	IR3 x_new = x_old + (Lref_*dt) * v_new;
+
+	return {x_new[IR3::u], x_new[IR3::v], x_new[IR3::w],
+			v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+}
+
+//! Returns the `cartesian_boris::state` state from a point in SI phase-space.
+cartesian_boris::state cartesian_boris::generate_state(const IR3 &pos, const IR3 &vel) const {
+	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+}
+
+//! Returns the vector position of the state in SI units.
+IR3 cartesian_boris::get_position(const state &s) const {
+	return {s[0], s[1], s[2]};
+}
+
+//! Returns the vector velocity of the state in SI units.
+IR3 cartesian_boris::get_velocity(const state &s) const {
+	return {s[3], s[4], s[5]};
+}
+
+//! Returns the kinetic energy of the state, normalized to `Uref`.
+double cartesian_boris::energy_kinetic(const state &s) const {
+	return s[3]*s[3]+s[4]*s[4]+s[5]*s[5];
+}
+
+//! Returns the parallel energy of the state, normalized to `Uref`.
+double cartesian_boris::energy_parallel(const state &s, double &time) const {
+	IR3 x = {s[0], s[1], s[2]};
+	IR3 v = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 b = magnetic_field_->contravariant_versor(x, Btime);
+	double vpar = inner_product(v, b);
+	return vpar*vpar;
+}
+
+//! Returns the perpendicular energy of the state, normalized to `Uref`.
+double cartesian_boris::energy_perpendicular(const state &s, double &time) const {
+	IR3 x = {s[0], s[1], s[2]};
+	IR3 v = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 b = magnetic_field_->contravariant_versor(x, Btime);
+	IR3 vperp = cross_product(v, b);
+	return inner_product(vperp, vperp);
+}
+
+//! Creates the first `cartesian_boris::state` from a point in cartesian phase-space.
+cartesian_boris::state cartesian_boris::generate_initial_state(
+		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+		const double &time, const double &dt) const {
+
+	state s0 = {
+		cartesian_position[IR3::u],
+		cartesian_position[IR3::v],
+		cartesian_position[IR3::w],
+		cartesian_velocity[IR3::u],
+		cartesian_velocity[IR3::v],
+		cartesian_velocity[IR3::w]
+	};
+	state s1 = do_step(s0, time, -0.5*dt);
+
+	return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/dynamics/cartesian_boris.hh
+++ b/gyronimo/dynamics/cartesian_boris.hh
@@ -77,7 +77,7 @@ class cartesian_boris {
  private:
   const double Lref_, Vref_, Tref_, qom_, Oref_;
   const IR3field *electric_field_, *magnetic_field_;
-  const double iE_time_factor_, iB_time_factor_;
+  const double iE_time_factor_, iB_time_factor_, tildeEref_;
   const metric_connected* metric_;
   const morphism* my_morphism_;
 };

--- a/gyronimo/dynamics/cartesian_boris.hh
+++ b/gyronimo/dynamics/cartesian_boris.hh
@@ -27,60 +27,59 @@ namespace gyronimo {
 
 //! Gyronimo implementation for cartesian boris stepper class.
 /*!
-	This class implements the boris pusher [C. K. Birdsall and 
-	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
-	which is typically defined only for cartesian coordinates.
-	Indeed, this class constrains field representation to cartesian coordinates
-	by checking if field metrics are of type `metric_cartesian`.
-	To use the boris pusher in curvilinear coordinates, look at
-	`classical_boris` class.
+        This class implements the boris pusher [C. K. Birdsall and
+        A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
+        which is typically defined only for cartesian coordinates.
+        Indeed, this class constrains field representation to cartesian
+   coordinates by checking if field metrics are of type `metric_cartesian`. To
+   use the boris pusher in curvilinear coordinates, look at `classical_boris`
+   class.
 */
 class cartesian_boris {
-public:
-	using state = std::array<double,6>;
+ public:
+  using state = std::array<double, 6>;
 
-	cartesian_boris(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield);
-	~cartesian_boris() {};
+  cartesian_boris(
+      const double& Lref, const double& Vref, const double& qom,
+      const IR3field* Efield, const IR3field* Bfield);
+  ~cartesian_boris() {};
 
-	state do_step(const state &in, const double &time, const double &dt) const;
+  state do_step(const state& in, const double& time, const double& dt) const;
 
-	state generate_state(const IR3 &pos, const IR3 &vel) const;
-	IR3 get_position(const state &s) const;
-	IR3 get_velocity(const state &s) const;
+  state generate_state(const IR3& pos, const IR3& vel) const;
+  IR3 get_position(const state& s) const;
+  IR3 get_velocity(const state& s) const;
 
-	double energy_kinetic(const state &s) const;
-	double energy_parallel(const state &s, double &time) const;
-	double energy_perpendicular(const state &s, double &time) const;
+  double energy_kinetic(const state& s) const;
+  double energy_parallel(const state& s, double& time) const;
+  double energy_perpendicular(const state& s, double& time) const;
 
-	state generate_initial_state(const IR3 &pos, const IR3 &vel, 
-		const double &t, const double &dt) const;
+  state generate_initial_state(
+      const IR3& pos, const IR3& vel, const double& t, const double& dt) const;
 
-	const IR3field* electric_field() const {return electric_field_;};
-	const IR3field* magnetic_field() const {return magnetic_field_;};
-	const morphism_cartesian* my_morphism() const {return my_morphism_;};
+  const IR3field* electric_field() const { return electric_field_; };
+  const IR3field* magnetic_field() const { return magnetic_field_; };
+  const morphism_cartesian* my_morphism() const { return my_morphism_; };
 
-	//! Returns the reference length scale `Lref`.
-	double Lref() const {return Lref_;};
-	//! Returns the reference time scale `Tref`.
-	double Tref() const {return Tref_;};
-	//! Returns the reference velocity scale `Vref`.
-	double Vref() const {return Vref_;};
-	//! Returns the reference frequency scale `Oref`.
-	double Oref() const {return Oref_;};
-	//! Returns the charge-over-mass ratio.
-	double qom() const {return qom_;};
+  //! Returns the reference length scale `Lref`.
+  double Lref() const { return Lref_; };
+  //! Returns the reference time scale `Tref`.
+  double Tref() const { return Tref_; };
+  //! Returns the reference velocity scale `Vref`.
+  double Vref() const { return Vref_; };
+  //! Returns the reference frequency scale `Oref`.
+  double Oref() const { return Oref_; };
+  //! Returns the charge-over-mass ratio.
+  double qom() const { return qom_; };
+ private:
+  const double Lref_, Vref_, Tref_, qom_, Oref_;
+  const IR3field *electric_field_, *magnetic_field_;
+  const double iEfield_time_factor_, iBfield_time_factor_;
+  const metric_cartesian* metric_;
+  const morphism_cartesian* my_morphism_;
 
-private:
+};  // end class classical_boris
 
-	const double Lref_, Vref_, Tref_, qom_, Oref_;
-	const IR3field *electric_field_, *magnetic_field_;
-	const double iEfield_time_factor_, iBfield_time_factor_;
-	const metric_cartesian *metric_;
-	const morphism_cartesian *my_morphism_;
+}  // end namespace gyronimo
 
-}; // end class classical_boris
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_CARTESIAN_BORIS
+#endif  // GYRONIMO_CARTESIAN_BORIS

--- a/gyronimo/dynamics/cartesian_boris.hh
+++ b/gyronimo/dynamics/cartesian_boris.hh
@@ -1,0 +1,87 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @cartesian_boris.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_CARTESIAN_BORIS
+#define GYRONIMO_CARTESIAN_BORIS
+
+#include <gyronimo/fields/IR3field.hh>
+#include <gyronimo/metrics/metric_cartesian.hh>
+
+namespace gyronimo {
+
+//! Gyronimo implementation for cartesian boris stepper class.
+/*!
+	This class implements the boris pusher [C. K. Birdsall and 
+	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
+	which is typically defined only for cartesian coordinates.
+	Indeed, this class constrains field representation to cartesian coordinates
+	by checking if field metrics are of type `metric_cartesian`.
+	To use the boris pusher in curvilinear coordinates, look at
+	`classical_boris` class.
+*/
+class cartesian_boris {
+public:
+	using state = std::array<double,6>;
+
+	cartesian_boris(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield);
+	~cartesian_boris() {};
+
+	state do_step(const state &in, const double &time, const double &dt) const;
+
+	state generate_state(const IR3 &pos, const IR3 &vel) const;
+	IR3 get_position(const state &s) const;
+	IR3 get_velocity(const state &s) const;
+
+	double energy_kinetic(const state &s) const;
+	double energy_parallel(const state &s, double &time) const;
+	double energy_perpendicular(const state &s, double &time) const;
+
+	state generate_initial_state(
+		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+		const double &t, const double &dt) const;
+
+	const IR3field* electric_field() const {return electric_field_;};
+	const IR3field* magnetic_field() const {return magnetic_field_;};
+	const morphism_cartesian* morph() const {return morph_;};
+
+	//! Returns the reference length scale `Lref`.
+	double Lref() const {return Lref_;};
+	//! Returns the reference time scale `Tref`.
+	double Tref() const {return Tref_;};
+	//! Returns the reference velocity scale `Vref`.
+	double Vref() const {return Vref_;};
+	//! Returns the reference frequency scale `Oref`.
+	double Oref() const {return Oref_;};
+	//! Returns the charge-over-mass ratio.
+	double qom() const {return qom_;};
+
+private:
+
+	const double Lref_, Vref_, Tref_, qom_, Oref_;
+	const IR3field *electric_field_, *magnetic_field_;
+	const double iEfield_time_factor_, iBfield_time_factor_;
+	const metric_cartesian *metric_;
+	const morphism_cartesian *morph_;
+
+}; // end class classical_boris
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_CARTESIAN_BORIS

--- a/gyronimo/dynamics/cartesian_boris.hh
+++ b/gyronimo/dynamics/cartesian_boris.hh
@@ -53,13 +53,12 @@ public:
 	double energy_parallel(const state &s, double &time) const;
 	double energy_perpendicular(const state &s, double &time) const;
 
-	state generate_initial_state(
-		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+	state generate_initial_state(const IR3 &pos, const IR3 &vel, 
 		const double &t, const double &dt) const;
 
 	const IR3field* electric_field() const {return electric_field_;};
 	const IR3field* magnetic_field() const {return magnetic_field_;};
-	const morphism_cartesian* morph() const {return morph_;};
+	const morphism_cartesian* my_morphism() const {return my_morphism_;};
 
 	//! Returns the reference length scale `Lref`.
 	double Lref() const {return Lref_;};
@@ -78,7 +77,7 @@ private:
 	const IR3field *electric_field_, *magnetic_field_;
 	const double iEfield_time_factor_, iBfield_time_factor_;
 	const metric_cartesian *metric_;
-	const morphism_cartesian *morph_;
+	const morphism_cartesian *my_morphism_;
 
 }; // end class classical_boris
 

--- a/gyronimo/dynamics/classical_boris.cc
+++ b/gyronimo/dynamics/classical_boris.cc
@@ -40,6 +40,7 @@ classical_boris::classical_boris(
       electric_field_(E), magnetic_field_(B),
       iE_time_factor_(E ? Tref_ / E->t_factor() : 1),
       iB_time_factor_(B ? Tref_ / B->t_factor() : 1),
+      tildeEref_(E && B ? Oref_ * E->m_factor() / (B->m_factor() * Vref_) : 1),
       metric_(B ? dynamic_cast<const metric_connected*>(B->metric()) : nullptr),
       my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
   if (!B) error(__func__, __FILE__, __LINE__, "no magnetic field.", 1);
@@ -53,7 +54,6 @@ classical_boris::classical_boris(
 classical_boris::state classical_boris::do_step(
     const state& s, const double& time, const double& dt) const {
   double Btime = time * iB_time_factor_;
-  const double tildeEref = Oref_ * iB_time_factor_ / (iE_time_factor_ * Vref_);
 
   IR3 q = this->get_position(s), v = this->get_velocity(s);
   double B = magnetic_field_->magnitude(q, Btime);
@@ -65,7 +65,7 @@ classical_boris::state classical_boris::do_step(
       IR3 {0, 0, 0};
 
   IR3 updated_v = electric_field_ ?
-      boris_push(v, Oref_, tildeEref, E, B, b, dt) :
+      boris_push(v, Oref_, tildeEref_, E, B, b, dt) :
       boris_push(v, Oref_, B, b, dt);
   IR3 updated_q = my_morphism_->translation(q, (Lref_ * dt) * updated_v);
 

--- a/gyronimo/dynamics/classical_boris.cc
+++ b/gyronimo/dynamics/classical_boris.cc
@@ -17,174 +17,183 @@
 
 // @classical_boris.cc, this file is part of ::gyronimo::
 
-#include <gyronimo/dynamics/classical_boris.hh>
-#include <gyronimo/core/contraction.hh>
 #include <gyronimo/core/codata.hh>
+#include <gyronimo/core/contraction.hh>
 #include <gyronimo/core/error.hh>
 #include <gyronimo/dynamics/boris_push.hh>
-#include <cmath>
-
+#include <gyronimo/dynamics/classical_boris.hh>
 #include <gyronimo/dynamics/lorentz.hh>
 #include <gyronimo/dynamics/odeint_adapter.hh>
+
 #include <boost/numeric/odeint.hpp>
+
+#include <cmath>
 
 namespace gyronimo {
 
 /*!
-	Class constructor.
-	Takes a reference length `Lref`, a reference velocity `Vref`, 
-	the charge-over-mass ratio `qom`, an electric field `Efield`
-	and a magnetic field `Bfield`. The field `Bfield`
-	cannot be `nullptr`.
+        Class constructor.
+        Takes a reference length `Lref`, a reference velocity `Vref`,
+        the charge-over-mass ratio `qom`, an electric field `Efield`
+        and a magnetic field `Bfield`. The field `Bfield`
+        cannot be `nullptr`.
 */
-classical_boris::classical_boris(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield)
-		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), qom_(qom),
-		Oref_(Bfield ? qom * codata::e / 
-			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
-		electric_field_(Efield), magnetic_field_(Bfield),
-		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
-		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
-		metric_(Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric()) : nullptr),
-		my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
+classical_boris::classical_boris(
+    const double& Lref, const double& Vref, const double& qom,
+    const IR3field* Efield, const IR3field* Bfield)
+    : Lref_(Lref), Vref_(Vref), Tref_(Lref / Vref), qom_(qom),
+      Oref_(
+          Bfield
+              ? qom * codata::e / codata::m_proton * Bfield->m_factor() * Tref_
+              : 1.0),
+      electric_field_(Efield), magnetic_field_(Bfield),
+      iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+      iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+      metric_(
+          Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric())
+                 : nullptr),
+      my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
+  // test if fields exist
+  // if(!Efield) error(__func__, __FILE__, __LINE__,
+  // 	    " Efield cannot be nullptr.", 1);
+  if (!Bfield)
+    error(__func__, __FILE__, __LINE__, " Bfield cannot be nullptr.", 1);
 
-	// test if fields exist
-	// if(!Efield) error(__func__, __FILE__, __LINE__, 
-	// 	    " Efield cannot be nullptr.", 1);
-	if(!Bfield) error(__func__, __FILE__, __LINE__, 
-		    " Bfield cannot be nullptr.", 1);
+  // test if metrics are the same
+  if (Efield) {
+    const metric_covariant* Emetric = Efield->metric();
+    const metric_covariant* Bmetric = Bfield->metric();
+    if (Emetric != Bmetric)
+      error(
+          __func__, __FILE__, __LINE__,
+          " Efield and Bfield must be in the same coordinate representation.",
+          1);
+  }
 
-	// test if metrics are the same
-	if(Efield) {
-		const metric_covariant *Emetric = Efield->metric();
-		const metric_covariant *Bmetric = Bfield->metric();
-		if(Emetric != Bmetric) error(__func__, __FILE__, __LINE__, 
-			" Efield and Bfield must be in the same coordinate representation.", 1);
-	}
+  // ensure that the field metrics derive from metric_connected
+  if (!metric_)
+    error(
+        __func__, __FILE__, __LINE__,
+        " field metrics must derive from 'gyronimo::metric_connected'.", 1);
 
-	// ensure that the field metrics derive from metric_connected
-	if(!metric_) error(__func__, __FILE__, __LINE__, 
-		" field metrics must derive from 'gyronimo::metric_connected'.", 1);
-
-	// test if normalization factors are consistent
-	if(Efield) {
-		double E_m_factor = Efield->m_factor();
-		double B_m_factor = Bfield->m_factor();
-		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
-			error(__func__, __FILE__, __LINE__, 
-				" inconsistent Efield and Bfield normalization.", 1);
-	}
+  // test if normalization factors are consistent
+  if (Efield) {
+    double E_m_factor = Efield->m_factor();
+    double B_m_factor = Bfield->m_factor();
+    if (std::abs(1.0 - E_m_factor / (Vref_ * B_m_factor)) > 1.0e-14)
+      error(
+          __func__, __FILE__, __LINE__,
+          " inconsistent Efield and Bfield normalization.", 1);
+  }
 }
 
 //! Performs a time step `dt` update to the state `in` and returns the result.
 classical_boris::state classical_boris::do_step(
-		const state &in, const double &time, const double &dt) const {
-	
-	// extract position and velocity from state
-	IR3 q_old = {in[0], in[1], in[2]};
-	IR3 v_old = {in[3], in[4], in[5]};
-	dIR3 e_old = my_morphism_->del(q_old);
+    const state& in, const double& time, const double& dt) const {
+  // extract position and velocity from state
+  IR3 q_old = {in[0], in[1], in[2]};
+  IR3 v_old = {in[3], in[4], in[5]};
+  dIR3 e_old = my_morphism_->del(q_old);
 
-	// calculate fields
-	IR3 Efield = {0.0, 0.0, 0.0};
-	if(electric_field_) {
-		double Etime = time * iEfield_time_factor_;
-		IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
-		Efield = contraction<second>(e_old, E_contravariant);
-	}
-	double Btime = time * iBfield_time_factor_;
-	IR3 Bfield_contravariant = magnetic_field_->contravariant(q_old, Btime);
-	IR3 Bfield = contraction<second>(e_old, Bfield_contravariant);
-	double Bmag = std::sqrt(inner_product(Bfield, Bfield));
-    IR3 Bversor = Bfield / Bmag;
+  // calculate fields
+  IR3 Efield = {0.0, 0.0, 0.0};
+  if (electric_field_) {
+    double Etime = time * iEfield_time_factor_;
+    IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
+    Efield = contraction<second>(e_old, E_contravariant);
+  }
+  double Btime = time * iBfield_time_factor_;
+  IR3 Bfield_contravariant = magnetic_field_->contravariant(q_old, Btime);
+  IR3 Bfield = contraction<second>(e_old, Bfield_contravariant);
+  double Bmag = std::sqrt(inner_product(Bfield, Bfield));
+  IR3 Bversor = Bfield / Bmag;
 
-	// perform cartesian_boris step
-	IR3 v_new = electric_field_ ? 
-		boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt) :
-		boris_push(v_old, Oref_, Bmag, Bversor, dt);
-	// IR3 x_new = x_old + (Lref_*dt) * v_new;
+  // perform cartesian_boris step
+  IR3 v_new = electric_field_
+      ? boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt)
+      : boris_push(v_old, Oref_, Bmag, Bversor, dt);
+  // IR3 x_new = x_old + (Lref_*dt) * v_new;
 
-	// IR3 q_new = my_morphism_->inverse(x_new);
-	// IR3 u_new = my_morphism_->to_contravariant(v_new, q_new);
+  // IR3 q_new = my_morphism_->inverse(x_new);
+  // IR3 u_new = my_morphism_->to_contravariant(v_new, q_new);
 
-	IR3 q_new = my_morphism_->translation(q_old, (Lref_*dt) * v_new);
+  IR3 q_new = my_morphism_->translation(q_old, (Lref_ * dt) * v_new);
 
-	return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
-			v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+  return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
+          v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
 }
 
 //! Returns the `classical_boris::state` state from a point in SI phase-space.
-classical_boris::state classical_boris::generate_state(const IR3 &pos, const IR3 &vel) const {
-	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
-			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+classical_boris::state classical_boris::generate_state(
+    const IR3& pos, const IR3& vel) const {
+  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+          vel[IR3::u], vel[IR3::v], vel[IR3::w]};
 }
 
 //! Returns the vector position of the state in SI units.
-IR3 classical_boris::get_position(const state &s) const {
-	return {s[0], s[1], s[2]};
+IR3 classical_boris::get_position(const state& s) const {
+  return {s[0], s[1], s[2]};
 }
 
 //! Returns the vector velocity of the state in SI units.
-IR3 classical_boris::get_velocity(const state &s) const {
-	IR3 q = {s[0], s[1], s[2]};
-	IR3 v = {s[3], s[4], s[5]};
-	return my_morphism_->to_contravariant(v, q);
+IR3 classical_boris::get_velocity(const state& s) const {
+  IR3 q = {s[0], s[1], s[2]};
+  IR3 v = {s[3], s[4], s[5]};
+  return my_morphism_->to_contravariant(v, q);
 }
 
 //! Returns the kinetic energy of the state, normalized to `Uref`.
-double classical_boris::energy_kinetic(const state &s) const {
-	return (s[3]*s[3] + s[4]*s[4] + s[5]*s[5]);
+double classical_boris::energy_kinetic(const state& s) const {
+  return (s[3] * s[3] + s[4] * s[4] + s[5] * s[5]);
 }
 
 //! Returns the parallel energy of the state, normalized to `Uref`.
-double classical_boris::energy_parallel(const state &s, double &time) const {
-	IR3 q = {s[0], s[1], s[2]};
-	IR3 v = {s[3], s[4], s[5]};
-	double Btime = time * iBfield_time_factor_;
-	IR3 Bversor_con = magnetic_field_->contravariant_versor(q, Btime);
-	IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q);
-	double vpar = inner_product(v, Bversor);
-	return vpar*vpar;
+double classical_boris::energy_parallel(const state& s, double& time) const {
+  IR3 q = {s[0], s[1], s[2]};
+  IR3 v = {s[3], s[4], s[5]};
+  double Btime = time * iBfield_time_factor_;
+  IR3 Bversor_con = magnetic_field_->contravariant_versor(q, Btime);
+  IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q);
+  double vpar = inner_product(v, Bversor);
+  return vpar * vpar;
 }
 
 //! Returns the perpendicular energy of the state, normalized to `Uref`.
-double classical_boris::energy_perpendicular(const state &s, double &time) const {
-	IR3 q = {s[0], s[1], s[2]};
-	IR3 v = {s[3], s[4], s[5]};
-	double Btime = time * iBfield_time_factor_;
-	IR3 Bversor_con = magnetic_field_->contravariant_versor(q, Btime);
-	IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q);
-	IR3 vperp = cross_product(v, Bversor);
-	return inner_product(vperp, vperp);
+double classical_boris::energy_perpendicular(
+    const state& s, double& time) const {
+  IR3 q = {s[0], s[1], s[2]};
+  IR3 v = {s[3], s[4], s[5]};
+  double Btime = time * iBfield_time_factor_;
+  IR3 Bversor_con = magnetic_field_->contravariant_versor(q, Btime);
+  IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q);
+  IR3 vperp = cross_product(v, Bversor);
+  return inner_product(vperp, vperp);
 }
 
 classical_boris::state classical_boris::generate_initial_state(
-		const IR3 &pos, const IR3 &vel, 
-		const double &time, const double &dt) const {
+    const IR3& pos, const IR3& vel, const double& time,
+    const double& dt) const {
+  // state s0 = {
+  // 	pos[IR3::u], pos[IR3::v], pos[IR3::w],
+  // 	vel[IR3::u], vel[IR3::v], vel[IR3::w]
+  // };
+  // state s1 = do_step(s0, time, -0.5*dt);
 
-	// state s0 = {
-	// 	pos[IR3::u], pos[IR3::v], pos[IR3::w],
-	// 	vel[IR3::u], vel[IR3::v], vel[IR3::w]
-	// };
-	// state s1 = do_step(s0, time, -0.5*dt);
+  // return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
 
-	// return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
-    
-    lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
-    odeint_adapter<gyronimo::lorentz> sys(&lo);
-    boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
-    IR3 vel_con = my_morphism_->to_contravariant(vel, pos);
-	lorentz::state inout = {
-		pos[IR3::u], pos[IR3::v], pos[IR3::w],
-		vel_con[IR3::u], vel_con[IR3::v], vel_con[IR3::w]
-	};
-	rk4.do_step(sys, inout, time, -0.5*dt);
-    IR3 qmh = {inout[0], inout[1], inout[2]};
-    IR3 vmh_con = {inout[3], inout[4], inout[5]};
-    IR3 vmh = my_morphism_->from_contravariant(vmh_con, qmh);
+  lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
+  odeint_adapter<gyronimo::lorentz> sys(&lo);
+  boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
+  IR3 vel_con = my_morphism_->to_contravariant(vel, pos);
+  lorentz::state inout = {pos[IR3::u],     pos[IR3::v],     pos[IR3::w],
+                          vel_con[IR3::u], vel_con[IR3::v], vel_con[IR3::w]};
+  rk4.do_step(sys, inout, time, -0.5 * dt);
+  IR3 qmh = {inout[0], inout[1], inout[2]};
+  IR3 vmh_con = {inout[3], inout[4], inout[5]};
+  IR3 vmh = my_morphism_->from_contravariant(vmh_con, qmh);
 
-	return {pos[IR3::u], pos[IR3::v], pos[IR3::w], 
-            vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
+  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+          vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
 }
 
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/dynamics/classical_boris.cc
+++ b/gyronimo/dynamics/classical_boris.cc
@@ -22,6 +22,11 @@
 #include <gyronimo/core/codata.hh>
 #include <gyronimo/core/error.hh>
 #include <gyronimo/dynamics/boris_push.hh>
+#include <cmath>
+
+#include <gyronimo/dynamics/lorentz.hh>
+#include <gyronimo/dynamics/odeint_adapter.hh>
+#include <boost/numeric/odeint.hpp>
 
 namespace gyronimo {
 
@@ -88,9 +93,10 @@ classical_boris::state classical_boris::do_step(
 		Efield = contraction<second>(e_old, E_contravariant);
 	}
 	double Btime = time * iBfield_time_factor_;
-	IR3 Bversor_contravariant = magnetic_field_->contravariant_versor(q_old, Btime);
-	IR3 Bversor = contraction<second>(e_old, Bversor_contravariant);
-	double Bmag = magnetic_field_->magnitude(q_old, Btime);
+	IR3 Bfield_contravariant = magnetic_field_->contravariant(q_old, Btime);
+	IR3 Bfield = contraction<second>(e_old, Bfield_contravariant);
+	double Bmag = std::sqrt(inner_product(Bfield, Bfield));
+    IR3 Bversor = Bfield / Bmag;
 
 	// perform cartesian_boris step
 	IR3 v_new = electric_field_ ? 
@@ -156,13 +162,29 @@ classical_boris::state classical_boris::generate_initial_state(
 		const IR3 &pos, const IR3 &vel, 
 		const double &time, const double &dt) const {
 
-	state s0 = {
-		pos[IR3::u], pos[IR3::v], pos[IR3::w],
-		vel[IR3::u], vel[IR3::v], vel[IR3::w]
-	};
-	state s1 = do_step(s0, time, -0.5*dt);
+	// state s0 = {
+	// 	pos[IR3::u], pos[IR3::v], pos[IR3::w],
+	// 	vel[IR3::u], vel[IR3::v], vel[IR3::w]
+	// };
+	// state s1 = do_step(s0, time, -0.5*dt);
 
-	return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
+	// return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
+    
+    lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
+    odeint_adapter<gyronimo::lorentz> sys(&lo);
+    boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
+    IR3 vel_con = my_morphism_->to_contravariant(vel, pos);
+	lorentz::state inout = {
+		pos[IR3::u], pos[IR3::v], pos[IR3::w],
+		vel_con[IR3::u], vel_con[IR3::v], vel_con[IR3::w]
+	};
+	rk4.do_step(sys, inout, time, -0.5*dt);
+    IR3 qmh = {inout[0], inout[1], inout[2]};
+    IR3 vmh_con = {inout[3], inout[4], inout[5]};
+    IR3 vmh = my_morphism_->from_contravariant(vmh_con, qmh);
+
+	return {pos[IR3::u], pos[IR3::v], pos[IR3::w], 
+            vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
 }
 
 } // end namespace gyronimo

--- a/gyronimo/dynamics/classical_boris.cc
+++ b/gyronimo/dynamics/classical_boris.cc
@@ -1,0 +1,175 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @classical_boris.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/dynamics/classical_boris.hh>
+#include <gyronimo/core/contraction.hh>
+#include <gyronimo/core/codata.hh>
+#include <gyronimo/core/error.hh>
+#include <gyronimo/dynamics/boris_push.hh>
+
+namespace gyronimo {
+
+/*!
+	Class constructor.
+	Takes a reference length `Lref`, a reference velocity `Vref`, 
+	the charge-over-mass ratio `qom`, an electric field `Efield`
+	and a magnetic field `Bfield`. The field `Bfield`
+	cannot be `nullptr`.
+*/
+classical_boris::classical_boris(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield)
+		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), qom_(qom),
+		Oref_(Bfield ? qom * codata::e / 
+			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
+		electric_field_(Efield), magnetic_field_(Bfield),
+		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+		metric_(Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric()) : nullptr),
+		morph_(metric_ ? metric_->morph() : nullptr) {
+
+	// test if fields exist
+	// if(!Efield) error(__func__, __FILE__, __LINE__, 
+	// 	    " Efield cannot be nullptr.", 1);
+	if(!Bfield) error(__func__, __FILE__, __LINE__, 
+		    " Bfield cannot be nullptr.", 1);
+
+	// test if metrics are the same
+	if(Efield) {
+		const metric_covariant *Emetric = Efield->metric();
+		const metric_covariant *Bmetric = Bfield->metric();
+		if(Emetric != Bmetric) error(__func__, __FILE__, __LINE__, 
+			" Efield and Bfield must be in the same coordinate representation.", 1);
+	}
+
+	// ensure that the field metrics derive from metric_connected
+	if(!metric_) error(__func__, __FILE__, __LINE__, 
+		" field metrics must derive from 'gyronimo::metric_connected'.", 1);
+
+	// test if normalization factors are consistent
+	if(Efield) {
+		double E_m_factor = Efield->m_factor();
+		double B_m_factor = Bfield->m_factor();
+		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
+			error(__func__, __FILE__, __LINE__, 
+				" inconsistent Efield and Bfield normalization.", 1);
+	}
+}
+
+//! Performs a time step `dt` update to the state `in` and returns the result.
+classical_boris::state classical_boris::do_step(
+		const state &in, const double &time, const double &dt) const {
+	
+	// extract position and velocity from state
+	IR3 q_old = {in[0], in[1], in[2]};
+	IR3 v_old = {in[3], in[4], in[5]};
+	dIR3 e_old = morph_->del(q_old);
+
+	// calculate fields
+	IR3 Efield = {0.0, 0.0, 0.0};
+	if(electric_field_) {
+		double Etime = time * iEfield_time_factor_;
+		IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
+		Efield = contraction<second>(e_old, E_contravariant);
+	}
+	double Btime = time * iBfield_time_factor_;
+	IR3 Bversor_contravariant = magnetic_field_->contravariant_versor(q_old, Btime);
+	IR3 Bversor = contraction<second>(e_old, Bversor_contravariant);
+	double Bmag = magnetic_field_->magnitude(q_old, Btime);
+
+	// perform cartesian_boris step
+	IR3 v_new = electric_field_ ? 
+		boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt) :
+		boris_push(v_old, Oref_, Bmag, Bversor, dt);
+	// IR3 x_new = x_old + (Lref_*dt) * v_new;
+
+	// IR3 q_new = morph_->inverse(x_new);
+	// IR3 u_new = morph_->to_contravariant(v_new, q_new);
+
+	IR3 q_new = morph_->translation(q_old, (Lref_*dt) * v_new);
+
+	return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
+			v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+}
+
+//! Returns the `classical_boris::state` state from a point in SI phase-space.
+classical_boris::state classical_boris::generate_state(const IR3 &pos, const IR3 &vel) const {
+	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+}
+
+//! Returns the vector position of the state in SI units.
+IR3 classical_boris::get_position(const state &s) const {
+	return {s[0], s[1], s[2]};
+}
+
+//! Returns the vector velocity of the state in SI units.
+IR3 classical_boris::get_velocity(const state &s) const {
+	IR3 q = {s[0], s[1], s[2]};
+	IR3 v = {s[3], s[4], s[5]};
+	return morph_->to_contravariant(v, q);
+}
+
+//! Returns the kinetic energy of the state, normalized to `Uref`.
+double classical_boris::energy_kinetic(const state &s) const {
+	return (s[3]*s[3] + s[4]*s[4] + s[5]*s[5]);
+}
+
+//! Returns the parallel energy of the state, normalized to `Uref`.
+double classical_boris::energy_parallel(const state &s, double &time) const {
+	IR3 q = {s[0], s[1], s[2]};
+	IR3 v = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 Bversor_con = magnetic_field_->contravariant_versor(q, Btime);
+	IR3 Bversor = morph_->from_contravariant(Bversor_con, q);
+	double vpar = inner_product(v, Bversor);
+	return vpar*vpar;
+}
+
+//! Returns the perpendicular energy of the state, normalized to `Uref`.
+double classical_boris::energy_perpendicular(const state &s, double &time) const {
+	IR3 q = {s[0], s[1], s[2]};
+	IR3 v = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 Bversor_con = magnetic_field_->contravariant_versor(q, Btime);
+	IR3 Bversor = morph_->from_contravariant(Bversor_con, q);
+	IR3 vperp = cross_product(v, Bversor);
+	return inner_product(vperp, vperp);
+}
+
+//! Creates the first `classical_boris::state` from a point in cartesian phase-space.
+classical_boris::state classical_boris::generate_initial_state(
+		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+		const double &time, const double &dt) const {
+
+	IR3 q = morph_->inverse(cartesian_position);
+	state s0 = {
+		q[IR3::u], q[IR3::v], q[IR3::w],
+		cartesian_velocity[IR3::u],
+		cartesian_velocity[IR3::v],
+		cartesian_velocity[IR3::w]
+	};
+	state s1 = do_step(s0, time, -0.5*dt);
+
+	return {
+		q[IR3::u], q[IR3::v], q[IR3::w],
+		s1[3], s1[4], s1[5]
+	};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/dynamics/classical_boris.hh
+++ b/gyronimo/dynamics/classical_boris.hh
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Manuel Assunção.
+// Copyright (C) 2022-2023 Manuel Assunção and Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,18 +26,34 @@
 
 namespace gyronimo {
 
-//! Gyronimo implementation for classical boris stepper class.
+//! Boris-like stepper, cartesian velocity and curvilinear position.
 /*!
-        This class implements the boris pusher [C. K. Birdsall and
-        A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
-        which is typically defined only for cartesian coordinates.
-        To circumvent this issue, this class converts back and forth
-        between curvilinear and cartesian coordinates. To achieve this,
-        field representation is only constrained to metrics of the type
-        `metric_connected` to be able to convert coordinates and vectors
-        using the connected `morphism`.
-        To use the boris pusher in cartesian coordinates, look at
-        `cartesian_boris` class.
+    Advances a charged-particle's cartesian velocity by a single
+    time step using the Boris algorithm [C. K. Birdsall and A. B. Langdon,
+    Plasma Physics via Computer Simulation, CRC Press, 1991], which is a
+    particular way of discretizing the equation of motion for the Lorentz force
+    @f{equation*}{
+      \frac{d\tilde{\mathbf{v}}}{d\tau}
+          = \tilde{\Omega}_{ref} \tilde{\mathbf{v}} \times \tilde{\mathbf{B}} +
+            \tilde{E}_{ref} \tilde{\mathbf{E}}
+    @f}
+    Here, @f$\tau = t/T_{ref}@f$, @f$\tilde{\mathbf{v}} = \mathbf{v}/V_{ref}@f$
+    @f$\tilde{\mathbf{B}} = \mathbf{B}/B_{ref}@f$, and @f$\tilde{\mathbf{E}} =
+    \mathbf{E}/E_{ref}@f$ are the time, cartesian velocity, magnetic, and
+    electric fields normalised, respectively, to `Tref`, `Vref`, `Bref`, and
+    `Eref` (all in SI units), whereas @f$\tilde{\Omega}_{ref} = T_{ref} \: q_s
+    B_{ref}/m_s@f$ and @f$\tilde{E}_{ref} = \tilde{\Omega}_{ref} E_{ref} /
+    (B_{ref} V_{ref})@f$. The curvilinear position is advanced from
+    @f$q^k_\tau@f$ to @f$q^k_{\tau + \Delta\tau}@f$ by solving the (possibly
+    nonlinear) system
+    @f{equation*}{
+      V_{ref} T_{ref} \: \Delta\tau \: \tilde{\mathbf{v}}_{\tau + \Delta\tau/2}
+          = \mathcal{M}\big(q^k_{\tau + \Delta\tau}\big) -
+              \mathcal{M}\big(q^k_\tau\big)
+    @f}
+    where @f$\mathcal{M}(q^k)@f$ is the morphism from the coordinates @f$q^k@f$
+    into the cartesian space carried by the specific magnetic and electric field
+    objects supplied to the constructor.
 */
 class classical_boris {
  public:
@@ -45,44 +61,37 @@ class classical_boris {
 
   classical_boris(
       const double& Lref, const double& Vref, const double& qom,
-      const IR3field* Efield, const IR3field* Bfield);
+      const IR3field* B, const IR3field* E);
   ~classical_boris() {};
 
-  state do_step(const state& in, const double& time, const double& dt) const;
-
-  state generate_state(const IR3& pos, const IR3& vel) const;
+  state do_step(const state& s, const double& time, const double& dt) const;
+  state generate_state(const IR3& q, const IR3& v) const;
   IR3 get_position(const state& s) const;
   IR3 get_velocity(const state& s) const;
+  IR3 get_dot_q(const state& s) const;
 
   double energy_kinetic(const state& s) const;
   double energy_parallel(const state& s, double& time) const;
   double energy_perpendicular(const state& s, double& time) const;
 
-  state generate_initial_state(
-      const IR3& pos, const IR3& vel, const double& t, const double& dt) const;
+  state half_back_step(
+      const IR3& q, const IR3& v, const double& t, const double& dt) const;
 
   const IR3field* electric_field() const { return electric_field_; };
   const IR3field* magnetic_field() const { return magnetic_field_; };
   const morphism* my_morphism() const { return my_morphism_; };
-
-  //! Returns the reference length scale `Lref`.
   double Lref() const { return Lref_; };
-  //! Returns the reference time scale `Tref`.
   double Tref() const { return Tref_; };
-  //! Returns the reference velocity scale `Vref`.
   double Vref() const { return Vref_; };
-  //! Returns the reference frequency scale `Oref`.
   double Oref() const { return Oref_; };
-  //! Returns the charge-over-mass ratio.
   double qom() const { return qom_; };
  private:
   const double Lref_, Vref_, Tref_, qom_, Oref_;
   const IR3field *electric_field_, *magnetic_field_;
-  const double iEfield_time_factor_, iBfield_time_factor_;
+  const double iE_time_factor_, iB_time_factor_;
   const metric_connected* metric_;
   const morphism* my_morphism_;
-
-};  // end class classical_boris
+};
 
 }  // end namespace gyronimo
 

--- a/gyronimo/dynamics/classical_boris.hh
+++ b/gyronimo/dynamics/classical_boris.hh
@@ -21,70 +21,69 @@
 #define GYRONIMO_CLASSICAL_BORIS
 
 #include <gyronimo/fields/IR3field.hh>
-#include <gyronimo/metrics/morphism.hh>
 #include <gyronimo/metrics/metric_connected.hh>
+#include <gyronimo/metrics/morphism.hh>
 
 namespace gyronimo {
 
 //! Gyronimo implementation for classical boris stepper class.
 /*!
-	This class implements the boris pusher [C. K. Birdsall and 
-	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
-	which is typically defined only for cartesian coordinates.
-	To circumvent this issue, this class converts back and forth
-	between curvilinear and cartesian coordinates. To achieve this, 
-	field representation is only constrained to metrics of the type
-	`metric_connected` to be able to convert coordinates and vectors
-	using the connected `morphism`.
-	To use the boris pusher in cartesian coordinates, look at
-	`cartesian_boris` class.
+        This class implements the boris pusher [C. K. Birdsall and
+        A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991],
+        which is typically defined only for cartesian coordinates.
+        To circumvent this issue, this class converts back and forth
+        between curvilinear and cartesian coordinates. To achieve this,
+        field representation is only constrained to metrics of the type
+        `metric_connected` to be able to convert coordinates and vectors
+        using the connected `morphism`.
+        To use the boris pusher in cartesian coordinates, look at
+        `cartesian_boris` class.
 */
 class classical_boris {
-public:
-	using state = std::array<double,6>;
+ public:
+  using state = std::array<double, 6>;
 
-	classical_boris(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield);
-	~classical_boris() {};
+  classical_boris(
+      const double& Lref, const double& Vref, const double& qom,
+      const IR3field* Efield, const IR3field* Bfield);
+  ~classical_boris() {};
 
-	state do_step(const state &in, const double &time, const double &dt) const;
+  state do_step(const state& in, const double& time, const double& dt) const;
 
-	state generate_state(const IR3 &pos, const IR3 &vel) const;
-	IR3 get_position(const state &s) const;
-	IR3 get_velocity(const state &s) const;
+  state generate_state(const IR3& pos, const IR3& vel) const;
+  IR3 get_position(const state& s) const;
+  IR3 get_velocity(const state& s) const;
 
-	double energy_kinetic(const state &s) const;
-	double energy_parallel(const state &s, double &time) const;
-	double energy_perpendicular(const state &s, double &time) const;
+  double energy_kinetic(const state& s) const;
+  double energy_parallel(const state& s, double& time) const;
+  double energy_perpendicular(const state& s, double& time) const;
 
-	state generate_initial_state(const IR3 &pos, const IR3 &vel, 
-		const double &t, const double &dt) const;
+  state generate_initial_state(
+      const IR3& pos, const IR3& vel, const double& t, const double& dt) const;
 
-	const IR3field* electric_field() const {return electric_field_;};
-	const IR3field* magnetic_field() const {return magnetic_field_;};
-	const morphism* my_morphism() const {return my_morphism_;};
+  const IR3field* electric_field() const { return electric_field_; };
+  const IR3field* magnetic_field() const { return magnetic_field_; };
+  const morphism* my_morphism() const { return my_morphism_; };
 
-	//! Returns the reference length scale `Lref`.
-	double Lref() const {return Lref_;};
-	//! Returns the reference time scale `Tref`.
-	double Tref() const {return Tref_;};
-	//! Returns the reference velocity scale `Vref`.
-	double Vref() const {return Vref_;};
-	//! Returns the reference frequency scale `Oref`.
-	double Oref() const {return Oref_;};
-	//! Returns the charge-over-mass ratio.
-	double qom() const {return qom_;};
+  //! Returns the reference length scale `Lref`.
+  double Lref() const { return Lref_; };
+  //! Returns the reference time scale `Tref`.
+  double Tref() const { return Tref_; };
+  //! Returns the reference velocity scale `Vref`.
+  double Vref() const { return Vref_; };
+  //! Returns the reference frequency scale `Oref`.
+  double Oref() const { return Oref_; };
+  //! Returns the charge-over-mass ratio.
+  double qom() const { return qom_; };
+ private:
+  const double Lref_, Vref_, Tref_, qom_, Oref_;
+  const IR3field *electric_field_, *magnetic_field_;
+  const double iEfield_time_factor_, iBfield_time_factor_;
+  const metric_connected* metric_;
+  const morphism* my_morphism_;
 
-private:
+};  // end class classical_boris
 
-	const double Lref_, Vref_, Tref_, qom_, Oref_;
-	const IR3field *electric_field_, *magnetic_field_;
-	const double iEfield_time_factor_, iBfield_time_factor_;
-	const metric_connected *metric_;
-	const morphism *my_morphism_;
+}  // end namespace gyronimo
 
-}; // end class classical_boris
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_CLASSICAL_BORIS
+#endif  // GYRONIMO_CLASSICAL_BORIS

--- a/gyronimo/dynamics/classical_boris.hh
+++ b/gyronimo/dynamics/classical_boris.hh
@@ -88,7 +88,7 @@ class classical_boris {
  private:
   const double Lref_, Vref_, Tref_, qom_, Oref_;
   const IR3field *electric_field_, *magnetic_field_;
-  const double iE_time_factor_, iB_time_factor_;
+  const double iE_time_factor_, iB_time_factor_, tildeEref_;
   const metric_connected* metric_;
   const morphism* my_morphism_;
 };

--- a/gyronimo/dynamics/classical_boris.hh
+++ b/gyronimo/dynamics/classical_boris.hh
@@ -57,13 +57,12 @@ public:
 	double energy_parallel(const state &s, double &time) const;
 	double energy_perpendicular(const state &s, double &time) const;
 
-	state generate_initial_state(
-		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+	state generate_initial_state(const IR3 &pos, const IR3 &vel, 
 		const double &t, const double &dt) const;
 
 	const IR3field* electric_field() const {return electric_field_;};
 	const IR3field* magnetic_field() const {return magnetic_field_;};
-	const morphism* morph() const {return morph_;};
+	const morphism* my_morphism() const {return my_morphism_;};
 
 	//! Returns the reference length scale `Lref`.
 	double Lref() const {return Lref_;};
@@ -82,7 +81,7 @@ private:
 	const IR3field *electric_field_, *magnetic_field_;
 	const double iEfield_time_factor_, iBfield_time_factor_;
 	const metric_connected *metric_;
-	const morphism *morph_;
+	const morphism *my_morphism_;
 
 }; // end class classical_boris
 

--- a/gyronimo/dynamics/classical_boris.hh
+++ b/gyronimo/dynamics/classical_boris.hh
@@ -1,0 +1,91 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @classical_boris.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_CLASSICAL_BORIS
+#define GYRONIMO_CLASSICAL_BORIS
+
+#include <gyronimo/fields/IR3field.hh>
+#include <gyronimo/metrics/morphism.hh>
+#include <gyronimo/metrics/metric_connected.hh>
+
+namespace gyronimo {
+
+//! Gyronimo implementation for classical boris stepper class.
+/*!
+	This class implements the boris pusher [C. K. Birdsall and 
+	A. B. Langdon, Plasma Physics via Computer Simulation, CRC Press, 1991], 
+	which is typically defined only for cartesian coordinates.
+	To circumvent this issue, this class converts back and forth
+	between curvilinear and cartesian coordinates. To achieve this, 
+	field representation is only constrained to metrics of the type
+	`metric_connected` to be able to convert coordinates and vectors
+	using the connected `morphism`.
+	To use the boris pusher in cartesian coordinates, look at
+	`cartesian_boris` class.
+*/
+class classical_boris {
+public:
+	using state = std::array<double,6>;
+
+	classical_boris(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield);
+	~classical_boris() {};
+
+	state do_step(const state &in, const double &time, const double &dt) const;
+
+	state generate_state(const IR3 &pos, const IR3 &vel) const;
+	IR3 get_position(const state &s) const;
+	IR3 get_velocity(const state &s) const;
+
+	double energy_kinetic(const state &s) const;
+	double energy_parallel(const state &s, double &time) const;
+	double energy_perpendicular(const state &s, double &time) const;
+
+	state generate_initial_state(
+		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+		const double &t, const double &dt) const;
+
+	const IR3field* electric_field() const {return electric_field_;};
+	const IR3field* magnetic_field() const {return magnetic_field_;};
+	const morphism* morph() const {return morph_;};
+
+	//! Returns the reference length scale `Lref`.
+	double Lref() const {return Lref_;};
+	//! Returns the reference time scale `Tref`.
+	double Tref() const {return Tref_;};
+	//! Returns the reference velocity scale `Vref`.
+	double Vref() const {return Vref_;};
+	//! Returns the reference frequency scale `Oref`.
+	double Oref() const {return Oref_;};
+	//! Returns the charge-over-mass ratio.
+	double qom() const {return qom_;};
+
+private:
+
+	const double Lref_, Vref_, Tref_, qom_, Oref_;
+	const IR3field *electric_field_, *magnetic_field_;
+	const double iEfield_time_factor_, iBfield_time_factor_;
+	const metric_connected *metric_;
+	const morphism *morph_;
+
+}; // end class classical_boris
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_CLASSICAL_BORIS

--- a/gyronimo/dynamics/curvilinear_boris.cc
+++ b/gyronimo/dynamics/curvilinear_boris.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2022 Manuel Assunção.
+// Copyright (C) 2022-2023 Manuel Assunção and Paulo Rodrigues.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -31,170 +31,108 @@
 
 namespace gyronimo {
 
-/*!
-        Class constructor.
-        Takes a reference length `Lref`, a reference velocity `Vref`,
-        the charge-over-mass ratio `qom`, an electric field `Efield`
-        and a magnetic field `Bfield`. The field `Bfield`
-        cannot be `nullptr`.
-*/
+//! Class constructor.
 curvilinear_boris::curvilinear_boris(
     const double& Lref, const double& Vref, const double& qom,
-    const IR3field* Efield, const IR3field* Bfield)
+    const IR3field* B, const IR3field* E)
     : Lref_(Lref), Vref_(Vref), Tref_(Lref / Vref), qom_(qom),
-      Oref_(
-          Bfield
-              ? qom * codata::e / codata::m_proton * Bfield->m_factor() * Tref_
-              : 1.0),
-      electric_field_(Efield), magnetic_field_(Bfield),
-      iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
-      iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
-      metric_(
-          Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric())
-                 : nullptr),
+      Oref_(B ? qom * codata::e / codata::m_proton * B->m_factor() * Tref_ : 1),
+      electric_field_(E), magnetic_field_(B),
+      iE_time_factor_(E ? Tref_ / E->t_factor() : 1),
+      iB_time_factor_(B ? Tref_ / B->t_factor() : 1),
+      metric_(B ? dynamic_cast<const metric_connected*>(B->metric()) : nullptr),
       my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
-  // test if fields exist
-  // if(!Efield) error(__func__, __FILE__, __LINE__,
-  // 	    " Efield cannot be nullptr.", 1);
-  if (!Bfield)
-    error(__func__, __FILE__, __LINE__, " Bfield cannot be nullptr.", 1);
-
-  // test if metrics are the same
-  if (Efield) {
-    const metric_covariant* Emetric = Efield->metric();
-    const metric_covariant* Bmetric = Bfield->metric();
-    if (Emetric != Bmetric)
-      error(
-          __func__, __FILE__, __LINE__,
-          " Efield and Bfield must be in the same coordinate representation.",
-          1);
-  }
-
-  // ensure that the field metrics derive from metric_connected
+  if (!B) error(__func__, __FILE__, __LINE__, "no magnetic field.", 1);
+  if (E && B->metric() != E->metric())
+    error(__func__, __FILE__, __LINE__, "mismatched E/B coordinates.", 1);
   if (!metric_)
-    error(
-        __func__, __FILE__, __LINE__,
-        " field metrics must derive from 'gyronimo::metric_connected'.", 1);
-
-  // test if normalization factors are consistent
-  if (Efield) {
-    double E_m_factor = Efield->m_factor();
-    double B_m_factor = Bfield->m_factor();
-    if (std::abs(1.0 - E_m_factor / (Vref_ * B_m_factor)) > 1.0e-14)
-      error(
-          __func__, __FILE__, __LINE__,
-          " inconsistent Efield and Bfield normalization.", 1);
-  }
+    error(__func__, __FILE__, __LINE__, "field has no metric_connected.", 1);
 }
 
-//! Performs a time step `dt` update to the state `in` and returns the result.
+//! Returns the update of a state by a single time step `dt`.
 curvilinear_boris::state curvilinear_boris::do_step(
-    const state& in, const double& time, const double& dt) const {
-  // extract position and velocity from state
-  IR3 q_old = {in[0], in[1], in[2]};
-  IR3 v_old = {in[3], in[4], in[5]};
-  dIR3 e_old = my_morphism_->del(q_old);
+    const state& s, const double& time, const double& dt) const {
+  double Btime = time * iB_time_factor_;
+  const double tildeEref = Oref_ * iB_time_factor_ / (iE_time_factor_ * Vref_);
 
-  // calculate fields
-  IR3 Efield = {0.0, 0.0, 0.0};
-  if (electric_field_) {
-    double Etime = time * iEfield_time_factor_;
-    IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
-    Efield = contraction<second>(e_old, E_contravariant);
-  }
-  double Btime = time * iBfield_time_factor_;
-  IR3 Bfield_contravariant = magnetic_field_->contravariant(q_old, Btime);
-  IR3 Bfield = contraction<second>(e_old, Bfield_contravariant);
-  double Bmag = std::sqrt(inner_product(Bfield, Bfield));
-  IR3 Bversor = Bfield / Bmag;
+  IR3 q = this->get_position(s), v = this->get_velocity(s);
+  double B = magnetic_field_->magnitude(q, Btime);
+  IR3 b = my_morphism_->from_contravariant(
+      magnetic_field_->contravariant_versor(q, Btime), q);
+  IR3 E = electric_field_ ?
+      my_morphism_->from_contravariant(
+          electric_field_->contravariant(q, time * iE_time_factor_), q) :
+      IR3 {0, 0, 0};
 
-  // perform cartesian_boris step
-  IR3 v_new = electric_field_
-      ? boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt)
-      : boris_push(v_old, Oref_, Bmag, Bversor, dt);
+  IR3 updated_v = electric_field_ ?
+      boris_push(v, Oref_, tildeEref, E, B, b, dt) :
+      boris_push(v, Oref_, B, b, dt);
+  IR3 dot_q_temporary = my_morphism_->to_contravariant(updated_v, q);
+  IR3 q_temporary = q + (0.5 * Lref_ * dt) * dot_q_temporary;
+  IR3 v_temporary = my_morphism_->to_contravariant(updated_v, q_temporary);
+  IR3 updated_q = q + (Lref_ * dt) * v_temporary;
 
-  IR3 u_half = my_morphism_->to_contravariant(v_new, q_old);
-  IR3 q_half = q_old + (0.5 * Lref_ * dt) * u_half;
-  IR3 u_new = my_morphism_->to_contravariant(v_new, q_half);
-  IR3 q_new = q_old + (Lref_ * dt) * u_new;
-
-  return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
-          v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+  return this->generate_state(updated_q, updated_v);
 }
 
-//! Returns the `curvilinear_boris::state` state from a point in SI phase-space.
+//! Builds a state from curvilinear position and normalised cartesian velocity.
 curvilinear_boris::state curvilinear_boris::generate_state(
-    const IR3& pos, const IR3& vel) const {
-  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
-          vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+    const IR3& q, const IR3& v) const {
+  return {q[IR3::u], q[IR3::v], q[IR3::w], v[IR3::u], v[IR3::v], v[IR3::w]};
 }
 
-//! Returns the vector position of the `curvilinear_boris::state`.
+//! Extracts curvilinear position from state.
 IR3 curvilinear_boris::get_position(const state& s) const {
   return {s[0], s[1], s[2]};
 }
 
-//! Returns the vector velocity of the `curvilinear_boris::state`, normalized to
-//! `Vref`.
+//! Extracts cartesian normalised velocity from state.
 IR3 curvilinear_boris::get_velocity(const state& s) const {
-  IR3 q_pos = {s[0], s[1], s[2]};
-  IR3 vel_cartesian = {s[3], s[4], s[5]};
-  IR3 vel_contravariant = my_morphism_->to_contravariant(vel_cartesian, q_pos);
-  return vel_contravariant;
+  return {s[3], s[4], s[5]};
 }
 
-//! Returns the kinetic energy of the state, normalized to `Uref`.
+//! Extracts curvilinear normalised velocity from state.
+IR3 curvilinear_boris::get_dot_q(const state& s) const {
+  IR3 q = this->get_position(s), v = this->get_velocity(s);
+  return my_morphism_->to_contravariant(v, q);
+}
+
+//! Returns the kinetic energy of the state, normalised to `Uref`.
 double curvilinear_boris::energy_kinetic(const state& s) const {
-  return s[3] * s[3] + s[4] * s[4] + s[5] * s[5];
+  IR3 v = this->get_velocity(s);
+  return inner_product(v, v);
 }
 
-//! Returns the parallel energy of the state, normalized to `Uref`.
+//! Returns the parallel energy of the state, normalised to `Uref`.
 double curvilinear_boris::energy_parallel(const state& s, double& time) const {
-  IR3 q_pos = {s[0], s[1], s[2]};
-  IR3 vel = {s[3], s[4], s[5]};
-  double Btime = time * iBfield_time_factor_;
-  IR3 b_contravariant = magnetic_field_->contravariant_versor(q_pos, Btime);
-  IR3 b_cartesian = my_morphism_->from_contravariant(b_contravariant, q_pos);
-  double vpar = inner_product(vel, b_cartesian);
-  return vpar * vpar;
+  IR3 q = this->get_position(s), v = this->get_velocity(s);
+  IR3 b = my_morphism_->from_contravariant(
+      magnetic_field_->contravariant_versor(q, time * iB_time_factor_), q);
+  double v_parallel = inner_product(v, b);
+  return v_parallel * v_parallel;
 }
 
-//! Returns the perpendicular energy of the state, normalized to `Uref`.
+//! Returns the perpendicular energy of the state, normalised to `Uref`.
 double curvilinear_boris::energy_perpendicular(
     const state& s, double& time) const {
-  IR3 q_pos = {s[0], s[1], s[2]};
-  IR3 vel = {s[3], s[4], s[5]};
-  double Btime = time * iBfield_time_factor_;
-  IR3 Bversor_con = magnetic_field_->contravariant_versor(q_pos, Btime);
-  IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q_pos);
-  IR3 vperp = cross_product(vel, Bversor);
-  return inner_product(vperp, vperp);
+  IR3 q = this->get_position(s), v = this->get_velocity(s);
+  IR3 b = my_morphism_->from_contravariant(
+      magnetic_field_->contravariant_versor(q, time * iB_time_factor_), q);
+  IR3 v_perpendicular = cross_product(v, b);
+  return inner_product(v_perpendicular, v_perpendicular);
 }
 
-curvilinear_boris::state curvilinear_boris::generate_initial_state(
-    const IR3& pos, const IR3& vel, const double& time,
-    const double& dt) const {
-  // state s0 = {
-  // 	pos[IR3::u], pos[IR3::v], pos[IR3::w],
-  // 	vel[IR3::u], vel[IR3::v], vel[IR3::w]
-  // };
-  // state s1 = do_step(s0, time, -0.5*dt);
-
-  // return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
-
-  lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
-  odeint_adapter<gyronimo::lorentz> sys(&lo);
+//! Returns a state with the velocity integrated backwards by a half time step.
+curvilinear_boris::state curvilinear_boris::half_back_step(
+    const IR3& q, const IR3& v, const double& time, const double& dt) const {
+  lorentz lo(Lref_, Vref_, qom_, magnetic_field_, electric_field_);
+  auto ls = lo.generate_state(q, my_morphism_->to_contravariant(v, q));
   boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
-  IR3 vel_con = my_morphism_->to_contravariant(vel, pos);
-  lorentz::state inout = {pos[IR3::u],     pos[IR3::v],     pos[IR3::w],
-                          vel_con[IR3::u], vel_con[IR3::v], vel_con[IR3::w]};
-  rk4.do_step(sys, inout, time, -0.5 * dt);
-  IR3 qmh = {inout[0], inout[1], inout[2]};
-  IR3 vmh_con = {inout[3], inout[4], inout[5]};
-  IR3 vmh = my_morphism_->from_contravariant(vmh_con, qmh);
-
-  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
-          vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
+  rk4.do_step(odeint_adapter(&lo), ls, time, -0.5 * dt);
+  IR3 q_half_back = lo.get_position(ls), dot_q_half_back = lo.get_velocity(ls);
+  IR3 v_half_back =
+      my_morphism_->from_contravariant(dot_q_half_back, q_half_back);
+  return this->generate_state(q, v_half_back);
 }
 
 }  // end namespace gyronimo

--- a/gyronimo/dynamics/curvilinear_boris.cc
+++ b/gyronimo/dynamics/curvilinear_boris.cc
@@ -1,0 +1,172 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @curvilinear_boris.cc, this file is part of ::gyronimo::
+
+#include <typeinfo>
+#include <gyronimo/dynamics/curvilinear_boris.hh>
+#include <gyronimo/core/contraction.hh>
+#include <gyronimo/core/codata.hh>
+#include <gyronimo/core/error.hh>
+#include <gyronimo/dynamics/boris_push.hh>
+
+namespace gyronimo {
+
+/*!
+	Class constructor.
+	Takes a reference length `Lref`, a reference velocity `Vref`, 
+	the charge-over-mass ratio `qom`, an electric field `Efield`
+	and a magnetic field `Bfield`. The field `Bfield`
+	cannot be `nullptr`.
+*/
+curvilinear_boris::curvilinear_boris(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield)
+		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), qom_(qom),
+		Oref_(Bfield ? qom * codata::e / 
+			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
+		electric_field_(Efield), magnetic_field_(Bfield),
+		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+		metric_(Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric()) : nullptr),
+		morph_(metric_ ? metric_->morph() : nullptr) {
+
+	// test if fields exist
+	// if(!Efield) error(__func__, __FILE__, __LINE__, 
+	// 	    " Efield cannot be nullptr.", 1);
+	if(!Bfield) error(__func__, __FILE__, __LINE__, 
+		    " Bfield cannot be nullptr.", 1);
+
+	// test if metrics are the same
+	if(Efield) {
+		const metric_covariant *Emetric = Efield->metric();
+		const metric_covariant *Bmetric = Bfield->metric();
+		if(Emetric != Bmetric) error(__func__, __FILE__, __LINE__, 
+			" Efield and Bfield must be in the same coordinate representation.", 1);
+	}
+
+	// ensure that the field metrics derive from metric_connected
+	if(!metric_) error(__func__, __FILE__, __LINE__, 
+		" field metrics must derive from 'gyronimo::metric_connected'.", 1);
+
+	// test if normalization factors are consistent
+	if(Efield) {
+		double E_m_factor = Efield->m_factor();
+		double B_m_factor = Bfield->m_factor();
+		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
+			error(__func__, __FILE__, __LINE__, 
+				" inconsistent Efield and Bfield normalization.", 1);
+	}
+}
+
+//! Performs a time step `dt` update to the state `in` and returns the result.
+curvilinear_boris::state curvilinear_boris::do_step(
+		const state &in, const double &time, const double &dt) const {
+	
+	// extract position and velocity from state
+	IR3 q_old = {in[0], in[1], in[2]};
+	IR3 v_old = {in[3], in[4], in[5]};
+	dIR3 e_old = morph_->del(q_old);
+
+	// calculate fields
+	IR3 Efield = {0.0, 0.0, 0.0};
+	if(electric_field_) {
+		double Etime = time * iEfield_time_factor_;
+		IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
+		Efield = contraction<second>(e_old, E_contravariant);
+	}
+	double Btime = time * iBfield_time_factor_;
+	IR3 Bversor_contravariant = magnetic_field_->contravariant_versor(q_old, Btime);
+	IR3 Bversor = contraction<second>(e_old, Bversor_contravariant);
+	double Bmag = magnetic_field_->magnitude(q_old, Btime);
+
+	// perform cartesian_boris step
+	IR3 v_new = electric_field_ ? 
+		boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt) :
+		boris_push(v_old, Oref_, Bmag, Bversor, dt);
+
+	IR3 u_half = morph_->to_contravariant(v_new, q_old);
+	IR3 q_half = q_old + (0.5*Lref_*dt) * u_half;
+	IR3 u_new = morph_->to_contravariant(v_new, q_half);
+	IR3 q_new = q_old + (Lref_*dt) * u_new;
+
+	return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
+			v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+}
+
+//! Returns the `curvilinear_boris::state` state from a point in SI phase-space.
+curvilinear_boris::state curvilinear_boris::generate_state(const IR3 &pos, const IR3 &vel) const {
+	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+}
+
+//! Returns the vector position of the `curvilinear_boris::state`.
+IR3 curvilinear_boris::get_position(const state &s) const {
+	return {s[0], s[1], s[2]};
+}
+
+//! Returns the vector velocity of the `curvilinear_boris::state`, normalized to `Vref`.
+IR3 curvilinear_boris::get_velocity(const state &s) const {
+	IR3 q_pos = {s[0], s[1], s[2]};
+	IR3 vel_cartesian = {s[3], s[4], s[5]};
+	IR3 vel_contravariant = morph_->to_contravariant(vel_cartesian, q_pos);
+	return vel_contravariant;
+}
+
+//! Returns the kinetic energy of the state, normalized to `Uref`.
+double curvilinear_boris::energy_kinetic(const state &s) const {
+	return s[3]*s[3] + s[4]*s[4] + s[5]*s[5];
+}
+
+//! Returns the parallel energy of the state, normalized to `Uref`.
+double curvilinear_boris::energy_parallel(const state &s, double &time) const {
+	IR3 q_pos = {s[0], s[1], s[2]};
+	IR3 vel = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 b_contravariant = magnetic_field_->contravariant_versor(q_pos, Btime);
+	IR3 b_cartesian = morph_->from_contravariant(b_contravariant, q_pos);
+	double vpar = inner_product(vel, b_cartesian);
+	return vpar*vpar;
+}
+
+//! Returns the perpendicular energy of the state, normalized to `Uref`.
+double curvilinear_boris::energy_perpendicular(const state &s, double &time) const {
+	IR3 q_pos = {s[0], s[1], s[2]};
+	IR3 vel = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 Bversor_con = magnetic_field_->contravariant_versor(q_pos, Btime);
+	IR3 Bversor = morph_->from_contravariant(Bversor_con, q_pos);
+	IR3 vperp = cross_product(vel, Bversor);
+	return inner_product(vperp, vperp);
+}
+
+//! Creates the first `curvilinear_boris::state` from a point in cartesian phase-space.
+curvilinear_boris::state curvilinear_boris::generate_initial_state(
+		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+		const double &time, const double &dt) const {
+
+	IR3 q = morph_->inverse(cartesian_position);
+	IR3 v = cartesian_velocity;
+	state s0 = {
+		q[IR3::u], q[IR3::v], q[IR3::w],
+		v[IR3::u], v[IR3::v], v[IR3::w]
+	};
+	state s1 = do_step(s0, time, -0.5*dt);
+
+	return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
+}
+
+} // end namespace gyronimo

--- a/gyronimo/dynamics/curvilinear_boris.cc
+++ b/gyronimo/dynamics/curvilinear_boris.cc
@@ -17,173 +17,184 @@
 
 // @curvilinear_boris.cc, this file is part of ::gyronimo::
 
-#include <typeinfo>
-#include <gyronimo/dynamics/curvilinear_boris.hh>
-#include <gyronimo/core/contraction.hh>
 #include <gyronimo/core/codata.hh>
+#include <gyronimo/core/contraction.hh>
 #include <gyronimo/core/error.hh>
 #include <gyronimo/dynamics/boris_push.hh>
-
+#include <gyronimo/dynamics/curvilinear_boris.hh>
 #include <gyronimo/dynamics/lorentz.hh>
 #include <gyronimo/dynamics/odeint_adapter.hh>
+
 #include <boost/numeric/odeint.hpp>
+
+#include <typeinfo>
 
 namespace gyronimo {
 
 /*!
-	Class constructor.
-	Takes a reference length `Lref`, a reference velocity `Vref`, 
-	the charge-over-mass ratio `qom`, an electric field `Efield`
-	and a magnetic field `Bfield`. The field `Bfield`
-	cannot be `nullptr`.
+        Class constructor.
+        Takes a reference length `Lref`, a reference velocity `Vref`,
+        the charge-over-mass ratio `qom`, an electric field `Efield`
+        and a magnetic field `Bfield`. The field `Bfield`
+        cannot be `nullptr`.
 */
-curvilinear_boris::curvilinear_boris(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield)
-		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), qom_(qom),
-		Oref_(Bfield ? qom * codata::e / 
-			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
-		electric_field_(Efield), magnetic_field_(Bfield),
-		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
-		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
-		metric_(Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric()) : nullptr),
-		my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
+curvilinear_boris::curvilinear_boris(
+    const double& Lref, const double& Vref, const double& qom,
+    const IR3field* Efield, const IR3field* Bfield)
+    : Lref_(Lref), Vref_(Vref), Tref_(Lref / Vref), qom_(qom),
+      Oref_(
+          Bfield
+              ? qom * codata::e / codata::m_proton * Bfield->m_factor() * Tref_
+              : 1.0),
+      electric_field_(Efield), magnetic_field_(Bfield),
+      iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+      iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+      metric_(
+          Bfield ? dynamic_cast<const metric_connected*>(Bfield->metric())
+                 : nullptr),
+      my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
+  // test if fields exist
+  // if(!Efield) error(__func__, __FILE__, __LINE__,
+  // 	    " Efield cannot be nullptr.", 1);
+  if (!Bfield)
+    error(__func__, __FILE__, __LINE__, " Bfield cannot be nullptr.", 1);
 
-	// test if fields exist
-	// if(!Efield) error(__func__, __FILE__, __LINE__, 
-	// 	    " Efield cannot be nullptr.", 1);
-	if(!Bfield) error(__func__, __FILE__, __LINE__, 
-		    " Bfield cannot be nullptr.", 1);
+  // test if metrics are the same
+  if (Efield) {
+    const metric_covariant* Emetric = Efield->metric();
+    const metric_covariant* Bmetric = Bfield->metric();
+    if (Emetric != Bmetric)
+      error(
+          __func__, __FILE__, __LINE__,
+          " Efield and Bfield must be in the same coordinate representation.",
+          1);
+  }
 
-	// test if metrics are the same
-	if(Efield) {
-		const metric_covariant *Emetric = Efield->metric();
-		const metric_covariant *Bmetric = Bfield->metric();
-		if(Emetric != Bmetric) error(__func__, __FILE__, __LINE__, 
-			" Efield and Bfield must be in the same coordinate representation.", 1);
-	}
+  // ensure that the field metrics derive from metric_connected
+  if (!metric_)
+    error(
+        __func__, __FILE__, __LINE__,
+        " field metrics must derive from 'gyronimo::metric_connected'.", 1);
 
-	// ensure that the field metrics derive from metric_connected
-	if(!metric_) error(__func__, __FILE__, __LINE__, 
-		" field metrics must derive from 'gyronimo::metric_connected'.", 1);
-
-	// test if normalization factors are consistent
-	if(Efield) {
-		double E_m_factor = Efield->m_factor();
-		double B_m_factor = Bfield->m_factor();
-		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
-			error(__func__, __FILE__, __LINE__, 
-				" inconsistent Efield and Bfield normalization.", 1);
-	}
+  // test if normalization factors are consistent
+  if (Efield) {
+    double E_m_factor = Efield->m_factor();
+    double B_m_factor = Bfield->m_factor();
+    if (std::abs(1.0 - E_m_factor / (Vref_ * B_m_factor)) > 1.0e-14)
+      error(
+          __func__, __FILE__, __LINE__,
+          " inconsistent Efield and Bfield normalization.", 1);
+  }
 }
 
 //! Performs a time step `dt` update to the state `in` and returns the result.
 curvilinear_boris::state curvilinear_boris::do_step(
-		const state &in, const double &time, const double &dt) const {
-	
-	// extract position and velocity from state
-	IR3 q_old = {in[0], in[1], in[2]};
-	IR3 v_old = {in[3], in[4], in[5]};
-	dIR3 e_old = my_morphism_->del(q_old);
+    const state& in, const double& time, const double& dt) const {
+  // extract position and velocity from state
+  IR3 q_old = {in[0], in[1], in[2]};
+  IR3 v_old = {in[3], in[4], in[5]};
+  dIR3 e_old = my_morphism_->del(q_old);
 
-	// calculate fields
-	IR3 Efield = {0.0, 0.0, 0.0};
-	if(electric_field_) {
-		double Etime = time * iEfield_time_factor_;
-		IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
-		Efield = contraction<second>(e_old, E_contravariant);
-	}
-	double Btime = time * iBfield_time_factor_;
-	IR3 Bfield_contravariant = magnetic_field_->contravariant(q_old, Btime);
-	IR3 Bfield = contraction<second>(e_old, Bfield_contravariant);
-	double Bmag = std::sqrt(inner_product(Bfield, Bfield));
-    IR3 Bversor = Bfield / Bmag;
+  // calculate fields
+  IR3 Efield = {0.0, 0.0, 0.0};
+  if (electric_field_) {
+    double Etime = time * iEfield_time_factor_;
+    IR3 E_contravariant = electric_field_->contravariant(q_old, Etime);
+    Efield = contraction<second>(e_old, E_contravariant);
+  }
+  double Btime = time * iBfield_time_factor_;
+  IR3 Bfield_contravariant = magnetic_field_->contravariant(q_old, Btime);
+  IR3 Bfield = contraction<second>(e_old, Bfield_contravariant);
+  double Bmag = std::sqrt(inner_product(Bfield, Bfield));
+  IR3 Bversor = Bfield / Bmag;
 
-	// perform cartesian_boris step
-	IR3 v_new = electric_field_ ? 
-		boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt) :
-		boris_push(v_old, Oref_, Bmag, Bversor, dt);
+  // perform cartesian_boris step
+  IR3 v_new = electric_field_
+      ? boris_push(v_old, Oref_, Efield, Bmag, Bversor, dt)
+      : boris_push(v_old, Oref_, Bmag, Bversor, dt);
 
-	IR3 u_half = my_morphism_->to_contravariant(v_new, q_old);
-	IR3 q_half = q_old + (0.5*Lref_*dt) * u_half;
-	IR3 u_new = my_morphism_->to_contravariant(v_new, q_half);
-	IR3 q_new = q_old + (Lref_*dt) * u_new;
+  IR3 u_half = my_morphism_->to_contravariant(v_new, q_old);
+  IR3 q_half = q_old + (0.5 * Lref_ * dt) * u_half;
+  IR3 u_new = my_morphism_->to_contravariant(v_new, q_half);
+  IR3 q_new = q_old + (Lref_ * dt) * u_new;
 
-	return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
-			v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
+  return {q_new[IR3::u], q_new[IR3::v], q_new[IR3::w],
+          v_new[IR3::u], v_new[IR3::v], v_new[IR3::w]};
 }
 
 //! Returns the `curvilinear_boris::state` state from a point in SI phase-space.
-curvilinear_boris::state curvilinear_boris::generate_state(const IR3 &pos, const IR3 &vel) const {
-	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
-			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+curvilinear_boris::state curvilinear_boris::generate_state(
+    const IR3& pos, const IR3& vel) const {
+  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+          vel[IR3::u], vel[IR3::v], vel[IR3::w]};
 }
 
 //! Returns the vector position of the `curvilinear_boris::state`.
-IR3 curvilinear_boris::get_position(const state &s) const {
-	return {s[0], s[1], s[2]};
+IR3 curvilinear_boris::get_position(const state& s) const {
+  return {s[0], s[1], s[2]};
 }
 
-//! Returns the vector velocity of the `curvilinear_boris::state`, normalized to `Vref`.
-IR3 curvilinear_boris::get_velocity(const state &s) const {
-	IR3 q_pos = {s[0], s[1], s[2]};
-	IR3 vel_cartesian = {s[3], s[4], s[5]};
-	IR3 vel_contravariant = my_morphism_->to_contravariant(vel_cartesian, q_pos);
-	return vel_contravariant;
+//! Returns the vector velocity of the `curvilinear_boris::state`, normalized to
+//! `Vref`.
+IR3 curvilinear_boris::get_velocity(const state& s) const {
+  IR3 q_pos = {s[0], s[1], s[2]};
+  IR3 vel_cartesian = {s[3], s[4], s[5]};
+  IR3 vel_contravariant = my_morphism_->to_contravariant(vel_cartesian, q_pos);
+  return vel_contravariant;
 }
 
 //! Returns the kinetic energy of the state, normalized to `Uref`.
-double curvilinear_boris::energy_kinetic(const state &s) const {
-	return s[3]*s[3] + s[4]*s[4] + s[5]*s[5];
+double curvilinear_boris::energy_kinetic(const state& s) const {
+  return s[3] * s[3] + s[4] * s[4] + s[5] * s[5];
 }
 
 //! Returns the parallel energy of the state, normalized to `Uref`.
-double curvilinear_boris::energy_parallel(const state &s, double &time) const {
-	IR3 q_pos = {s[0], s[1], s[2]};
-	IR3 vel = {s[3], s[4], s[5]};
-	double Btime = time * iBfield_time_factor_;
-	IR3 b_contravariant = magnetic_field_->contravariant_versor(q_pos, Btime);
-	IR3 b_cartesian = my_morphism_->from_contravariant(b_contravariant, q_pos);
-	double vpar = inner_product(vel, b_cartesian);
-	return vpar*vpar;
+double curvilinear_boris::energy_parallel(const state& s, double& time) const {
+  IR3 q_pos = {s[0], s[1], s[2]};
+  IR3 vel = {s[3], s[4], s[5]};
+  double Btime = time * iBfield_time_factor_;
+  IR3 b_contravariant = magnetic_field_->contravariant_versor(q_pos, Btime);
+  IR3 b_cartesian = my_morphism_->from_contravariant(b_contravariant, q_pos);
+  double vpar = inner_product(vel, b_cartesian);
+  return vpar * vpar;
 }
 
 //! Returns the perpendicular energy of the state, normalized to `Uref`.
-double curvilinear_boris::energy_perpendicular(const state &s, double &time) const {
-	IR3 q_pos = {s[0], s[1], s[2]};
-	IR3 vel = {s[3], s[4], s[5]};
-	double Btime = time * iBfield_time_factor_;
-	IR3 Bversor_con = magnetic_field_->contravariant_versor(q_pos, Btime);
-	IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q_pos);
-	IR3 vperp = cross_product(vel, Bversor);
-	return inner_product(vperp, vperp);
+double curvilinear_boris::energy_perpendicular(
+    const state& s, double& time) const {
+  IR3 q_pos = {s[0], s[1], s[2]};
+  IR3 vel = {s[3], s[4], s[5]};
+  double Btime = time * iBfield_time_factor_;
+  IR3 Bversor_con = magnetic_field_->contravariant_versor(q_pos, Btime);
+  IR3 Bversor = my_morphism_->from_contravariant(Bversor_con, q_pos);
+  IR3 vperp = cross_product(vel, Bversor);
+  return inner_product(vperp, vperp);
 }
 
 curvilinear_boris::state curvilinear_boris::generate_initial_state(
-		const IR3 &pos, const IR3 &vel, const double &time, const double &dt) const {
+    const IR3& pos, const IR3& vel, const double& time,
+    const double& dt) const {
+  // state s0 = {
+  // 	pos[IR3::u], pos[IR3::v], pos[IR3::w],
+  // 	vel[IR3::u], vel[IR3::v], vel[IR3::w]
+  // };
+  // state s1 = do_step(s0, time, -0.5*dt);
 
-	// state s0 = {
-	// 	pos[IR3::u], pos[IR3::v], pos[IR3::w],
-	// 	vel[IR3::u], vel[IR3::v], vel[IR3::w]
-	// };
-	// state s1 = do_step(s0, time, -0.5*dt);
+  // return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
 
-	// return {s0[0], s0[1], s0[2], s1[3], s1[4], s1[5]};
+  lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
+  odeint_adapter<gyronimo::lorentz> sys(&lo);
+  boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
+  IR3 vel_con = my_morphism_->to_contravariant(vel, pos);
+  lorentz::state inout = {pos[IR3::u],     pos[IR3::v],     pos[IR3::w],
+                          vel_con[IR3::u], vel_con[IR3::v], vel_con[IR3::w]};
+  rk4.do_step(sys, inout, time, -0.5 * dt);
+  IR3 qmh = {inout[0], inout[1], inout[2]};
+  IR3 vmh_con = {inout[3], inout[4], inout[5]};
+  IR3 vmh = my_morphism_->from_contravariant(vmh_con, qmh);
 
-    lorentz lo(Lref_, Vref_, qom_, electric_field_, magnetic_field_);
-    odeint_adapter<gyronimo::lorentz> sys(&lo);
-    boost::numeric::odeint::runge_kutta4<gyronimo::lorentz::state> rk4;
-    IR3 vel_con = my_morphism_->to_contravariant(vel, pos);
-	lorentz::state inout = {
-		pos[IR3::u], pos[IR3::v], pos[IR3::w],
-		vel_con[IR3::u], vel_con[IR3::v], vel_con[IR3::w]
-	};
-	rk4.do_step(sys, inout, time, -0.5*dt);
-    IR3 qmh = {inout[0], inout[1], inout[2]};
-    IR3 vmh_con = {inout[3], inout[4], inout[5]};
-    IR3 vmh = my_morphism_->from_contravariant(vmh_con, qmh);
-
-	return {pos[IR3::u], pos[IR3::v], pos[IR3::w], 
-            vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
+  return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+          vmh[IR3::u], vmh[IR3::v], vmh[IR3::w]};
 }
 
-} // end namespace gyronimo
+}  // end namespace gyronimo

--- a/gyronimo/dynamics/curvilinear_boris.cc
+++ b/gyronimo/dynamics/curvilinear_boris.cc
@@ -40,6 +40,7 @@ curvilinear_boris::curvilinear_boris(
       electric_field_(E), magnetic_field_(B),
       iE_time_factor_(E ? Tref_ / E->t_factor() : 1),
       iB_time_factor_(B ? Tref_ / B->t_factor() : 1),
+      tildeEref_(E && B ? Oref_ * E->m_factor() / (B->m_factor() * Vref_) : 1),
       metric_(B ? dynamic_cast<const metric_connected*>(B->metric()) : nullptr),
       my_morphism_(metric_ ? metric_->my_morphism() : nullptr) {
   if (!B) error(__func__, __FILE__, __LINE__, "no magnetic field.", 1);
@@ -53,7 +54,6 @@ curvilinear_boris::curvilinear_boris(
 curvilinear_boris::state curvilinear_boris::do_step(
     const state& s, const double& time, const double& dt) const {
   double Btime = time * iB_time_factor_;
-  const double tildeEref = Oref_ * iB_time_factor_ / (iE_time_factor_ * Vref_);
 
   IR3 q = this->get_position(s), v = this->get_velocity(s);
   double B = magnetic_field_->magnitude(q, Btime);
@@ -65,7 +65,7 @@ curvilinear_boris::state curvilinear_boris::do_step(
       IR3 {0, 0, 0};
 
   IR3 updated_v = electric_field_ ?
-      boris_push(v, Oref_, tildeEref, E, B, b, dt) :
+      boris_push(v, Oref_, tildeEref_, E, B, b, dt) :
       boris_push(v, Oref_, B, b, dt);
   IR3 dot_q_temporary = my_morphism_->to_contravariant(updated_v, q);
   IR3 q_temporary = q + (0.5 * Lref_ * dt) * dot_q_temporary;

--- a/gyronimo/dynamics/curvilinear_boris.hh
+++ b/gyronimo/dynamics/curvilinear_boris.hh
@@ -1,0 +1,89 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @curvilinear_boris.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_CURVILINEAR_BORIS
+#define GYRONIMO_CURVILINEAR_BORIS
+
+#include <gyronimo/fields/IR3field.hh>
+#include <gyronimo/metrics/morphism.hh>
+#include <gyronimo/metrics/metric_connected.hh>
+
+namespace gyronimo {
+
+//! Gyronimo implementation for curvilinear boris stepper class.
+/*!
+	This class implements the curvilinear boris pusher 
+	[Journal of Plasma Physics, Volume 61, Issue 3, April 1999, pp. 367 - 389].
+	This class mixes the typical Cartesian boris push with a Runge-Kutta 2 advance
+	in curvilinear coordinates. To achieve this, field representation is only 
+	constrained to metrics of the type `metric_connected` to be able to convert 
+	coordinates and vectors using the connected `morphism`.
+	To use the classical boris pusher in curvilinear coordinates, look at
+	`classical_boris` class.
+*/
+class curvilinear_boris {
+public:
+	using state = std::array<double,6>;
+
+	curvilinear_boris(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield);
+	~curvilinear_boris() {};
+
+	state do_step(const state &in, const double &time, const double &dt) const;
+
+	state generate_state(const IR3 &pos, const IR3 &vel) const;
+	IR3 get_position(const state &s) const;
+	IR3 get_velocity(const state &s) const;
+
+	double energy_kinetic(const state &s) const;
+	double energy_parallel(const state &s, double &time) const;
+	double energy_perpendicular(const state &s, double &time) const;
+
+	state generate_initial_state(
+		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+		const double &t, const double &dt) const;
+
+	const IR3field* electric_field() const {return electric_field_;};
+	const IR3field* magnetic_field() const {return magnetic_field_;};
+	const morphism* morph() const {return morph_;};
+
+	//! Returns the reference length scale `Lref`.
+	double Lref() const {return Lref_;};
+	//! Returns the reference time scale `Tref`.
+	double Tref() const {return Tref_;};
+	//! Returns the reference velocity scale `Vref`.
+	double Vref() const {return Vref_;};
+	//! Returns the reference frequency scale `Oref`.
+	double Oref() const {return Oref_;};
+	//! Returns the charge-over-mass ratio.
+	double qom() const {return qom_;};
+
+private:
+
+	const double Lref_, Vref_, Tref_, qom_, Oref_;
+	const IR3field *electric_field_, *magnetic_field_;
+	const double iEfield_time_factor_, iBfield_time_factor_;
+	const metric_connected *metric_;
+	const morphism *morph_;
+
+}; // end class curvilinear_boris
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_CURVILINEAR_BORIS

--- a/gyronimo/dynamics/curvilinear_boris.hh
+++ b/gyronimo/dynamics/curvilinear_boris.hh
@@ -21,68 +21,67 @@
 #define GYRONIMO_CURVILINEAR_BORIS
 
 #include <gyronimo/fields/IR3field.hh>
-#include <gyronimo/metrics/morphism.hh>
 #include <gyronimo/metrics/metric_connected.hh>
+#include <gyronimo/metrics/morphism.hh>
 
 namespace gyronimo {
 
 //! Gyronimo implementation for curvilinear boris stepper class.
 /*!
-	This class implements the curvilinear boris pusher 
-	[Journal of Plasma Physics, Volume 61, Issue 3, April 1999, pp. 367 - 389].
-	This class mixes the typical Cartesian boris push with a Runge-Kutta 2 advance
-	in curvilinear coordinates. To achieve this, field representation is only 
-	constrained to metrics of the type `metric_connected` to be able to convert 
-	coordinates and vectors using the connected `morphism`.
-	To use the classical boris pusher in curvilinear coordinates, look at
-	`classical_boris` class.
+        This class implements the curvilinear boris pusher
+        [Journal of Plasma Physics, Volume 61, Issue 3, April 1999, pp. 367 -
+   389]. This class mixes the typical Cartesian boris push with a Runge-Kutta 2
+   advance in curvilinear coordinates. To achieve this, field representation is
+   only constrained to metrics of the type `metric_connected` to be able to
+   convert coordinates and vectors using the connected `morphism`. To use the
+   classical boris pusher in curvilinear coordinates, look at `classical_boris`
+   class.
 */
 class curvilinear_boris {
-public:
-	using state = std::array<double,6>;
+ public:
+  using state = std::array<double, 6>;
 
-	curvilinear_boris(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield);
-	~curvilinear_boris() {};
+  curvilinear_boris(
+      const double& Lref, const double& Vref, const double& qom,
+      const IR3field* Efield, const IR3field* Bfield);
+  ~curvilinear_boris() {};
 
-	state do_step(const state &in, const double &time, const double &dt) const;
+  state do_step(const state& in, const double& time, const double& dt) const;
 
-	state generate_state(const IR3 &pos, const IR3 &vel) const;
-	IR3 get_position(const state &s) const;
-	IR3 get_velocity(const state &s) const;
+  state generate_state(const IR3& pos, const IR3& vel) const;
+  IR3 get_position(const state& s) const;
+  IR3 get_velocity(const state& s) const;
 
-	double energy_kinetic(const state &s) const;
-	double energy_parallel(const state &s, double &time) const;
-	double energy_perpendicular(const state &s, double &time) const;
+  double energy_kinetic(const state& s) const;
+  double energy_parallel(const state& s, double& time) const;
+  double energy_perpendicular(const state& s, double& time) const;
 
-	state generate_initial_state(const IR3 &pos, const IR3 &vel, 
-		const double &t, const double &dt) const;
+  state generate_initial_state(
+      const IR3& pos, const IR3& vel, const double& t, const double& dt) const;
 
-	const IR3field* electric_field() const {return electric_field_;};
-	const IR3field* magnetic_field() const {return magnetic_field_;};
-	const morphism* my_morphism() const {return my_morphism_;};
+  const IR3field* electric_field() const { return electric_field_; };
+  const IR3field* magnetic_field() const { return magnetic_field_; };
+  const morphism* my_morphism() const { return my_morphism_; };
 
-	//! Returns the reference length scale `Lref`.
-	double Lref() const {return Lref_;};
-	//! Returns the reference time scale `Tref`.
-	double Tref() const {return Tref_;};
-	//! Returns the reference velocity scale `Vref`.
-	double Vref() const {return Vref_;};
-	//! Returns the reference frequency scale `Oref`.
-	double Oref() const {return Oref_;};
-	//! Returns the charge-over-mass ratio.
-	double qom() const {return qom_;};
+  //! Returns the reference length scale `Lref`.
+  double Lref() const { return Lref_; };
+  //! Returns the reference time scale `Tref`.
+  double Tref() const { return Tref_; };
+  //! Returns the reference velocity scale `Vref`.
+  double Vref() const { return Vref_; };
+  //! Returns the reference frequency scale `Oref`.
+  double Oref() const { return Oref_; };
+  //! Returns the charge-over-mass ratio.
+  double qom() const { return qom_; };
+ private:
+  const double Lref_, Vref_, Tref_, qom_, Oref_;
+  const IR3field *electric_field_, *magnetic_field_;
+  const double iEfield_time_factor_, iBfield_time_factor_;
+  const metric_connected* metric_;
+  const morphism* my_morphism_;
 
-private:
+};  // end class curvilinear_boris
 
-	const double Lref_, Vref_, Tref_, qom_, Oref_;
-	const IR3field *electric_field_, *magnetic_field_;
-	const double iEfield_time_factor_, iBfield_time_factor_;
-	const metric_connected *metric_;
-	const morphism *my_morphism_;
+}  // end namespace gyronimo
 
-}; // end class curvilinear_boris
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_CURVILINEAR_BORIS
+#endif  // GYRONIMO_CURVILINEAR_BORIS

--- a/gyronimo/dynamics/curvilinear_boris.hh
+++ b/gyronimo/dynamics/curvilinear_boris.hh
@@ -91,7 +91,7 @@ class curvilinear_boris {
  private:
   const double Lref_, Vref_, Tref_, qom_, Oref_;
   const IR3field *electric_field_, *magnetic_field_;
-  const double iE_time_factor_, iB_time_factor_;
+  const double iE_time_factor_, iB_time_factor_, tildeEref_;
   const metric_connected* metric_;
   const morphism* my_morphism_;
 };

--- a/gyronimo/dynamics/curvilinear_boris.hh
+++ b/gyronimo/dynamics/curvilinear_boris.hh
@@ -55,13 +55,12 @@ public:
 	double energy_parallel(const state &s, double &time) const;
 	double energy_perpendicular(const state &s, double &time) const;
 
-	state generate_initial_state(
-		const IR3 &cartesian_position, const IR3 &cartesian_velocity, 
+	state generate_initial_state(const IR3 &pos, const IR3 &vel, 
 		const double &t, const double &dt) const;
 
 	const IR3field* electric_field() const {return electric_field_;};
 	const IR3field* magnetic_field() const {return magnetic_field_;};
-	const morphism* morph() const {return morph_;};
+	const morphism* my_morphism() const {return my_morphism_;};
 
 	//! Returns the reference length scale `Lref`.
 	double Lref() const {return Lref_;};
@@ -80,7 +79,7 @@ private:
 	const IR3field *electric_field_, *magnetic_field_;
 	const double iEfield_time_factor_, iBfield_time_factor_;
 	const metric_connected *metric_;
-	const morphism *morph_;
+	const morphism *my_morphism_;
 
 }; // end class curvilinear_boris
 

--- a/gyronimo/dynamics/guiding_centre.cc
+++ b/gyronimo/dynamics/guiding_centre.cc
@@ -68,7 +68,7 @@ guiding_centre::state guiding_centre::operator()(
 // and \partial_t(\vec{B}) = B \partial_t(\vec{b}) + \vec{b}\partial_t B.
   IR3 curlb = inverseB*(
       Lref_*magnetic_field_->curl(position, Btime) -
-      cross_product(gradB, covariant_b, jacobian));
+      cross_product<contravariant>(gradB, covariant_b, jacobian));
   IR3 partial_t_b = inverseB*(
       Bfield_time_factor_*magnetic_field_->partial_t_covariant(
           position, Btime) -
@@ -83,7 +83,7 @@ guiding_centre::state guiding_centre::operator()(
 
   IR3 dot_X = prefactor*(vpp*contravariant_b +
       inverse_omega_tilde*(
-          vpp*vpp*curlb + cross_product(covariant_b, drifter, jacobian)));
+          vpp*vpp*curlb + cross_product<contravariant>(covariant_b, drifter, jacobian)));
   double dot_vpp = -prefactor*inner_product(
       contravariant_b + inverse_omega_tilde*vpp*curlb, drifter);
   return {dot_X[IR3::u], dot_X[IR3::v], dot_X[IR3::w], dot_vpp};

--- a/gyronimo/dynamics/lorentz.cc
+++ b/gyronimo/dynamics/lorentz.cc
@@ -1,0 +1,142 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @lorentz.cc, this file is part of ::gyronimo::
+
+#include <gyronimo/dynamics/lorentz.hh>
+#include <cmath>
+#include <gyronimo/core/error.hh>
+#include <gyronimo/core/codata.hh>
+#include <gyronimo/core/contraction.hh>
+
+namespace gyronimo {
+
+//! Class constructor.
+/*!
+	Takes a reference length `Lref`, a reference velocity `Vref`, 
+	the charge-over-mass ratio `qom`, an electric field `Efield`
+	and a magnetic field `Bfield`. The fields `Efield` and `Bfield`
+	cannot be `nullptr`. For null fields, create an IR3field that
+	returns zero in the contravariant components.
+*/
+lorentz::lorentz(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield)
+		: Lref_(Lref), Vref_(Vref), Tref_(Lref/Vref), 
+		Oref_(Bfield ? qom * codata::e / 
+			codata::m_proton * Bfield->m_factor() * Tref_ : 1.0), 
+		electric_field_(Efield), magnetic_field_(Bfield),
+		iEfield_time_factor_(Efield ? Tref_ / Efield->t_factor() : 1.0),
+		iBfield_time_factor_(Bfield ? Tref_ / Bfield->t_factor() : 1.0),
+		metric_(Bfield ? Bfield->metric() : nullptr) {
+
+	// test if fields exist
+	// if(!Efield) error(__func__, __FILE__, __LINE__, 
+	//             " Efield cannot be nullptr.", 1);
+	if(!Bfield) error(__func__, __FILE__, __LINE__, 
+	            " Bfield cannot be nullptr.", 1);
+
+	if(Efield) {
+		// test if fields are in the same coordinates
+		const metric_covariant *Emetric = Efield->metric();
+		const metric_covariant *Bmetric = Bfield->metric();
+		if(Emetric != Bmetric)
+			error(__func__, __FILE__, __LINE__, 
+				" Efield and Bfield must be in the same coordinates.", 1);
+
+		// test if normalization factors are consistent
+		double E_m_factor = Efield->m_factor();
+		double B_m_factor = Bfield->m_factor();
+		if(std::abs(1.0 - E_m_factor/(Vref_*B_m_factor)) > 1.0e-14)
+			error(__func__, __FILE__, __LINE__, 
+				" inconsistent Efield and Bfield.", 1);
+	}
+}
+
+//! Calculates the dynamic system `dx` for a particle in state `state`, at time `t`.
+lorentz::state lorentz::operator()(const state &s, const double &time) const {
+
+	// extract position and velocity
+	IR3 q = {s[0], s[1], s[2]};
+	IR3 v = {s[3], s[4], s[5]};
+	
+	IR3 dq = Lref_ * v;
+	IR3 dv = Lref_ * metric_->inertial_force(q, v);
+
+	if(electric_field_) {
+		double Etime = time * iEfield_time_factor_;
+		dv += Oref_ * electric_field_->contravariant(q, Etime);
+	}
+	if(magnetic_field_) {
+		double Btime = time * iBfield_time_factor_;
+		IR3 B = magnetic_field_->contravariant(q, Btime);
+		double jacobian = metric_->jacobian(q);
+		IR3 vxB_covariant = cross_product<covariant>(v, B, jacobian);
+		IR3 vxB = metric_->to_contravariant(vxB_covariant, q);
+		dv += Oref_ * vxB;
+	}
+
+	return {dq[IR3::u], dq[IR3::v], dq[IR3::w],
+	        dv[IR3::u], dv[IR3::v], dv[IR3::w]};
+}
+
+//! Generates a `lorentz::state` from curvilinear position `pos` and velocity `vel`.
+lorentz::state lorentz::generate_state(const IR3 &pos, const IR3 &vel) const {
+	return {pos[IR3::u], pos[IR3::v], pos[IR3::w],
+			vel[IR3::u], vel[IR3::v], vel[IR3::w]};
+}
+
+//! Extracts the position from a `lorentz::state`.
+IR3 lorentz::get_position(const state &s) const {
+	return {s[0], s[1], s[2]};
+}
+
+//! Extracts the velocity from a `lorentz::state`, normalized to `Vref`.
+IR3 lorentz::get_velocity(const state &s) const {
+	return {s[3], s[4], s[5]};
+}
+
+//! Returns the kinetic energy of the state, normalized to `Uref`.
+double lorentz::energy_kinetic(const state &s) const {
+	IR3 pos   = {s[0], s[1], s[2]};
+	IR3 v_con = {s[3], s[4], s[5]};
+	IR3 v_cov = metric_->to_covariant(v_con, pos);
+	return inner_product(v_cov, v_con);
+}
+
+//! Returns the parallel energy of the state, normalized to `Uref`.
+double lorentz::energy_parallel(const state &s, const double &time) const {
+	IR3 q = {s[0], s[1], s[2]};
+	IR3 v_con = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 b_cov = magnetic_field_->covariant_versor(q, Btime);
+	double vpar = inner_product(v_con, b_cov);
+	return vpar*vpar;
+}
+
+//! Returns the perpendicular energy of the state, normalized to `Uref`.
+double lorentz::energy_perpendicular(const state &s, const double &time) const {
+	IR3 q = {s[0], s[1], s[2]};
+	IR3 v_con = {s[3], s[4], s[5]};
+	double Btime = time * iBfield_time_factor_;
+	IR3 b_con = magnetic_field_->contravariant_versor(q, Btime);
+	double jacobian = metric_->jacobian(q);
+	IR3 vperp_cov = cross_product<covariant>(v_con, b_con, jacobian);
+	IR3 vperp_con = metric_->to_contravariant(vperp_cov, q);
+	return inner_product(vperp_cov, vperp_con);
+}
+
+} // end namespace gyronimo

--- a/gyronimo/dynamics/lorentz.hh
+++ b/gyronimo/dynamics/lorentz.hh
@@ -1,0 +1,106 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2022 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @lorentz.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_LORENTZ
+#define GYRONIMO_LORENTZ
+
+#include <typeinfo>
+#include <gyronimo/fields/IR3field.hh>
+
+namespace gyronimo {
+
+//! Equations of motion for a charged particle on a background electromagnetic field in curvilinear coordinates.
+/*!
+    Defines the equations of motion for a charged particle in an electromagnetic field 
+	in a general set of curvilinear coordinates,
+    @f{gather*}{
+		\frac{dq^\alpha}{d\tau} = L_{ref} \, v^\alpha \\
+		\frac{d\tilde{v}^\alpha}{d\tau} = \Omega_{ref} 
+			\left( \tilde{E}^\alpha + 
+				J \, \varepsilon_{ijk} \, \tilde{v}^i \, \tilde{B}^j \, g^{k\alpha} \right)
+			- L_{ref} \, \Gamma^\alpha_{\beta\gamma} \, \tilde{v}^\beta \, \tilde{v}^\gamma
+    @f}
+    All variables are adimensional: the position @f$ q^\alpha @f$ of the particle 
+	is defined by the coordinate transformation (which can be defined with normalization), 
+    the time is normalized to `Tref` with @f$ t=T_{ref}\,\tau @f$, and the
+    velocity to `Vref`=`Lref`/`Tref` with @f$ v^\alpha=V_{ref}\,\tilde{v}^\alpha @f$. 
+	Reference length and reference velocity are supplied to the constructor in SI units, 
+	other normalisations are done internally assuming *bona-fide* electromagnetic fields derived from
+    `IR3field`, with @f$ \tilde{E} = E/E_{ref} @f$ and @f$ \tilde{B} = B/B_{ref} @f$
+	as long as Faraday's law is respected: @f$ V_{ref} = E_{ref} / B_{ref} @f$
+    where the ratio between the reference magnitudes of the electric and magnetic
+    fields need to match `Vref`. Other normalisations are the reference frequency `Oref`
+	with @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$ and the
+	reference kinetic energy `Uref` with @f$ U_{ref} = \frac{1}{2} m_s V_{ref}^2 @f$.
+
+    The equations are implemented in a coordinate-invariant form and will work
+    out-of-the-box with any coordinates defined in the `metric_covariant` object
+    pointed to by the electromagnetic fields. This approach takes advantage of
+    all tensor and differential calculus machinery already implemented in
+    `metric_covariant` and `IR3field`, which can eventually be
+    specialised and optimised in further derived classes. The type
+    `lorentz::state_type` implements the state of the dynamical system,
+    storing the three contravariant components of the particle
+    position @f$ q^\alpha @f$ and of the normalised velocity @f$ \tilde{v}^\alpha @f$. Member
+    functions are provided to convert between `lorentz::state_type` values, `IR3` positions,
+    and `IR3` velocities [`get_position(state_type)`, `get_velocity(state_type)`,
+    `generate_state(...)`].
+*/
+class lorentz {
+public:
+	using state = std::array<double, 6>;
+
+	lorentz(const double &Lref, const double &Vref, 
+		const double &qom, const IR3field *Efield, const IR3field *Bfield);
+	~lorentz() {};
+
+	state operator()(const state &s, const double &time) const;
+
+	state generate_state(const IR3& pos, const IR3 &vel) const;
+	IR3 get_position(const state &s) const;
+	IR3 get_velocity(const state &s) const;
+
+	double energy_kinetic(const state &s) const;
+	double energy_parallel(const state &s, const double &time) const;
+	double energy_perpendicular(const state &s, const double &time) const;
+
+	const IR3field* electric_field() const {return electric_field_;};
+	const IR3field* magnetic_field() const {return magnetic_field_;};
+
+	//! Returns the reference frequency scale `Oref`.
+	double Oref() const {return Oref_;};
+	//! Returns the reference length scale `Lref`.
+	double Lref() const {return Lref_;};
+	//! Returns the reference time scale `Tref`.
+	double Tref() const {return Tref_;};
+	//! Returns the reference velocity scale `Vref`.
+	double Vref() const {return Vref_;};
+
+private:
+
+	const double Lref_, Vref_, Tref_, Oref_;
+	const IR3field *electric_field_, *magnetic_field_;
+	const double iEfield_time_factor_, iBfield_time_factor_;
+	const metric_covariant *metric_;
+
+}; // end class lorentz
+
+} // end namespace gyronimo
+
+#endif // GYRONIMO_LORENTZ

--- a/gyronimo/dynamics/lorentz.hh
+++ b/gyronimo/dynamics/lorentz.hh
@@ -20,87 +20,87 @@
 #ifndef GYRONIMO_LORENTZ
 #define GYRONIMO_LORENTZ
 
-#include <typeinfo>
 #include <gyronimo/fields/IR3field.hh>
+
+#include <typeinfo>
 
 namespace gyronimo {
 
-//! Equations of motion for a charged particle on a background electromagnetic field in curvilinear coordinates.
+//! Equations of motion for a charged particle on a background electromagnetic
+//! field in curvilinear coordinates.
 /*!
-    Defines the equations of motion for a charged particle in an electromagnetic field 
-	in a general set of curvilinear coordinates,
+    Defines the equations of motion for a charged particle in an electromagnetic
+    field in a general set of curvilinear coordinates,
     @f{gather*}{
-		\frac{dq^\alpha}{d\tau} = L_{ref} \, v^\alpha \\
-		\frac{d\tilde{v}^\alpha}{d\tau} = \Omega_{ref} 
-			\left( \tilde{E}^\alpha + 
-				J \, \varepsilon_{ijk} \, \tilde{v}^i \, \tilde{B}^j \, g^{k\alpha} \right)
-			- L_{ref} \, \Gamma^\alpha_{\beta\gamma} \, \tilde{v}^\beta \, \tilde{v}^\gamma
+      \frac{dq^\alpha}{d\tau} = L_{ref} \, v^\alpha \\
+      \frac{d\tilde{v}^\alpha}{d\tau} = \Omega_{ref} \left(
+          \tilde{E}^\alpha + J \, \varepsilon_{ijk} \, \tilde{v}^i \,
+              \tilde{B}^j \, g^{k\alpha} \right) -
+                  L_{ref} \, \Gamma^\alpha_{\beta\gamma} \,
+                      \tilde{v}^\beta \, \tilde{v}^\gamma
     @f}
-    All variables are adimensional: the position @f$ q^\alpha @f$ of the particle 
-	is defined by the coordinate transformation (which can be defined with normalization), 
-    the time is normalized to `Tref` with @f$ t=T_{ref}\,\tau @f$, and the
-    velocity to `Vref`=`Lref`/`Tref` with @f$ v^\alpha=V_{ref}\,\tilde{v}^\alpha @f$. 
-	Reference length and reference velocity are supplied to the constructor in SI units, 
-	other normalisations are done internally assuming *bona-fide* electromagnetic fields derived from
-    `IR3field`, with @f$ \tilde{E} = E/E_{ref} @f$ and @f$ \tilde{B} = B/B_{ref} @f$
-	as long as Faraday's law is respected: @f$ V_{ref} = E_{ref} / B_{ref} @f$
-    where the ratio between the reference magnitudes of the electric and magnetic
-    fields need to match `Vref`. Other normalisations are the reference frequency `Oref`
-	with @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \, T_{ref} @f$ and the
-	reference kinetic energy `Uref` with @f$ U_{ref} = \frac{1}{2} m_s V_{ref}^2 @f$.
+    All variables are adimensional: the position @f$ q^\alpha @f$ of the
+    particle is defined by the coordinate transformation (which can be defined
+    with normalization), the time is normalized to `Tref` with @f$
+    t=T_{ref}\,\tau @f$, and the velocity to `Vref`=`Lref`/`Tref` with @f$
+    v^\alpha=V_{ref}\,\tilde{v}^\alpha @f$. Reference length and reference
+    velocity are supplied to the constructor in SI units, other normalisations
+    are done internally assuming *bona-fide* electromagnetic fields derived from
+    `IR3field`, with @f$ \tilde{E} = E/E_{ref} @f$ and @f$ \tilde{B} = B/B_{ref}
+    @f$ as long as Faraday's law is respected: @f$ V_{ref} = E_{ref} / B_{ref}
+    @f$ where the ratio between the reference magnitudes of the electric and
+    magnetic fields need to match `Vref`. Other normalisations are the reference
+    frequency `Oref` with @f$ \Omega_{ref} = \frac{q_s \, B_{ref}}{m_s} \,
+    T_{ref} @f$ and the reference kinetic energy `Uref` with @f$ U_{ref} =
+    \frac{1}{2} m_s V_{ref}^2 @f$.
 
     The equations are implemented in a coordinate-invariant form and will work
     out-of-the-box with any coordinates defined in the `metric_covariant` object
     pointed to by the electromagnetic fields. This approach takes advantage of
     all tensor and differential calculus machinery already implemented in
-    `metric_covariant` and `IR3field`, which can eventually be
-    specialised and optimised in further derived classes. The type
-    `lorentz::state_type` implements the state of the dynamical system,
-    storing the three contravariant components of the particle
-    position @f$ q^\alpha @f$ and of the normalised velocity @f$ \tilde{v}^\alpha @f$. Member
-    functions are provided to convert between `lorentz::state_type` values, `IR3` positions,
-    and `IR3` velocities [`get_position(state_type)`, `get_velocity(state_type)`,
-    `generate_state(...)`].
+    `metric_covariant` and `IR3field`, which can eventually be specialised and
+    optimised in further derived classes. The type `lorentz::state_type`
+    implements the state of the dynamical system, storing the three
+    contravariant components of the particle position @f$ q^\alpha @f$ and of
+    the normalised velocity @f$ \tilde{v}^\alpha @f$. Member functions are
+    provided to convert between `lorentz::state_type` values, `IR3` positions,
+    and `IR3` velocities [`get_position(state_type)`,
+    `get_velocity(state_type)`, `generate_state(...)`].
 */
 class lorentz {
-public:
-	using state = std::array<double, 6>;
+ public:
+  using state = std::array<double, 6>;
 
-	lorentz(const double &Lref, const double &Vref, 
-		const double &qom, const IR3field *Efield, const IR3field *Bfield);
-	~lorentz() {};
+  lorentz(
+      const double& Lref, const double& Vref, const double& qom,
+      const IR3field* B, const IR3field* E);
+  ~lorentz() {};
 
-	state operator()(const state &s, const double &time) const;
+  state operator()(const state& s, const double& time) const;
 
-	state generate_state(const IR3& pos, const IR3 &vel) const;
-	IR3 get_position(const state &s) const;
-	IR3 get_velocity(const state &s) const;
+  state generate_state(const IR3& q, const IR3& v) const;
+  IR3 get_position(const state& s) const;
+  IR3 get_velocity(const state& s) const;
 
-	double energy_kinetic(const state &s) const;
-	double energy_parallel(const state &s, const double &time) const;
-	double energy_perpendicular(const state &s, const double &time) const;
+  double energy_kinetic(const state& s) const;
+  double energy_parallel(const state& s, const double& time) const;
+  double energy_perpendicular(const state& s, const double& time) const;
 
-	const IR3field* electric_field() const {return electric_field_;};
-	const IR3field* magnetic_field() const {return magnetic_field_;};
+  const IR3field* electric_field() const { return electric_field_; };
+  const IR3field* magnetic_field() const { return magnetic_field_; };
 
-	//! Returns the reference frequency scale `Oref`.
-	double Oref() const {return Oref_;};
-	//! Returns the reference length scale `Lref`.
-	double Lref() const {return Lref_;};
-	//! Returns the reference time scale `Tref`.
-	double Tref() const {return Tref_;};
-	//! Returns the reference velocity scale `Vref`.
-	double Vref() const {return Vref_;};
+  double Oref() const { return Oref_; };
+  double Lref() const { return Lref_; };
+  double Tref() const { return Tref_; };
+  double Vref() const { return Vref_; };
+ private:
+  const double Lref_, Vref_, Tref_, Oref_;
+  const IR3field *electric_field_, *magnetic_field_;
+  const double iE_time_factor_, iB_time_factor_;
+  const metric_covariant* metric_;
 
-private:
+};  // end class lorentz
 
-	const double Lref_, Vref_, Tref_, Oref_;
-	const IR3field *electric_field_, *magnetic_field_;
-	const double iEfield_time_factor_, iBfield_time_factor_;
-	const metric_covariant *metric_;
+}  // end namespace gyronimo
 
-}; // end class lorentz
-
-} // end namespace gyronimo
-
-#endif // GYRONIMO_LORENTZ
+#endif  // GYRONIMO_LORENTZ

--- a/gyronimo/metrics/metric_cartesian.cc
+++ b/gyronimo/metrics/metric_cartesian.cc
@@ -50,6 +50,9 @@ ddIR3 metric_cartesian::christoffel_second_kind(const IR3& r) const {
   return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
           0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 }
+IR3 metric_cartesian::inertial_force(const IR3& r, const IR3& vel) const {
+	return {0.0, 0.0, 0.0};
+}
 IR3 metric_cartesian::to_covariant(const IR3& B, const IR3& r) const {
   return B;
 }

--- a/gyronimo/metrics/metric_cartesian.hh
+++ b/gyronimo/metrics/metric_cartesian.hh
@@ -40,6 +40,7 @@ class metric_cartesian : public metric_connected {
 
   virtual ddIR3 christoffel_first_kind(const IR3& r) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& r) const override;
+  virtual IR3 inertial_force(const IR3& r, const IR3& vel) const;
 
   virtual IR3 to_covariant(const IR3& B, const IR3& r) const override;
   virtual IR3 to_contravariant(const IR3& B, const IR3& r) const override;

--- a/gyronimo/metrics/metric_covariant.cc
+++ b/gyronimo/metrics/metric_covariant.cc
@@ -157,4 +157,15 @@ ddIR3 metric_covariant::christoffel_second_kind(const IR3& r) const {
       this->inverse(r), this->christoffel_first_kind(r));
 }
 
-}  // end namespace gyronimo.
+//! Implementation of the contravariant inertial force
+/*!
+    Implements the rule
+    @f$ F^\alpha = - \Gamma^\alpha_{\beta\gamma} \, v^\beta \, v^\gamma @f$
+    where `vel` must be contravariant
+*/
+IR3 metric_covariant::inertial_force(const IR3& r, const IR3& vel) const {
+  ddIR3 CF2 = christoffel_second_kind(r);
+  return (-1.0)*contraction<second,third>(CF2, vel, vel);
+}
+
+} // end namespace gyronimo.

--- a/gyronimo/metrics/metric_covariant.cc
+++ b/gyronimo/metrics/metric_covariant.cc
@@ -1,6 +1,6 @@
 // ::gyronimo:: - gyromotion for the people, by the people -
 // An object-oriented library for gyromotion applications in plasma physics.
-// Copyright (C) 2021-2022 Paulo Rodrigues and Manuel Assunção.
+// Copyright (C) 2021-2023 Paulo Rodrigues and Manuel Assunção.
 
 // ::gyronimo:: is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -96,10 +96,9 @@ IR3 metric_covariant::to_contravariant(const IR3& B, const IR3& r) const {
 
 //! General-purpose derivative of the inverse metric.
 /*!
-    Implements the rule
-    ```
+    Implements the rule @f$
     \partial_k g^{ij} = - g^{im} \partial_k g_{mn} g^{nj}
-    ```
+    @f$.
 */
 dSM3 metric_covariant::del_inverse(const IR3& r) const {
   SM3 ig = this->inverse(r);
@@ -113,16 +112,15 @@ dSM3 metric_covariant::del_inverse(const IR3& r) const {
 
 //! General-purpose Christoffel symbols of the first kind.
 /*!
-    Implements the rule
-    ```
-    \Gamma_{\alpha\beta\gamma} = \frac{1}{2} \left(
-                \frac{\partial g_{\alpha\beta}}{\partial q^\gamma} +
-                \frac{\partial g_{\alpha\gamma}}{\partial q^\beta} -
-                \frac{\partial g_{\beta\gamma}}{\partial q^\alpha} \right)
-    ```
+    Implements the rule @f$
+    \Gamma_{ijk} = \frac{1}{2} \left(
+                \frac{\partial g_{ij}}{\partial q^k} +
+                \frac{\partial g_{ik}}{\partial q^j} -
+                \frac{\partial g_{jk}}{\partial q^i} \right)
+    @f$.
 */
-ddIR3 metric_covariant::christoffel_first_kind(const IR3& r) const {
-  dSM3 dg = del(r);
+ddIR3 metric_covariant::christoffel_first_kind(const IR3& q) const {
+  dSM3 dg = del(q);
   return {
       0.5 * (dg[dSM3::uuu] + dg[dSM3::uuu] - dg[dSM3::uuu]),  // uuu
       0.5 * (dg[dSM3::uuv] + dg[dSM3::uvu] - dg[dSM3::uvu]),  // uuv
@@ -147,25 +145,20 @@ ddIR3 metric_covariant::christoffel_first_kind(const IR3& r) const {
 
 //! General-purpose Christoffel symbols of the second kind.
 /*!
-    Implements the rule
-    ```
-    \Gamma^\alpha_{\beta\gamma} = g^{\alpha\mu} \, \Gamma_{\mu\beta\gamma}
-    ```
+    Implements the rule @f$ \Gamma^k_{ij} = g^{km} \, \Gamma_{mij} @f$.
 */
-ddIR3 metric_covariant::christoffel_second_kind(const IR3& r) const {
+ddIR3 metric_covariant::christoffel_second_kind(const IR3& q) const {
   return contraction<second, first>(
-      this->inverse(r), this->christoffel_first_kind(r));
+      this->inverse(q), this->christoffel_first_kind(q));
 }
 
-//! Implementation of the contravariant inertial force
+//! Contravariant inertial force.
 /*!
-    Implements the rule
-    @f$ F^\alpha = - \Gamma^\alpha_{\beta\gamma} \, v^\beta \, v^\gamma @f$
-    where `vel` must be contravariant
+    Implements the rule @f$ F^k = - \Gamma^k_{ij} \, \dot{q}^i \, \dot{q}^j @f$.
 */
-IR3 metric_covariant::inertial_force(const IR3& r, const IR3& vel) const {
-  ddIR3 CF2 = christoffel_second_kind(r);
-  return (-1.0)*contraction<second,third>(CF2, vel, vel);
+IR3 metric_covariant::inertial_force(const IR3& q, const IR3& dot_q) const {
+  ddIR3 gamma = christoffel_second_kind(q);
+  return (-1.0)*contraction<second,third>(gamma, dot_q, dot_q);
 }
 
 } // end namespace gyronimo.

--- a/gyronimo/metrics/metric_covariant.hh
+++ b/gyronimo/metrics/metric_covariant.hh
@@ -56,7 +56,7 @@ class metric_covariant {
   virtual ddIR3 christoffel_first_kind(const IR3& r) const;
   virtual ddIR3 christoffel_second_kind(const IR3& r) const;
 
-  virtual IR3 inertial_force(const IR3& r, const IR3& vel) const;
+  virtual IR3 inertial_force(const IR3& q, const IR3& dot_q) const;
 };
 
 }

--- a/gyronimo/metrics/metric_covariant.hh
+++ b/gyronimo/metrics/metric_covariant.hh
@@ -55,6 +55,8 @@ class metric_covariant {
   virtual dSM3 del_inverse(const IR3& r) const;
   virtual ddIR3 christoffel_first_kind(const IR3& r) const;
   virtual ddIR3 christoffel_second_kind(const IR3& r) const;
+
+  virtual IR3 inertial_force(const IR3& r, const IR3& vel) const;
 };
 
 }

--- a/gyronimo/metrics/metric_cylindrical.cc
+++ b/gyronimo/metrics/metric_cylindrical.cc
@@ -60,4 +60,13 @@ ddIR3 metric_cylindrical::christoffel_second_kind(const IR3& q) const {
       1 / q[IR3::u], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 }
 
-}  // end namespace gyronimo
+IR3 metric_cylindrical::inertial_force(const IR3& q, const IR3& vel) const {
+  ddIR3 CF2 = christoffel_second_kind(q);
+  return {
+    -CF2[ddIR3::uvv]*vel[IR3::v]*vel[IR3::v],
+    -2*CF2[ddIR3::vuv]*vel[IR3::u]*vel[IR3::v],
+    0.0
+  };
+}
+
+} // end namespace gyronimo

--- a/gyronimo/metrics/metric_cylindrical.hh
+++ b/gyronimo/metrics/metric_cylindrical.hh
@@ -42,6 +42,7 @@ class metric_cylindrical : public metric_connected {
 
   virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
+  virtual IR3 inertial_force(const IR3& q, const IR3& vel) const;
 
   double Lref() { return Lref_; };
 

--- a/gyronimo/metrics/metric_spherical.cc
+++ b/gyronimo/metrics/metric_spherical.cc
@@ -86,5 +86,14 @@ ddIR3 metric_spherical::christoffel_second_kind(const IR3& q) const {
   return {0, 0, 0, -r, 0, -r * s * s,
       0, ir, 0, 0, 0, -s * c, 0,  0, ir, 0, c / s, 0};
 }
+IR3 metric_spherical::inertial_force(const IR3& q, const IR3& vel) const {
+	ddIR3 CF2 = christoffel_second_kind(q);
+	double Vu = vel[IR3::u], Vv = vel[IR3::v], Vw = vel[IR3::w];
+	return {
+		-(CF2[ddIR3::uvv]*Vv*Vv + CF2[ddIR3::uww]*Vw*Vw),
+		-(2*CF2[ddIR3::vuv]*Vu*Vv + CF2[ddIR3::vww]*Vw*Vw),
+		-2*(CF2[ddIR3::wuw]*Vu + CF2[ddIR3::wvw]*Vv)*Vw,
+	};
+}
 
 }  // end namespace gyronimo.

--- a/gyronimo/metrics/metric_spherical.hh
+++ b/gyronimo/metrics/metric_spherical.hh
@@ -49,6 +49,7 @@ class metric_spherical : public metric_connected {
 
   virtual ddIR3 christoffel_first_kind(const IR3& q) const override;
   virtual ddIR3 christoffel_second_kind(const IR3& q) const override;
+  virtual IR3 inertial_force(const IR3& q, const IR3& vel) const;
 
   double Lref() const { return Lref_; };
 

--- a/gyronimo/metrics/morphism_vmec.cc
+++ b/gyronimo/metrics/morphism_vmec.cc
@@ -112,10 +112,10 @@ dIR3 morphism_vmec::del(const IR3& q) const {
     double cosmn = std::cos(angle_mn), sinmn = std::sin(angle_mn);
     double rmnc_i = (*Rmnc_[i])(s), zmns_i = (*Zmns_[i])(s);
     R += rmnc_i * cosmn; // assuming stellarator symmetry
-    dR_ds += (*Rmnc_[i]).derivative(s) * cosmn;
+    dR_ds += Rmnc_[i]->derivative(s) * cosmn;
     dR_dtheta += m * rmnc_i * sinmn;
     dR_dzeta += n * rmnc_i * sinmn;
-    dZ_ds += (*Zmns_[i]).derivative(s) * sinmn;
+    dZ_ds += Zmns_[i]->derivative(s) * sinmn;
     dZ_dtheta += m * zmns_i * cosmn;
     dZ_dzeta += n * zmns_i * cosmn;
   }
@@ -135,16 +135,16 @@ ddIR3 morphism_vmec::ddel(const IR3& q) const {
   double d2Z_ds2 = 0.0, d2Z_dsdtheta = 0.0, d2Z_dsdzeta = 0.0;
   double d2Z_dzeta2 = 0.0, d2Z_dzetadtheta = 0.0, d2Z_dtheta2 = 0.0;
 
-#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dR_dzeta, d2R_ds2, d2R_dsdtheta, d2R_dsdzeta, d2R_dtheta2, d2R_dthetadzeta, d2R_dzeta2, Z, dZ_ds ,dZ_dtheta, dZ_dzeta, d2Z_ds2, d2Z_dsdtheta, d2Z_dsdzeta, d2Z_dtheta2, d2Z_dthetadzeta, d2Z_dzeta2)
+#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dR_dzeta, d2R_ds2, d2R_dsdtheta, d2R_dsdzeta, d2R_dtheta2, d2R_dzetadtheta, d2R_dzeta2, dZ_ds ,dZ_dtheta, dZ_dzeta, d2Z_ds2, d2Z_dsdtheta, d2Z_dsdzeta, d2Z_dtheta2, d2Z_dzetadtheta, d2Z_dzeta2)
   for (size_t i = 0; i < xm_.size(); ++i) {
     double m = xm_[i], n = xn_[i];
     double cosmn = std::cos(m * theta - n * zeta);
     double sinmn = std::sin(m * theta - n * zeta);
     double rmnc_i = (*Rmnc_[i])(s), zmns_i = (*Zmns_[i])(s);
-    double d_rmnc_i = (*Rmnc_[i]).derivative(s);
-    double d_zmns_i = (*Zmns_[i]).derivative(s);
-    double d2_rmnc_i = (*Rmnc_[i]).derivative2(s);
-    double d2_zmns_i = (*Zmns_[i]).derivative2(s);
+    double d_rmnc_i = Rmnc_[i]->derivative(s);
+    double d_zmns_i = Zmns_[i]->derivative(s);
+    double d2_rmnc_i = Rmnc_[i]->derivative2(s);
+    double d2_zmns_i = Zmns_[i]->derivative2(s);
     R += rmnc_i * cosmn; // assuming stellarator symmetry
     dR_ds += d_rmnc_i * cosmn;
     dR_dzeta += n * rmnc_i * sinmn;
@@ -180,16 +180,16 @@ double morphism_vmec::jacobian(const IR3& q) const {
   double dZ_ds = 0.0, dZ_dtheta = 0.0;
   double sn_zeta = std::sin(zeta), cn_zeta = std::cos(zeta);
 
-#pragma omp parallel for reduction(+: R, Z, dR_ds, dR_dtheta, dR_dzeta, dZ_ds, dZ_dtheta, dZ_dzeta)
+#pragma omp parallel for reduction(+: R, dR_ds, dR_dtheta, dZ_ds, dZ_dtheta)
   for (size_t i = 0; i < xm_.size(); ++i) {
     double m = xm_[i], n = xn_[i];
     double angle_mn = m * theta - n * zeta;
     double cosmn = std::cos(angle_mn), sinmn = std::sin(angle_mn);
     double rmnc_i = (*Rmnc_[i])(s), zmns_i = (*Zmns_[i])(s);
     R += rmnc_i * cosmn; // assuming stellarator symmetry
-    dR_ds += (*Rmnc_[i]).derivative(s) * cosmn;
+    dR_ds += Rmnc_[i]->derivative(s) * cosmn;
     dR_dtheta += m * rmnc_i * sinmn;
-    dZ_ds += (*Zmns_[i]).derivative(s) * sinmn;
+    dZ_ds += Zmns_[i]->derivative(s) * sinmn;
     dZ_dtheta += m * zmns_i * cosmn;
   }
   dR_dtheta = -dR_dtheta;

--- a/gyronimo/metrics/morphism_vmec.hh
+++ b/gyronimo/metrics/morphism_vmec.hh
@@ -44,6 +44,7 @@ class morphism_vmec : public morphism {
   virtual double jacobian(const IR3& q) const override;
 
   const parser_vmec* parser() const { return parser_; };
+  std::pair<double, double> get_rz(const IR3& position) const;
  private:
   const parser_vmec* parser_;
   narray_type xm_, xn_;
@@ -52,7 +53,6 @@ class morphism_vmec : public morphism {
   interpolator1d** Zmns_;
   interpolator1d** gmnc_;
 
-  std::pair<double, double> get_rz(const IR3& position) const;
   std::pair<double, double> reflection_past_axis(double s, double theta) const;
 };
 


### PR DESCRIPTION
Provides support for full-orbit tracing of charged particles subject to the Lorentz force due to electromagnetic fields.
Contributed features:
+ `lorentz` dynamical system compatible with the `odeint` integration library;
+ `cartesian_boris` stepper;
+ `classical_boris` stepper;
+ `curvilinear_boris` stepper;