### PR TITLE
GSL multiroot with user-supplied derivatives

### DIFF
--- a/gyronimo/core/multiroot_c1.hh
+++ b/gyronimo/core/multiroot_c1.hh
@@ -1,0 +1,285 @@
+// ::gyronimo:: - gyromotion for the people, by the people -
+// An object-oriented library for gyromotion applications in plasma physics.
+// Copyright (C) 2023 Manuel Assunção.
+
+// ::gyronimo:: is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// ::gyronimo:: is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
+
+// @multiroot_c1.hh, this file is part of ::gyronimo::
+
+#ifndef GYRONIMO_MULTIROOT_C1
+#define GYRONIMO_MULTIROOT_C1
+
+#include <gyronimo/core/error.hh>
+#include <gyronimo/core/generators.hh>
+
+#include <gsl/gsl_multiroots.h>
+
+#include <algorithm>
+#include <functional>
+#include <span>
+
+namespace gyronimo {
+
+//! Interface to [GSL](https://www.gnu.org/software/gsl) multiroot_c1 solver.
+/*!
+    Examples of the intended usage:
+
+    (1) Recommended Usage:
+    ```
+    container_t guess = {1.0, ..., 2.2};
+    container_t root =
+        multiroot_c1(multiroot_c1::hybridj, 1e-9, 75)(my_root_f, my_root_df, 
+          my_root_fdf, guess);
+    ```
+
+    (2) Simple Usage (Recommended only for cases where the computation of
+    the function cannot be recycled for the computation of the jacobian):
+    ```
+    container_t guess = {1.0, ..., 2.2};
+    container_t root =
+        multiroot_c1(multiroot_c1::gnewton, 1e-9, 75)(my_root_f, my_root_df, 
+          guess);
+    ```
+
+    (2) Simplest Usage (Recommended only for `newton` method):
+    ```
+    container_t guess = {1.0, ..., 2.2};
+    container_t root =
+        multiroot_c1(multiroot_c1::newton, 1e-9, 75)(my_root_fdf, guess);
+    ```
+
+    where `container_t` and `container_d_t` are any types following
+    `SizedContiguousRange`, `my_root_f` is a `std::function<container_t(const 
+    container_t&)>` object containing the function to find the root of, 
+    `my_root_df` is a `std::function<container_d_t(const container_t&)>` object 
+    containing the jacobian of the function to find the root of, and 
+    `my_root_fdf` is a 
+    `std::function<std::pair<container_t,container_d_t>(const container_t&)>` 
+    object containing both the function to find the root of and its jacobian. 
+    Each `multiroot_c1::solver` attribute is based on a GSL fdfsolver_type.
+    Check the GSL documentation to better understand each method's properties, 
+    and their eventual caveats.
+*/
+class multiroot_c1{
+ public:
+  enum solver {hybridsj, hybridj, newton, gnewton};
+
+  multiroot_c1(solver s, double tolerance, size_t iterations)
+      : method_(this->get_gsl_solver_type(s)), iterations_(iterations), 
+      tolerance_(tolerance) {};
+
+  // multiroot_c1(const gsl_multiroot_fdfsolver_type* method, 
+  //     double tolerance, size_t iterations)
+  //     : method_(method), iterations_(iterations), tolerance_(tolerance) {};
+
+  template<SizedContiguousRange UserArgs>
+  using user_function_t = typename std::function<UserArgs(const UserArgs&)>;
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  using user_dfunction_t = typename std::function<UserDArgs(const UserArgs&)>;
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  using user_fdfunction_t = 
+      typename std::function<std::pair<UserArgs,UserDArgs>(const UserArgs&)>;
+
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  UserArgs operator()(
+      user_fdfunction_t<UserArgs,UserDArgs>& fdf, const UserArgs& guess) const;
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  UserArgs operator()(user_function_t<UserArgs>& f,
+      user_dfunction_t<UserArgs,UserDArgs>& df, const UserArgs& guess) const;
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  UserArgs operator()(
+      user_function_t<UserArgs>& f, user_dfunction_t<UserArgs,UserDArgs>& df, 
+      user_fdfunction_t<UserArgs,UserDArgs>& fdf, const UserArgs& guess) const;
+
+  const gsl_multiroot_fdfsolver_type* method() const { return method_; };
+  double tolerance() const { return tolerance_; };
+  size_t iterations() const { return iterations_; };
+ private:
+  const gsl_multiroot_fdfsolver_type* method_;
+  const size_t iterations_;
+  const double tolerance_;
+  
+  inline const gsl_multiroot_fdfsolver_type* get_gsl_solver_type(
+    const solver& s) const;
+
+  template<SizedContiguousRange UserArgs>
+  UserArgs solve(gsl_multiroot_fdfsolver *solver) const;
+
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  struct function_pack {
+    user_function_t<UserArgs>* f;
+    user_dfunction_t<UserArgs,UserDArgs>* df;
+    user_fdfunction_t<UserArgs,UserDArgs>* fdf;
+  };
+
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  static int translation_function(
+      const gsl_vector* args_gsl, void* fpack, gsl_vector* eval_gsl);
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  static int translation_dfunction(
+      const gsl_vector* args_gsl, void* fpack, gsl_matrix* deval_gsl);
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  static int translation_fdfunction(const gsl_vector* args_gsl, 
+    void* fpack, gsl_vector* eval_gsl, gsl_matrix* deval_gsl);
+
+  template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+  auto allocate_gsl_objects(function_pack<UserArgs,UserDArgs>& fpack, 
+      const UserArgs& guess) const;
+  inline void deallocate_gsl_objects(
+      gsl_multiroot_fdfsolver* solver, gsl_vector* guess_gsl,
+      gsl_multiroot_function_fdf* struct_fdf_gsl) const;
+};
+
+inline const gsl_multiroot_fdfsolver_type* multiroot_c1::get_gsl_solver_type(
+    const solver& s) const {
+  switch(s) {
+    case solver::hybridsj:
+      return gsl_multiroot_fdfsolver_hybridsj;
+    case solver::hybridj:
+      return gsl_multiroot_fdfsolver_hybridj;
+    case solver::gnewton:
+      return gsl_multiroot_fdfsolver_gnewton;
+    default:
+      return gsl_multiroot_fdfsolver_newton;
+  }
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+UserArgs multiroot_c1::operator()(
+    user_function_t<UserArgs>& f, user_dfunction_t<UserArgs,UserDArgs>& df, 
+    user_fdfunction_t<UserArgs,UserDArgs>& fdf, const UserArgs& guess) const {
+  function_pack<UserArgs,UserDArgs> pack = {&f, &df, &fdf};
+  auto [solver, guess_gsl, struct_fdf_gsl] = 
+      allocate_gsl_objects<UserArgs,UserDArgs>(pack, guess);
+  UserArgs root = solve<UserArgs>(solver);
+  deallocate_gsl_objects(solver, guess_gsl, struct_fdf_gsl);
+  return root;
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+UserArgs multiroot_c1::operator()(user_function_t<UserArgs>& f,
+    user_dfunction_t<UserArgs,UserDArgs>& df, const UserArgs& guess) const {
+  user_fdfunction_t<UserArgs,UserDArgs> fdf = 
+      [&](UserArgs args) -> std::pair<UserArgs,UserDArgs> {
+        return {f(args), df(args)};
+      };
+  return (*this)(f, df, fdf, guess);
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+UserArgs multiroot_c1::operator()(
+    user_fdfunction_t<UserArgs,UserDArgs>& fdf, const UserArgs& guess) const {
+  user_function_t<UserArgs> f = [&](UserArgs args) -> UserArgs {
+      std::pair<UserArgs,UserDArgs> eval = fdf(args);
+      return eval.first;
+    };
+  user_dfunction_t<UserArgs,UserDArgs> df = [&](UserArgs args) -> UserDArgs {
+      std::pair<UserArgs,UserDArgs> eval = fdf(args);
+      return eval.second;
+    };
+  return (*this)(f, df, fdf, guess);
+}
+
+template<SizedContiguousRange UserArgs>
+UserArgs multiroot_c1::solve(gsl_multiroot_fdfsolver *solver) const {
+
+  for(auto iteration : std::views::iota(1u, iterations_)) {
+    int flag = gsl_multiroot_fdfsolver_iterate(solver);
+    switch(flag) {
+      case GSL_ENOPROG: error(__func__, __FILE__, __LINE__,
+          "iteration is stuck.", 1);
+      case GSL_ENOPROGJ: error(__func__, __FILE__, __LINE__,
+          "jacobian not improving the solution.", 1);
+      case GSL_EBADFUNC: error(__func__, __FILE__, __LINE__,
+          "singular user-supplied function (Inf/NaN).", 1);
+    }
+    if(gsl_multiroot_test_residual(solver->f, tolerance_) == GSL_SUCCESS) break;
+  }
+  if(gsl_multiroot_test_residual(solver->f, tolerance_) == GSL_CONTINUE)
+      error(__func__, __FILE__, __LINE__,
+          "still above tolerance after max iterations.", 1);
+
+  UserArgs root = generate_sized<UserArgs>(solver->x->size);
+  std::ranges::copy(std::span(solver->x->data, solver->x->size), root.begin());
+  return root;
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+int multiroot_c1::translation_function(
+    const gsl_vector* args_gsl, void* fpack, gsl_vector* eval_gsl) {
+  UserArgs args = generate_sized<UserArgs>(args_gsl->size);
+  std::ranges::copy(std::span(args_gsl->data, args_gsl->size), args.begin());
+  auto *pk = static_cast<function_pack<UserArgs,UserDArgs>*>(fpack);
+  UserArgs eval = (*pk->f)(args);
+  std::ranges::copy(eval, eval_gsl->data);
+  return GSL_SUCCESS;
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+int multiroot_c1::translation_dfunction(
+    const gsl_vector* args_gsl, void* fpack, gsl_matrix* deval_gsl) {
+  UserArgs args = generate_sized<UserArgs>(args_gsl->size);
+  std::ranges::copy(std::span(args_gsl->data, args_gsl->size), args.begin());
+  auto *pk = static_cast<function_pack<UserArgs,UserDArgs>*>(fpack);
+  UserDArgs deval = (*pk->df)(args);
+  std::ranges::copy(deval, deval_gsl->data);
+  return GSL_SUCCESS;
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+int multiroot_c1::translation_fdfunction(
+    const gsl_vector* args_gsl, void* fpack, 
+    gsl_vector* eval_gsl, gsl_matrix* deval_gsl) {
+  UserArgs args = generate_sized<UserArgs>(args_gsl->size);
+  std::ranges::copy(std::span(args_gsl->data, args_gsl->size), args.begin());
+  auto *pk = static_cast<function_pack<UserArgs,UserDArgs>*>(fpack);
+  std::pair<UserArgs,UserDArgs> eval = (*pk->fdf)(args);
+  std::ranges::copy(eval.first, eval_gsl->data);
+  std::ranges::copy(eval.second, deval_gsl->data);
+  return GSL_SUCCESS;
+}
+
+template<SizedContiguousRange UserArgs, SizedContiguousRange UserDArgs>
+auto multiroot_c1::allocate_gsl_objects(
+    function_pack<UserArgs,UserDArgs>& fpack, 
+    const UserArgs& guess) const {
+  const size_t n = guess.size();
+  gsl_multiroot_fdfsolver* solver = gsl_multiroot_fdfsolver_alloc(method_, n);
+  gsl_vector* guess_gsl = gsl_vector_alloc(n);
+  auto* struct_fdf_gsl = new gsl_multiroot_function_fdf {
+      &translation_function<UserArgs,UserDArgs>, 
+      &translation_dfunction<UserArgs,UserDArgs>, 
+      &translation_fdfunction<UserArgs,UserDArgs>, 
+      n, &fpack
+    };
+  if (!solver || !guess_gsl || !struct_fdf_gsl)
+    error(__func__, __FILE__, __LINE__, "gsl object allocation failed.", 1);
+  std::ranges::copy(guess, guess_gsl->data);
+  gsl_multiroot_fdfsolver_set(solver, struct_fdf_gsl, guess_gsl);
+  return std::tuple<
+      gsl_multiroot_fdfsolver*, gsl_vector*, gsl_multiroot_function_fdf*> {
+      solver, guess_gsl, struct_fdf_gsl};
+}
+
+inline void multiroot_c1::deallocate_gsl_objects(
+    gsl_multiroot_fdfsolver* solver, gsl_vector* guess_gsl,
+    gsl_multiroot_function_fdf* struct_fdf_gsl) const {
+  gsl_multiroot_fdfsolver_free(solver);
+  gsl_vector_free(guess_gsl);
+  delete struct_fdf_gsl;
+}
+
+}  // end namespace gyronimo.
+
+#endif  // GYRONIMO_MULTIROOT_C1

--- a/gyronimo/metrics/morphism_vmec.cc
+++ b/gyronimo/metrics/morphism_vmec.cc
@@ -91,13 +91,13 @@ IR3 morphism_vmec::inverse(
   multiroot_c1 root_finder(multiroot_c1::newton, 1.0e-12, 100);
   using IR2 = std::array<double, 2>;
   using IR4 = std::array<double, 4>;
-  std::function<std::pair<IR2,IR4>(const IR2&)> zero_fdf = 
-    [&](const IR2& args) -> std::pair<IR2,IR4> {
-      auto [s, theta] = reflection_past_axis(args[0], args[1]);
-      auto cis_mn = morphism_vmec::cached_cis(theta, zeta);
-      auto a = std::transform_reduce(index_.begin(), index_.end(), 
-        aux_rz_del_t{0, 0, 0, 0, 0, 0}, std::plus<>(), 
-        [&](size_t i) -> aux_rz_del_t {
+  std::function<std::pair<IR2, IR4>(const IR2&)> zero_fdf =
+      [&](const IR2& args) -> std::pair<IR2, IR4> {
+    auto [s, theta] = reflection_past_axis(args[0], args[1]);
+    auto cis_mn = morphism_vmec::cached_cis(theta, zeta);
+    auto a = std::transform_reduce(
+        index_.begin(), index_.end(), aux_rz_del_t {0, 0, 0, 0, 0, 0},
+        std::plus<>(), [&](size_t i) -> aux_rz_del_t {
           double r_mn_i = (*r_mn_[i])(s), z_mn_i = (*z_mn_[i])(s);
           double cos_mn_i = std::real(cis_mn[i]);
           double sin_mn_i = std::imag(cis_mn[i]);
@@ -110,8 +110,8 @@ IR3 morphism_vmec::inverse(
               m_[i] * z_mn_i * cos_mn_i  // dzdw_mn_i
           };
         });
-      return {{a.r - r, a.z - z}, {a.drdu, a.drdw, a.dzdu, a.dzdw}};
-    };
+    return {{a.r - r, a.z - z}, {a.drdu, a.drdw, a.dzdu, a.dzdw}};
+  };
   auto roots = root_finder(zero_fdf, IR2 {guess.first, guess.second});
   auto [flux, theta] = reflection_past_axis(roots[0], roots[1]);
   return {flux, zeta, theta};
@@ -121,7 +121,7 @@ double morphism_vmec::jacobian(const IR3& q) const {
   double s = q[IR3::u], zeta = q[IR3::v], theta = q[IR3::w];
   auto cis_mn = morphism_vmec::cached_cis(theta, zeta);
   auto a = std::transform_reduce(
-      index_.begin(), index_.end(), aux_rz_del_t{0, 0, 0, 0, 0, 0},
+      index_.begin(), index_.end(), aux_rz_del_t {0, 0, 0, 0, 0, 0},
       std::plus<>(), [&](size_t i) -> aux_rz_del_t {
         double r_mn_i = (*r_mn_[i])(s);
         double cos_mn_i = std::real(cis_mn[i]), sin_mn_i = std::imag(cis_mn[i]);
@@ -131,7 +131,7 @@ double morphism_vmec::jacobian(const IR3& q) const {
             (*r_mn_[i]).derivative(s) * cos_mn_i,  // drdu_mn_i
             -m_[i] * r_mn_i * sin_mn_i,  // drdw_mn_i
             (*z_mn_[i]).derivative(s) * sin_mn_i,  // dzdu_mn_i
-            m_[i] * (*z_mn_[i])(s) * cos_mn_i  // dzdw_mn_i
+            m_[i] * (*z_mn_[i])(s)*cos_mn_i  // dzdw_mn_i
         };
       });
   return a.r * (a.drdu * a.dzdw - a.drdw * a.dzdu);
@@ -202,9 +202,9 @@ ddIR3 morphism_vmec::ddel(const IR3& q) const {
       a.d2rdudu * cos_zeta, a.d2rdudv * cos_zeta - a.drdu * sin_zeta,
       a.d2rdudw * cos_zeta,
       (a.d2rdvdv - a.r) * cos_zeta - 2 * a.drdv * sin_zeta,
-      a.d2rdvdw * cos_zeta - a.drdw * sin_zeta, a.d2rdwdw * cos_zeta,
-      a.d2rdudu * sin_zeta, a.d2rdudv * sin_zeta + a.drdu * cos_zeta,
-      a.d2rdudw * sin_zeta,
+      a.d2rdvdw * cos_zeta - a.drdw * sin_zeta,
+      a.d2rdwdw * cos_zeta, a.d2rdudu * sin_zeta,
+      a.d2rdudv * sin_zeta + a.drdu * cos_zeta, a.d2rdudw * sin_zeta,
       (a.d2rdvdv - a.r) * sin_zeta + 2 * a.drdv * cos_zeta,
       a.d2rdvdw * sin_zeta + a.drdw * cos_zeta, a.d2rdwdw * sin_zeta,
       a.d2zdudu, a.d2zdudv, a.d2zdudw, a.d2zdvdv, a.d2zdvdw, a.d2zdwdw};

--- a/gyronimo/metrics/morphism_vmec.cc
+++ b/gyronimo/metrics/morphism_vmec.cc
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with ::gyronimo::.  If not, see <https://www.gnu.org/licenses/>.
 
-// @mrophism_vmec.cc, this file is part of ::gyronimo::
+// @morphism_vmec.cc, this file is part of ::gyronimo::
 
-#include <gyronimo/core/multiroot.hh>
+#include <gyronimo/core/multiroot_c1.hh>
 #include <gyronimo/metrics/morphism_vmec.hh>
 
 #include <numeric>
@@ -88,14 +88,31 @@ IR3 morphism_vmec::inverse(
     const IR3& X, const std::pair<double, double>& guess) const {
   double x = X[IR3::u], y = X[IR3::v], z = X[IR3::w];
   double r = std::sqrt(x * x + y * y), zeta = std::atan2(y, x);
-  multiroot root_finder(gsl_multiroot_fsolver_hybrids, 1.0e-12, 75);
+  multiroot_c1 root_finder(multiroot_c1::newton, 1.0e-12, 100);
   using IR2 = std::array<double, 2>;
-  std::function<IR2(const IR2&)> zero_function = [&](const IR2& args) -> IR2 {
-    auto [flux, theta] = reflection_past_axis(args[0], args[1]);
-    auto [r_trial, z_trial] = get_rz({flux, zeta, theta});
-    return {r_trial - r, z_trial - z};
-  };
-  auto roots = root_finder(zero_function, IR2 {guess.first, guess.second});
+  using IR4 = std::array<double, 4>;
+  std::function<std::pair<IR2,IR4>(const IR2&)> zero_fdf = 
+    [&](const IR2& args) -> std::pair<IR2,IR4> {
+      auto [s, theta] = reflection_past_axis(args[0], args[1]);
+      auto cis_mn = morphism_vmec::cached_cis(theta, zeta);
+      auto a = std::transform_reduce(index_.begin(), index_.end(), 
+        aux_rz_del_t{0, 0, 0, 0, 0, 0}, std::plus<>(), 
+        [&](size_t i) -> aux_rz_del_t {
+          double r_mn_i = (*r_mn_[i])(s), z_mn_i = (*z_mn_[i])(s);
+          double cos_mn_i = std::real(cis_mn[i]);
+          double sin_mn_i = std::imag(cis_mn[i]);
+          return {
+              r_mn_i * cos_mn_i,  // r_mn_i
+              z_mn_i * sin_mn_i,  // z_mn_i
+              (*r_mn_[i]).derivative(s) * cos_mn_i,  // drdu_mn_i
+              -m_[i] * r_mn_i * sin_mn_i,  // drdw_mn_i
+              (*z_mn_[i]).derivative(s) * sin_mn_i,  // dzdu_mn_i
+              m_[i] * z_mn_i * cos_mn_i  // dzdw_mn_i
+          };
+        });
+      return {{a.r - r, a.z - z}, {a.drdu, a.drdw, a.dzdu, a.dzdw}};
+    };
+  auto roots = root_finder(zero_fdf, IR2 {guess.first, guess.second});
   auto [flux, theta] = reflection_past_axis(roots[0], roots[1]);
   return {flux, zeta, theta};
 }

--- a/gyronimo/metrics/morphism_vmec.hh
+++ b/gyronimo/metrics/morphism_vmec.hh
@@ -70,9 +70,15 @@ class morphism_vmec : public morphism {
   void build_interpolator_array(
       std::vector<std::unique_ptr<interpolator1d>>& interpolator_array,
       const narray_type& samples_array, const interpolator1d_factory* ifactory);
-  struct aux_rz_t { double r, z; };
-  struct aux_rz_del_t { double r, z, drdu, drdw, dzdu, dzdw; };
-  struct aux_del_t { double r, drdu, drdv, drdw, dzdu, dzdv, dzdw; };
+  struct aux_rz_t {
+    double r, z;
+  };
+  struct aux_rz_del_t {
+    double r, z, drdu, drdw, dzdu, dzdw;
+  };
+  struct aux_del_t {
+    double r, drdu, drdv, drdw, dzdu, dzdv, dzdw;
+  };
   struct aux_ddel_t {
     double r, drdu, drdv, drdw, dzdu, dzdv, dzdw;
     double d2rdudu, d2rdudv, d2rdudw, d2rdvdv, d2rdvdw, d2rdwdw;
@@ -107,15 +113,18 @@ inline morphism_vmec::aux_rz_t operator+(
 }
 
 inline morphism_vmec::aux_rz_del_t operator+(
-    const morphism_vmec::aux_rz_del_t& x, const morphism_vmec::aux_rz_del_t& y) {
-  return {x.r + y.r, x.z + y.z, x.drdu + y.drdu, x.drdw + y.drdw,
-          x.dzdu + y.dzdu, x.dzdw + y.dzdw};
+    const morphism_vmec::aux_rz_del_t& x,
+    const morphism_vmec::aux_rz_del_t& y) {
+  return {
+      x.r + y.r, x.z + y.z, x.drdu + y.drdu, x.drdw + y.drdw, x.dzdu + y.dzdu,
+      x.dzdw + y.dzdw};
 }
 
 inline morphism_vmec::aux_del_t operator+(
     const morphism_vmec::aux_del_t& x, const morphism_vmec::aux_del_t& y) {
-  return {x.r + y.r, x.drdu + y.drdu, x.drdv + y.drdv, x.drdw + y.drdw,
-          x.dzdu + y.dzdu, x.dzdv + y.dzdv, x.dzdw + y.dzdw};
+  return {
+      x.r + y.r, x.drdu + y.drdu, x.drdv + y.drdv, x.drdw + y.drdw,
+      x.dzdu + y.dzdu, x.dzdv + y.dzdv, x.dzdw + y.dzdw};
 }
 
 inline morphism_vmec::aux_ddel_t operator+(

--- a/gyronimo/metrics/morphism_vmec.hh
+++ b/gyronimo/metrics/morphism_vmec.hh
@@ -48,6 +48,7 @@ class morphism_vmec : public morphism {
   virtual ~morphism_vmec() override {};
   virtual IR3 operator()(const IR3& q) const override;
   virtual IR3 inverse(const IR3& x) const override;
+  virtual double jacobian(const IR3& q) const override;
   virtual dIR3 del(const IR3& q) const override;
   virtual ddIR3 ddel(const IR3& q) const override;
   virtual IR3 translation(const IR3& q, const IR3& delta) const override;
@@ -70,6 +71,7 @@ class morphism_vmec : public morphism {
       std::vector<std::unique_ptr<interpolator1d>>& interpolator_array,
       const narray_type& samples_array, const interpolator1d_factory* ifactory);
   struct aux_rz_t { double r, z; };
+  struct aux_rz_del_t { double r, z, drdu, drdw, dzdu, dzdw; };
   struct aux_del_t { double r, drdu, drdv, drdw, dzdu, dzdv, dzdw; };
   struct aux_ddel_t {
     double r, drdu, drdv, drdw, dzdu, dzdv, dzdw;
@@ -77,6 +79,7 @@ class morphism_vmec : public morphism {
     double d2zdudu, d2zdudv, d2zdudw, d2zdvdv, d2zdvdw, d2zdwdw;
   };
   friend aux_rz_t operator+(const aux_rz_t& x, const aux_rz_t& y);
+  friend aux_rz_del_t operator+(const aux_rz_del_t& x, const aux_rz_del_t& y);
   friend aux_del_t operator+(const aux_del_t& x, const aux_del_t& y);
   friend aux_ddel_t operator+(const aux_ddel_t& x, const aux_ddel_t& y);
 };
@@ -101,6 +104,12 @@ inline std::pair<double, double> morphism_vmec::reflection_past_axis(
 inline morphism_vmec::aux_rz_t operator+(
     const morphism_vmec::aux_rz_t& x, const morphism_vmec::aux_rz_t& y) {
   return {x.r + y.r, x.z + y.z};
+}
+
+inline morphism_vmec::aux_rz_del_t operator+(
+    const morphism_vmec::aux_rz_del_t& x, const morphism_vmec::aux_rz_del_t& y) {
+  return {x.r + y.r, x.z + y.z, x.drdu + y.drdu, x.drdw + y.drdw,
+          x.dzdu + y.dzdu, x.dzdw + y.dzdw};
 }
 
 inline morphism_vmec::aux_del_t operator+(


### PR DESCRIPTION
Add `multiroot_c1` class interface to make GSL multi-root finding with derivatives easier.
Change `morphism_vmec` to use `multiroot_c1`.